### PR TITLE
维护更新

### DIFF
--- a/Groupmodules/groupchat.js
+++ b/Groupmodules/groupchat.js
@@ -7,6 +7,7 @@ const fileManager = require('../modules/fileManager'); // Import fileManager
 // const { v4: uuidv4 } = require('uuid'); // 如果需要唯一ID生成
 
 const CANVAS_PLACEHOLDER = '{{VCPChatCanvas}}';
+const GROUP_SESSION_WATCHER_PLACEHOLDER = '{{VCPChatGroupSessionWatcher}}';
 
 // 新增：话题总结相关常量
 const MIN_MESSAGES_FOR_SUMMARY = 4;
@@ -32,6 +33,68 @@ function initializePaths(paths) {
     fs.ensureDirSync(mainAppPaths.AGENT_GROUPS_DIR);
     console.log('[GroupChat] Paths initialized. AgentGroups directory ensured:', mainAppPaths.AGENT_GROUPS_DIR);
 }
+
+/**
+ * 获取群聊会话监控信息
+ * @param {string} groupId - 群组ID
+ * @param {string} topicId - 话题ID
+ * @returns {Promise<object>} - 群聊会话监控信息
+ */
+async function getGroupSessionWatcher(groupId, topicId) {
+    try {
+        if (!mainAppPaths.USER_DATA_DIR) {
+            return {
+                status: "error",
+                error: "用户数据目录未初始化",
+                timestamp: new Date().toISOString(),
+                displayTime: new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' })
+            };
+        }
+
+        const groupHistoryPath = path.join(mainAppPaths.USER_DATA_DIR, groupId, 'topics', topicId, 'history.json');
+        
+        if (await fs.pathExists(groupHistoryPath)) {
+            const stats = await fs.stat(groupHistoryPath);
+            const historyContent = await fs.readJson(groupHistoryPath);
+            
+            return {
+                status: "active",
+                currentSession: {
+                    groupId: groupId,
+                    topicId: topicId,
+                    filePath: groupHistoryPath,
+                    lastModified: stats.mtime.toISOString(),
+                    lastModifiedDisplay: stats.mtime.toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' }),
+                    modifiedTimestamp: stats.mtime.getTime(),
+                    size: stats.size,
+                    messageCount: historyContent.length
+                },
+                timestamp: new Date().toISOString(),
+                displayTime: new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' })
+            };
+        } else {
+            return {
+                status: "no_session",
+                message: `未找到群聊会话文件: ${groupHistoryPath}`,
+                groupId: groupId,
+                topicId: topicId,
+                timestamp: new Date().toISOString(),
+                displayTime: new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' })
+            };
+        }
+    } catch (error) {
+        console.error(`[GroupChat] Error in getGroupSessionWatcher for group ${groupId}, topic ${topicId}:`, error.message);
+        return {
+            status: "error",
+            error: error.message,
+            groupId: groupId,
+            topicId: topicId,
+            timestamp: new Date().toISOString(),
+            displayTime: new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' })
+        };
+    }
+}
+
 
 /**
  * 获取全局VCP设置（如URL, API Key, 用户名）
@@ -369,7 +432,13 @@ async function handleGroupChatMessage(groupId, topicId, userMessage, sendStreamC
         // 1. 构建 SystemPrompt (基于当前 agentConfig 和 groupConfig)
         let combinedSystemPrompt = agentConfig.systemPrompt || `你是${agentName}。`;
         if (groupConfig.groupPrompt) {
-            combinedSystemPrompt += `\n\n[群聊设定]:\n${groupConfig.groupPrompt}`;
+            let groupPrompt = groupConfig.groupPrompt;
+            // 处理 VCPChatGroupSessionWatcher 占位符
+            if (groupPrompt.includes(GROUP_SESSION_WATCHER_PLACEHOLDER)) {
+                const sessionWatcherInfo = await getGroupSessionWatcher(groupId, topicId);
+                groupPrompt = groupPrompt.replace(new RegExp(GROUP_SESSION_WATCHER_PLACEHOLDER, 'g'), JSON.stringify(sessionWatcherInfo));
+            }
+            combinedSystemPrompt += `\n\n[群聊设定]:\n${groupPrompt}`;
         }
 
         // 2. 构建上下文结构 (每次循环都基于最新的 groupHistory)
@@ -388,7 +457,14 @@ async function handleGroupChatMessage(groupId, topicId, userMessage, sendStreamC
                     try {
                         const canvasData = await ipcMain.invoke('get-latest-canvas-content');
                         if (canvasData && !canvasData.error) {
-                            const formattedCanvasContent = `\n[Canvas Content]\n${canvasData.content || ''}\n[Canvas Path]\n${canvasData.path || 'No file path'}\n[Canvas Errors]\n${canvasData.errors || 'No errors'}\n`;
+                            const formattedCanvasContent = `
+[Canvas Content]
+${canvasData.content || ''}
+[Canvas Path]
+${canvasData.path || 'No file path'}
+[Canvas Errors]
+${canvasData.errors || 'No errors'}
+`;
                             textForAIContext = textForAIContext.replace(new RegExp(CANVAS_PLACEHOLDER, 'g'), formattedCanvasContent);
                         } else {
                             console.error("[GroupChat] Failed to get latest canvas content:", canvasData?.error);
@@ -406,7 +482,11 @@ async function handleGroupChatMessage(groupId, topicId, userMessage, sendStreamC
                 if (msg.attachments && msg.attachments.length > 0) {
                     for (const att of msg.attachments) {
                         if (att._fileManagerData && typeof att._fileManagerData.extractedText === 'string' && att._fileManagerData.extractedText.trim() !== '') {
-                            textForAIContext += `\n\n[附加文件: ${att.name || '未知文件'}]\n${att._fileManagerData.extractedText}\n[/附加文件结束: ${att.name || '未知文件'}]`;
+                            textForAIContext += `
+
+[附加文件: ${att.name || '未知文件'}]
+${att._fileManagerData.extractedText}
+[/附加文件结束: ${att.name || '未知文件'}]`;
                         } else if (att._fileManagerData && att.type && !att.type.startsWith('image/')) {
                             textForAIContext += `\n\n[附加文件: ${att.name || '未知文件'} (无法预览文本内容)]`;
                         } else if (!att._fileManagerData) {
@@ -756,7 +836,13 @@ async function handleInviteAgentToSpeak(groupId, topicId, invitedAgentId, sendSt
     // 1. 构建 SystemPrompt
     let combinedSystemPrompt = agentConfig.systemPrompt || `你是${agentName}。`;
     if (groupConfig.groupPrompt) {
-        combinedSystemPrompt += `\n\n[群聊设定]:\n${groupConfig.groupPrompt}`;
+        let groupPrompt = groupConfig.groupPrompt;
+        // 处理 VCPChatGroupSessionWatcher 占位符
+        if (groupPrompt.includes(GROUP_SESSION_WATCHER_PLACEHOLDER)) {
+            const sessionWatcherInfo = await getGroupSessionWatcher(groupId, topicId);
+            groupPrompt = groupPrompt.replace(new RegExp(GROUP_SESSION_WATCHER_PLACEHOLDER, 'g'), JSON.stringify(sessionWatcherInfo));
+        }
+        combinedSystemPrompt += `\n\n[群聊设定]:\n${groupPrompt}`;
     }
 
     // 2. 构建上下文结构 (基于最新的 groupHistory)
@@ -775,7 +861,14 @@ async function handleInviteAgentToSpeak(groupId, topicId, invitedAgentId, sendSt
             try {
                 const canvasData = await ipcMain.invoke('get-latest-canvas-content');
                 if (canvasData && !canvasData.error) {
-                    const formattedCanvasContent = `\n[Canvas Content]\n${canvasData.content || ''}\n[Canvas Path]\n${canvasData.path || 'No file path'}\n[Canvas Errors]\n${canvasData.errors || 'No errors'}\n`;
+                    const formattedCanvasContent = `
+[Canvas Content]
+${canvasData.content || ''}
+[Canvas Path]
+${canvasData.path || 'No file path'}
+[Canvas Errors]
+${canvasData.errors || 'No errors'}
+`;
                     textForAIContext = textForAIContext.replace(new RegExp(CANVAS_PLACEHOLDER, 'g'), formattedCanvasContent);
                 } else {
                     console.error("[GroupChat Invite] Failed to get latest canvas content:", canvasData?.error);
@@ -790,7 +883,11 @@ async function handleInviteAgentToSpeak(groupId, topicId, invitedAgentId, sendSt
         if (msg.attachments && msg.attachments.length > 0) {
             for (const att of msg.attachments) {
                 if (att._fileManagerData && typeof att._fileManagerData.extractedText === 'string' && att._fileManagerData.extractedText.trim() !== '') {
-                    textForAIContext += `\n\n[附加文件: ${att.name || '未知文件'}]\n${att._fileManagerData.extractedText}\n[/附加文件结束: ${att.name || '未知文件'}]`;
+                    textForAIContext += `
+
+[附加文件: ${att.name || '未知文件'}]
+${att._fileManagerData.extractedText}
+[/附加文件结束: ${att.name || '未知文件'}]`;
                 } else if (att._fileManagerData && att.type && !att.type.startsWith('image/')) {
                     textForAIContext += `\n\n[附加文件: ${att.name || '未知文件'} (无法预览文本内容)]`;
                 } else if (!att._fileManagerData) {
@@ -1112,7 +1209,11 @@ async function triggerTopicSummarizationIfNeeded(groupId, topicId, groupHistory,
             if (msg.attachments && msg.attachments.length > 0) {
                 for (const att of msg.attachments) {
                     if (att._fileManagerData && typeof att._fileManagerData.extractedText === 'string' && att._fileManagerData.extractedText.trim() !== '') {
-                        contentText += `\n\n[附加文件: ${att.name || '未知文件'}]\n${att._fileManagerData.extractedText}\n[/附加文件结束: ${att.name || '未知文件'}]`;
+                        contentText += `
+
+[附加文件: ${att.name || '未知文件'}]
+${att._fileManagerData.extractedText}
+[/附加文件结束: ${att.name || '未知文件'}]`;
                     } else if (att._fileManagerData && att.type && !att.type.startsWith('image/')) {
                         contentText += `\n\n[附加文件: ${att.name || '未知文件'} (无法预览文本内容)]`;
                     }

--- a/VCPDistributedServer/Plugin/ChatRoomViewer/ChatRoomViewer.js
+++ b/VCPDistributedServer/Plugin/ChatRoomViewer/ChatRoomViewer.js
@@ -4,6 +4,26 @@ const os = require('os');
 const WebSocket = require('ws');
 const chokidar = require('chokidar'); // 添加chokidar用于实时文件监控
 
+// 全局变量用于存储最新数据
+let cachedData = {
+    statusInfo: null,
+    themeInfo: null,
+    agentsInfo: null,
+    sessionWatcherInfo: null,
+    modeBubbleTip: null,
+    sessionTimeElapsed: null,
+    groupSessionWatcher: null,
+    lastUpdate: Date.now()
+};
+
+// 文件监控器
+let fileWatchers = new Map();
+let isWatcherMode = process.argv.includes('--watch');
+
+// 当前监控的文件路径缓存
+let currentSessionFile = null;
+let currentAgentConfigs = new Set();
+
 // 从环境变量读取配置
 const debugMode = (process.env.DebugMode || "false").toLowerCase() === "true";
 const enabled = (process.env.Enabled || "true").toLowerCase() === "true";
@@ -64,6 +84,389 @@ function getCurrentTimestamp(format = 'iso') {
     return formatTimestamp(new Date(), format);
 }
 
+// 初始化文件监控器
+function initializeFileWatchers() {
+    if (!isWatcherMode) return;
+    
+    // 为避免初始化过程阻塞，异步执行
+    setImmediate(async () => {
+        try {
+            const mainDir = getVCPChatMainDirectory();
+            const settingsPath = path.join(mainDir, 'AppData', 'settings.json');
+            
+            // 监控settings.json文件变化（进一步降低稳定性阈值）
+            const settingsWatcher = chokidar.watch(settingsPath, {
+                persistent: true,
+                ignoreInitial: true,
+                awaitWriteFinish: {
+                    stabilityThreshold: 50,  // 从100降低到50
+                    pollInterval: 10         // 从50降低到10
+                }
+            });
+            
+            settingsWatcher.on('change', async () => {
+                FORCE_LOG('[ChatRoomViewer] Settings file changed, updating theme info and status...');
+                try {
+                    // 更新主题信息和状态信息
+                    cachedData.themeInfo = await generateThemeInfo();
+                    cachedData.statusInfo = await generateVCPChatStatus();
+                    cachedData.lastUpdate = Date.now();
+                    
+                    // 立即输出更新后的数据
+                    outputCachedData();
+                } catch (error) {
+                    FORCE_LOG('[ChatRoomViewer] Error updating data after settings change:', error.message);
+                }
+            });
+            
+            fileWatchers.set('settings', settingsWatcher);
+            
+            // 监控主题CSS文件的变化（进一步降低稳定性阈值）
+            const themeCSSPath = path.join(mainDir, 'styles', 'themes.css');
+            const themeCSSWatcher = chokidar.watch(themeCSSPath, {
+                persistent: true,
+                ignoreInitial: true,
+                awaitWriteFinish: {
+                    stabilityThreshold: 30,  // 从50降低到30
+                    pollInterval: 10         // 从25降低到10
+                }
+            });
+            
+            themeCSSWatcher.on('change', async () => {
+                FORCE_LOG('[ChatRoomViewer] Theme CSS file changed, updating theme info...');
+                try {
+                    // 更新主题信息
+                    cachedData.themeInfo = await generateThemeInfo();
+                    cachedData.lastUpdate = Date.now();
+                    
+                    // 立即输出更新后的数据
+                    outputCachedData();
+                } catch (error) {
+                    FORCE_LOG('[ChatRoomViewer] Error updating theme info after CSS change:', error.message);
+                }
+            });
+            
+            fileWatchers.set('themeCSS', themeCSSWatcher);
+            
+            // 初始化Agent配置文件监控
+            await initializeAgentConfigWatchers();
+            
+            // 初始化会话文件监控
+            await initializeSessionFileWatcher();
+            
+            FORCE_LOG('[ChatRoomViewer] File watchers initialized');
+        } catch (error) {
+            FORCE_LOG('[ChatRoomViewer] Error initializing file watchers:', error.message);
+        }
+    });
+}
+
+// 初始化Agent配置文件监控
+async function initializeAgentConfigWatchers() {
+    try {
+        const mainDir = getVCPChatMainDirectory();
+        const agentsDir = path.join(mainDir, 'AppData', 'Agents');
+        
+        // 监控整个Agents目录的变化（进一步优化监控参数）
+        const agentDirWatcher = chokidar.watch(agentsDir, {
+            persistent: true,
+            ignoreInitial: true,
+            depth: 2, // 监控到config.json的深度
+            awaitWriteFinish: {
+                stabilityThreshold: 30,  // 从50降低到30
+                pollInterval: 10         // 从25降低到10
+            },
+            usePolling: true,           // 使用轮询提高响应速度
+            interval: 100               // 轮询间隔100ms
+        });
+        
+        agentDirWatcher.on('change', async (filePath) => {
+            // 只关注config.json文件的变化
+            if (path.basename(filePath) === 'config.json') {
+                FORCE_LOG('[ChatRoomViewer] Agent config file changed:', filePath);
+                try {
+                    // 更新Agent信息
+                    cachedData.agentsInfo = await getAllAgentsInfo();
+                    cachedData.lastUpdate = Date.now();
+                    
+                    // 立即输出更新后的数据
+                    outputCachedData();
+                } catch (error) {
+                    FORCE_LOG('[ChatRoomViewer] Error updating agents info after config change:', error.message);
+                }
+            }
+        });
+        
+        agentDirWatcher.on('add', async (filePath) => {
+            // 新增的config.json文件
+            if (path.basename(filePath) === 'config.json') {
+                FORCE_LOG('[ChatRoomViewer] New agent config file added:', filePath);
+                try {
+                    cachedData.agentsInfo = await getAllAgentsInfo();
+                    cachedData.lastUpdate = Date.now();
+                    outputCachedData();
+                } catch (error) {
+                    FORCE_LOG('[ChatRoomViewer] Error updating agents info after config addition:', error.message);
+                }
+            }
+        });
+        
+        agentDirWatcher.on('unlink', async (filePath) => {
+            // 删除的config.json文件
+            if (path.basename(filePath) === 'config.json') {
+                FORCE_LOG('[ChatRoomViewer] Agent config file deleted:', filePath);
+                try {
+                    cachedData.agentsInfo = await getAllAgentsInfo();
+                    cachedData.lastUpdate = Date.now();
+                    outputCachedData();
+                } catch (error) {
+                    FORCE_LOG('[ChatRoomViewer] Error updating agents info after config deletion:', error.message);
+                }
+            }
+        });
+        
+        fileWatchers.set('agentConfigs', agentDirWatcher);
+        FORCE_LOG('[ChatRoomViewer] Agent config watchers initialized');
+        
+    } catch (error) {
+        FORCE_LOG('[ChatRoomViewer] Error initializing agent config watchers:', error.message);
+    }
+}
+
+// 初始化会话文件监控
+async function initializeSessionFileWatcher() {
+    try {
+        // 获取当前活跃的会话文件
+        const sessionWatcher = await getCurrentSessionWatcher();
+        
+        if (sessionWatcher.status === 'active' && sessionWatcher.currentSession) {
+            const sessionFilePath = sessionWatcher.currentSession.filePath;
+            
+            // 如果当前监控的文件发生了变化，需要重新设置监控
+            if (currentSessionFile !== sessionFilePath) {
+                // 清除旧的会话文件监控
+                if (fileWatchers.has('sessionFile')) {
+                    fileWatchers.get('sessionFile').close();
+                    fileWatchers.delete('sessionFile');
+                }
+                
+                // 设置新的会话文件监控（进一步优化监控参数）
+                const sessionFileWatcher = chokidar.watch(sessionFilePath, {
+                    persistent: true,
+                    ignoreInitial: true,
+                    awaitWriteFinish: {
+                        stabilityThreshold: 30,  // 从50降低到30
+                        pollInterval: 10         // 从25降低到10
+                    },
+                    usePolling: true,           // 使用轮询提高响应速度
+                    interval: 100               // 轮询间隔100ms
+                });
+                
+                sessionFileWatcher.on('change', async () => {
+                    FORCE_LOG('[ChatRoomViewer] Session history file changed:', sessionFilePath);
+                    try {
+                        // 更新会话相关的信息 - 同时更新sessionWatcherInfo以供其他占位符复用
+                        const latestSessionWatcher = await getCurrentSessionWatcher();
+                        cachedData.sessionWatcherInfo = latestSessionWatcher;
+                        cachedData.statusInfo = await generateVCPChatStatus();
+                        cachedData.sessionTimeElapsed = await generateSessionTimeElapsed();
+                        cachedData.lastUpdate = Date.now();
+                        
+                        // 立即输出更新后的数据
+                        outputCachedData();
+                    } catch (error) {
+                        FORCE_LOG('[ChatRoomViewer] Error updating session info after history change:', error.message);
+                    }
+                });
+                
+                fileWatchers.set('sessionFile', sessionFileWatcher);
+                currentSessionFile = sessionFilePath;
+                FORCE_LOG('[ChatRoomViewer] Session file watcher initialized for:', sessionFilePath);
+            }
+        }
+        
+        // 同时监控UserData目录以检测新的会话文件（进一步优化监控参数）
+        const mainDir = getVCPChatMainDirectory();
+        const userDataDir = path.join(mainDir, 'AppData', 'UserData');
+        
+        if (!fileWatchers.has('userDataDir')) {
+            const userDataDirWatcher = chokidar.watch(userDataDir, {
+                persistent: true,
+                ignoreInitial: true,
+                depth: 3, // 监控到history.json的深度
+                awaitWriteFinish: {
+                    stabilityThreshold: 30,  // 从50降低到30
+                    pollInterval: 10         // 从25降低到10
+                },
+                usePolling: true,           // 使用轮询提高响应速度
+                interval: 100               // 轮询间隔100ms
+            });
+            
+            userDataDirWatcher.on('change', async (filePath) => {
+                // 只关注history.json文件的变化
+                if (path.basename(filePath) === 'history.json') {
+                    FORCE_LOG('[ChatRoomViewer] History file changed in UserData:', filePath);
+                    
+                    // 重新检查当前活跃的会话是否发生了变化
+                    const newSessionWatcher = await getCurrentSessionWatcher();
+                    if (newSessionWatcher.status === 'active' && newSessionWatcher.currentSession) {
+                        const newSessionFile = newSessionWatcher.currentSession.filePath;
+                        
+                        // 如果活跃的会话文件发生了变化，重新初始化监控
+                        if (newSessionFile !== currentSessionFile) {
+                            await initializeSessionFileWatcher();
+                        } else {
+                            // 更新会话相关信息，确保三个占位符的同步更新
+                            try {
+                                cachedData.sessionWatcherInfo = newSessionWatcher;
+                                cachedData.statusInfo = await generateVCPChatStatus();
+                                cachedData.sessionTimeElapsed = await generateSessionTimeElapsed();
+                                cachedData.lastUpdate = Date.now();
+                                outputCachedData();
+                            } catch (error) {
+                                FORCE_LOG('[ChatRoomViewer] Error updating session info:', error.message);
+                            }
+                        }
+                    }
+                }
+            });
+            
+            userDataDirWatcher.on('add', async (filePath) => {
+                if (path.basename(filePath) === 'history.json') {
+                    FORCE_LOG('[ChatRoomViewer] New history file added:', filePath);
+                    // 重新检查活跃会话
+                    await initializeSessionFileWatcher();
+                }
+            });
+            
+            fileWatchers.set('userDataDir', userDataDirWatcher);
+            FORCE_LOG('[ChatRoomViewer] UserData directory watcher initialized');
+        }
+        
+    } catch (error) {
+        FORCE_LOG('[ChatRoomViewer] Error initializing session file watcher:', error.message);
+    }
+}
+
+// 初始化群聊会话文件监控
+async function initializeGroupSessionWatcher() {
+    if (!isWatcherMode) return;
+    
+    // 为避免初始化过程阻塞，异步执行
+    setImmediate(async () => {
+        try {
+            // 获取当前活跃的群聊会话文件
+            const groupSessionWatcher = await generateGroupSessionWatcher();
+            
+            if (groupSessionWatcher.status === 'active' && groupSessionWatcher.currentSession) {
+                const groupSessionFilePath = groupSessionWatcher.currentSession.filePath;
+                
+                // 设置群聊会话文件监控
+                const groupSessionFileWatcher = chokidar.watch(groupSessionFilePath, {
+                    persistent: true,
+                    ignoreInitial: true,
+                    awaitWriteFinish: {
+                        stabilityThreshold: 50, // 降低稳定性阈值提高响应速度
+                        pollInterval: 25
+                    }
+                });
+                
+                groupSessionFileWatcher.on('change', async () => {
+                    FORCE_LOG('[ChatRoomViewer] Group session history file changed:', groupSessionFilePath);
+                    try {
+                        // 更新群聊会话相关信息
+                        cachedData.groupSessionWatcher = await generateGroupSessionWatcher();
+                        cachedData.lastUpdate = Date.now();
+                        
+                        // 立即输出更新后的数据
+                        outputCachedData();
+                    } catch (error) {
+                        FORCE_LOG('[ChatRoomViewer] Error updating group session info after history change:', error.message);
+                    }
+                });
+                
+                fileWatchers.set('groupSessionFile', groupSessionFileWatcher);
+                FORCE_LOG('[ChatRoomViewer] Group session file watcher initialized for:', groupSessionFilePath);
+            }
+            
+            // 监控AgentGroups目录以检测新的群聊会话文件
+            const mainDir = getVCPChatMainDirectory();
+            const agentGroupsDir = path.join(mainDir, 'AppData', 'AgentGroups');
+            
+            if (!fileWatchers.has('agentGroupsDir')) {
+                const agentGroupsDirWatcher = chokidar.watch(agentGroupsDir, {
+                    persistent: true,
+                    ignoreInitial: true,
+                    depth: 4, // 监控到group history.json文件的深度
+                    awaitWriteFinish: {
+                        stabilityThreshold: 50, // 降低稳定性阈值提高响应速度
+                        pollInterval: 25
+                    }
+                });
+                
+                agentGroupsDirWatcher.on('change', async (filePath) => {
+                    // 只关注群聊相关的history.json文件变化
+                    if (path.basename(filePath) === 'history.json' && filePath.includes('group_topic_')) {
+                        FORCE_LOG('[ChatRoomViewer] Group history file changed in AgentGroups:', filePath);
+                        
+                        try {
+                            cachedData.groupSessionWatcher = await generateGroupSessionWatcher();
+                            cachedData.lastUpdate = Date.now();
+                            outputCachedData();
+                        } catch (error) {
+                            FORCE_LOG('[ChatRoomViewer] Error updating group session info:', error.message);
+                        }
+                    }
+                });
+                
+                agentGroupsDirWatcher.on('add', async (filePath) => {
+                    if (path.basename(filePath) === 'history.json' && filePath.includes('group_topic_')) {
+                        FORCE_LOG('[ChatRoomViewer] New group history file added:', filePath);
+                        // 重新初始化群聊监控
+                        await initializeGroupSessionWatcher();
+                    }
+                });
+                
+                fileWatchers.set('agentGroupsDir', agentGroupsDirWatcher);
+                FORCE_LOG('[ChatRoomViewer] AgentGroups directory watcher initialized');
+            }
+            
+        } catch (error) {
+            FORCE_LOG('[ChatRoomViewer] Error initializing group session watcher:', error.message);
+        }
+    });
+}
+
+// 输出缓存的数据
+function outputCachedData() {
+    const outputData = {
+        "{{VCPChatStatus}}": JSON.stringify(cachedData.statusInfo || {}),
+        "{{VCPChatTheme}}": JSON.stringify(cachedData.themeInfo || {}),
+        "{{VCPChatSessionWatcher}}": JSON.stringify(cachedData.sessionWatcherInfo || {}),
+        "{{VCPChatAgent}}": JSON.stringify(cachedData.agentsInfo || {}),
+        "{{VCPChatModeBubbleTip}}": JSON.stringify(cachedData.modeBubbleTip || {}),
+        "{{VCPChatSessionTimeElapsed}}": JSON.stringify(cachedData.sessionTimeElapsed || {}),
+        "{{VCPChatGroupSessionWatcher}}": JSON.stringify(cachedData.groupSessionWatcher || {})
+    };
+    
+    process.stdout.write(JSON.stringify(outputData));
+}
+
+// 清理文件监控器
+function cleanupFileWatchers() {
+    for (const [name, watcher] of fileWatchers) {
+        try {
+            watcher.close();
+            FORCE_LOG(`[ChatRoomViewer] Closed file watcher: ${name}`);
+        } catch (error) {
+            FORCE_LOG(`[ChatRoomViewer] Error closing file watcher ${name}:`, error.message);
+        }
+    }
+    fileWatchers.clear();
+    // 重置缓存的文件路径
+    currentSessionFile = null;
+    currentAgentConfigs.clear();
+}
 
 // 检测VCPChat主目录
 function getVCPChatMainDirectory() {
@@ -382,10 +785,339 @@ async function generateThemeInfo() {
 
 // 获取当前会话监控信息
 async function getCurrentSessionWatcher() {
-    // 这个函数现在只是一个占位符，实际的会话监控信息在generateVCPChatStatus中生成
-    return {
-        info: "会话监控信息将通过VCPChatStatus获取"
-    };
+    try {
+        const mainDir = getVCPChatMainDirectory();
+        const userDataDir = path.join(mainDir, 'AppData', 'UserData');
+        
+        // 查找最新修改的history.json文件
+        let latestFile = null;
+        let latestTime = 0;
+        
+        const agentDirs = await fs.readdir(userDataDir, { withFileTypes: true });
+        
+        for (const agentDir of agentDirs) {
+            if (agentDir.isDirectory() && agentDir.name.startsWith('_Agent_')) {
+                const topicsDir = path.join(userDataDir, agentDir.name, 'topics');
+                try {
+                    const topicDirs = await fs.readdir(topicsDir, { withFileTypes: true });
+                    
+                    for (const topicDir of topicDirs) {
+                        if (topicDir.isDirectory()) {
+                            const historyPath = path.join(topicsDir, topicDir.name, 'history.json');
+                            try {
+                                const stats = await fs.stat(historyPath);
+                                if (stats.mtime.getTime() > latestTime) {
+                                    latestTime = stats.mtime.getTime();
+                                    latestFile = {
+                                        filePath: historyPath,
+                                        agentId: agentDir.name,
+                                        topicId: topicDir.name,
+                                        lastModified: stats.mtime,
+                                        size: stats.size
+                                    };
+                                }
+                            } catch (statError) {
+                                // 跳过无法访问的文件
+                            }
+                        }
+                    }
+                } catch (topicsError) {
+                    // 跳过无法访问的topics目录
+                }
+            }
+        }
+        
+        if (latestFile) {
+            return {
+                status: "active",
+                currentSession: {
+                    agentId: latestFile.agentId,
+                    topicId: latestFile.topicId,
+                    filePath: latestFile.filePath,
+                    lastModified: formatTimestamp(latestFile.lastModified, 'iso'),
+                    lastModifiedDisplay: formatTimestamp(latestFile.lastModified, 'time'),
+                    modifiedTimestamp: latestFile.lastModified.getTime(),
+                    size: latestFile.size
+                },
+                timestamp: getCurrentTimestamp('iso'),
+                displayTime: formatTimestamp(new Date(), 'time')
+            };
+        } else {
+            return {
+                status: "no_active_session",
+                message: "未找到活跃的会话文件",
+                timestamp: getCurrentTimestamp('iso'),
+                displayTime: formatTimestamp(new Date(), 'time')
+            };
+        }
+    } catch (error) {
+        FORCE_LOG('[ChatRoomViewer] Error in getCurrentSessionWatcher:', error.message);
+        return {
+            status: "error",
+            error: error.message,
+            timestamp: getCurrentTimestamp('iso'),
+            displayTime: formatTimestamp(new Date(), 'time')
+        };
+    }
+}
+
+// 新增：生成会话时间流逝信息（优化实现，直接复用缓存数据）
+async function generateSessionTimeElapsed() {
+    try {
+        // 直接复用缓存的sessionWatcherInfo，避免重复查询
+        let sessionWatcher = cachedData.sessionWatcherInfo;
+        
+        // 如果缓存为空或过期（降低过期时间阈值），则获取最新数据
+        if (!sessionWatcher || Date.now() - cachedData.lastUpdate > 50) {  // 从100降低到50
+            sessionWatcher = await getCurrentSessionWatcher();
+        }
+        
+        if (sessionWatcher.status !== "active" || !sessionWatcher.currentSession) {
+            return {
+                status: "no_session",
+                message: "当前没有活跃的会话",
+                timestamp: getCurrentTimestamp('iso'),
+                displayTime: formatTimestamp(new Date(), 'time')
+            };
+        }
+        
+        // 直接使用已知的会话文件路径，避免重复查询
+        const historyPath = sessionWatcher.currentSession.filePath;
+        let historyContent = [];
+        
+        try {
+            const content = await fs.readFile(historyPath, 'utf-8');
+            historyContent = JSON.parse(content);
+        } catch (readError) {
+            return {
+                status: "empty_session",
+                message: "会话文件为空",
+                currentTime: formatTimestamp(new Date(), 'datetime'),
+                sessionFilePath: historyPath,
+                timestamp: getCurrentTimestamp('iso')
+            };
+        }
+        
+        if (!Array.isArray(historyContent) || historyContent.length === 0) {
+            return {
+                status: "empty_session", 
+                message: "会话文件为空",
+                currentTime: formatTimestamp(new Date(), 'datetime'),
+                sessionFilePath: historyPath,
+                timestamp: getCurrentTimestamp('iso')
+            };
+        }
+        
+        const currentTime = Date.now();
+        const lastMessage = historyContent[historyContent.length - 1];
+        const lastMessageTime = lastMessage.timestamp || 0;
+        const timeSinceLastMessage = currentTime - lastMessageTime;
+        
+        // 计算会话持续时间
+        const firstMessage = historyContent[0];
+        const sessionStart = firstMessage.timestamp || 0;
+        const sessionEnd = lastMessageTime;
+        const totalDuration = sessionEnd - sessionStart;
+        
+        // 分析会话中的集中交流时段
+        const conversationSessions = analyzeConversationSessions(historyContent);
+        
+        return {
+            status: "active",
+            timeSinceLastMessage: {
+                milliseconds: timeSinceLastMessage,
+                humanReadable: formatDuration(timeSinceLastMessage),
+                lastMessageTime: formatTimestamp(lastMessageTime, 'datetime')
+            },
+            currentTime: formatTimestamp(currentTime, 'datetime'),
+            sessionDuration: {
+                startTime: formatTimestamp(sessionStart, 'datetime'),
+                endTime: formatTimestamp(sessionEnd, 'datetime'),
+                totalDuration: formatDuration(totalDuration),
+                totalMilliseconds: totalDuration
+            },
+            conversationSessions: conversationSessions,
+            sessionFilePath: historyPath,
+            messageCount: historyContent.length,
+            timestamp: getCurrentTimestamp('iso'),
+            displayTime: formatTimestamp(new Date(), 'time')
+        };
+        
+    } catch (error) {
+        FORCE_LOG('[ChatRoomViewer] Error generating session time elapsed:', error.message);
+        return {
+            status: "error",
+            error: error.message,
+            timestamp: getCurrentTimestamp('iso'),
+            displayTime: formatTimestamp(new Date(), 'time')
+        };
+    }
+}
+
+// 分析会话中的集中交流时段
+function analyzeConversationSessions(messages) {
+    if (!Array.isArray(messages) || messages.length === 0) return [];
+    
+    const sessions = [];
+    let currentSession = null;
+    const SESSION_GAP_THRESHOLD = 30 * 60 * 1000; // 30分钟间隔认为是新的会话时段
+    
+    for (let i = 0; i < messages.length; i++) {
+        const message = messages[i];
+        const messageTime = message.timestamp || 0;
+        
+        if (!currentSession) {
+            // 开始新的会话时段
+            currentSession = {
+                startIndex: i,
+                startTime: messageTime,
+                endTime: messageTime,
+                messageCount: 1,
+                endIndex: i
+            };
+        } else {
+            const timeSinceLastMessage = messageTime - currentSession.endTime;
+            
+            if (timeSinceLastMessage > SESSION_GAP_THRESHOLD) {
+                // 时间间隔太长，结束当前会话，开始新会话
+                sessions.push({
+                    ...currentSession,
+                    duration: currentSession.endTime - currentSession.startTime,
+                    durationHuman: formatDuration(currentSession.endTime - currentSession.startTime),
+                    startTimeHuman: formatTimestamp(currentSession.startTime, 'datetime'),
+                    endTimeHuman: formatTimestamp(currentSession.endTime, 'datetime')
+                });
+                
+                currentSession = {
+                    startIndex: i,
+                    startTime: messageTime,
+                    endTime: messageTime,
+                    messageCount: 1,
+                    endIndex: i
+                };
+            } else {
+                // 继续当前会话时段
+                currentSession.endTime = messageTime;
+                currentSession.messageCount++;
+                currentSession.endIndex = i;
+            }
+        }
+    }
+    
+    // 添加最后一个会话时段
+    if (currentSession) {
+        sessions.push({
+            ...currentSession,
+            duration: currentSession.endTime - currentSession.startTime,
+            durationHuman: formatDuration(currentSession.endTime - currentSession.startTime),
+            startTimeHuman: formatTimestamp(currentSession.startTime, 'datetime'),
+            endTimeHuman: formatTimestamp(currentSession.endTime, 'datetime')
+        });
+    }
+    
+    return sessions;
+}
+
+// 格式化持续时间为人类可读格式
+function formatDuration(milliseconds) {
+    const seconds = Math.floor(milliseconds / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+    
+    if (days > 0) {
+        const remainingHours = hours % 24;
+        const remainingMinutes = minutes % 60;
+        return `${days}天${remainingHours}小时${remainingMinutes}分钟`;
+    } else if (hours > 0) {
+        const remainingMinutes = minutes % 60;
+        const remainingSeconds = seconds % 60;
+        return `${hours}小时${remainingMinutes}分钟${remainingSeconds}秒`;
+    } else if (minutes > 0) {
+        const remainingSeconds = seconds % 60;
+        return `${minutes}分钟${remainingSeconds}秒`;
+    } else {
+        return `${seconds}秒`;
+    }
+}
+
+// 新增：生成群聊会话监控信息
+async function generateGroupSessionWatcher() {
+    try {
+        const mainDir = getVCPChatMainDirectory();
+        const groupDataDir = path.join(mainDir, 'AppData', 'UserData');
+        
+        // 查找群聊会话文件（以_Agent_开头但实际是群聊的特殊处理）
+        let latestGroupFile = null;
+        let latestTime = 0;
+        
+        const dirs = await fs.readdir(groupDataDir, { withFileTypes: true });
+        
+        // 寻找群聊相关的目录结构
+        for (const dir of dirs) {
+            if (dir.isDirectory()) {
+                const groupTopicsDir = path.join(groupDataDir, dir.name, 'topics');
+                try {
+                    const topicDirs = await fs.readdir(groupTopicsDir, { withFileTypes: true });
+                    
+                    for (const topicDir of topicDirs) {
+                        if (topicDir.isDirectory() && topicDir.name.startsWith('group_topic_')) {
+                            const historyPath = path.join(groupTopicsDir, topicDir.name, 'history.json');
+                            try {
+                                const stats = await fs.stat(historyPath);
+                                if (stats.mtime.getTime() > latestTime) {
+                                    latestTime = stats.mtime.getTime();
+                                    latestGroupFile = {
+                                        filePath: historyPath,
+                                        groupId: dir.name,
+                                        topicId: topicDir.name,
+                                        lastModified: stats.mtime,
+                                        size: stats.size
+                                    };
+                                }
+                            } catch (statError) {
+                                // 跳过无法访问的文件
+                            }
+                        }
+                    }
+                } catch (topicsError) {
+                    // 跳过无法访问的topics目录
+                }
+            }
+        }
+        
+        if (latestGroupFile) {
+            return {
+                status: "active",
+                currentSession: {
+                    groupId: latestGroupFile.groupId,
+                    topicId: latestGroupFile.topicId,
+                    filePath: latestGroupFile.filePath,
+                    lastModified: formatTimestamp(latestGroupFile.lastModified, 'iso'),
+                    lastModifiedDisplay: formatTimestamp(latestGroupFile.lastModified, 'time'),
+                    modifiedTimestamp: latestGroupFile.lastModified.getTime(),
+                    size: latestGroupFile.size
+                },
+                timestamp: getCurrentTimestamp('iso'),
+                displayTime: formatTimestamp(new Date(), 'time')
+            };
+        } else {
+            return {
+                status: "no_group_session",
+                message: "未找到活跃的群聊会话文件",
+                timestamp: getCurrentTimestamp('iso'),
+                displayTime: formatTimestamp(new Date(), 'time')
+            };
+        }
+    } catch (error) {
+        FORCE_LOG('[ChatRoomViewer] Error in generateGroupSessionWatcher:', error.message);
+        return {
+            status: "error",
+            error: error.message,
+            timestamp: getCurrentTimestamp('iso'),
+            displayTime: formatTimestamp(new Date(), 'time')
+        };
+    }
 }
 
 // 获取所有Agent的基本信息
@@ -578,7 +1310,9 @@ async function main() {
             "{{VCPChatTheme}}": "[ChatRoomViewer: Disabled]",
             "{{VCPChatSessionWatcher}}": "[ChatRoomViewer: Disabled]",
             "{{VCPChatAgent}}": "[ChatRoomViewer: Disabled]",
-            "{{VCPChatModeBubbleTip}}": "[ChatRoomViewer: Disabled]"
+            "{{VCPChatModeBubbleTip}}": "[ChatRoomViewer: Disabled]",
+            "{{VCPChatSessionTimeElapsed}}": "[ChatRoomViewer: Disabled]",
+            "{{VCPChatGroupSessionWatcher}}": "[ChatRoomViewer: Disabled]"
         };
         process.stdout.write(JSON.stringify(disabledOutput));
         process.exit(0);
@@ -589,27 +1323,38 @@ async function main() {
         FORCE_LOG('[ChatRoomViewer] Starting to collect VCPChat client information...');
         
         // 并行获取所有信息
-        const [statusInfo, themeInfo, agentsInfo] = await Promise.all([
+        const [statusInfo, themeInfo, agentsInfo, sessionTimeElapsed, groupSessionWatcher] = await Promise.all([
             generateVCPChatStatus(),
             generateThemeInfo(),
-            getAllAgentsInfo()
+            getAllAgentsInfo(),
+            generateSessionTimeElapsed(),
+            generateGroupSessionWatcher()
         ]);
         
         // 获取主题模式气泡示范（同步操作）
         const modeBubbleTip = generateModeBubbleTip();
         
-        // 获取日志信息（同步操作）
-        // 已删除日志功能
-        
         // 获取会话监控信息
         const sessionWatcherInfo = statusInfo.sessionWatcher || { error: "无法获取会话监控信息" };
+        
+        // 缓存数据
+        cachedData.statusInfo = statusInfo;
+        cachedData.themeInfo = themeInfo;
+        cachedData.agentsInfo = agentsInfo;
+        cachedData.sessionWatcherInfo = sessionWatcherInfo;
+        cachedData.modeBubbleTip = modeBubbleTip;
+        cachedData.sessionTimeElapsed = sessionTimeElapsed;
+        cachedData.groupSessionWatcher = groupSessionWatcher;
+        cachedData.lastUpdate = Date.now();
         
         const outputData = {
             "{{VCPChatStatus}}": JSON.stringify(statusInfo),
             "{{VCPChatTheme}}": JSON.stringify(themeInfo),
             "{{VCPChatSessionWatcher}}": JSON.stringify(sessionWatcherInfo),
             "{{VCPChatAgent}}": JSON.stringify(agentsInfo),
-            "{{VCPChatModeBubbleTip}}": JSON.stringify(modeBubbleTip)
+            "{{VCPChatModeBubbleTip}}": JSON.stringify(modeBubbleTip),
+            "{{VCPChatSessionTimeElapsed}}": JSON.stringify(sessionTimeElapsed),
+            "{{VCPChatGroupSessionWatcher}}": JSON.stringify(groupSessionWatcher)
         };
         
         if (debugMode) {
@@ -618,10 +1363,22 @@ async function main() {
             FORCE_LOG('[ChatRoomViewer] Generated session watcher data:', JSON.stringify(sessionWatcherInfo, null, 2));
             FORCE_LOG('[ChatRoomViewer] Generated agents data:', JSON.stringify(agentsInfo, null, 2));
             FORCE_LOG('[ChatRoomViewer] Generated mode bubble tip:', JSON.stringify(modeBubbleTip, null, 2));
+            FORCE_LOG('[ChatRoomViewer] Generated session time elapsed:', JSON.stringify(sessionTimeElapsed, null, 2));
+            FORCE_LOG('[ChatRoomViewer] Generated group session watcher:', JSON.stringify(groupSessionWatcher, null, 2));
         }
         
         process.stdout.write(JSON.stringify(outputData));
-        process.exit(0);
+        
+        // 初始化文件监控器（在获取数据后，确保有正确的会话文件信息）
+        initializeFileWatchers();
+        
+        // 初始化群聊会话文件监控
+        initializeGroupSessionWatcher();
+        
+        // 如果不是监控模式，则退出
+        if (!isWatcherMode) {
+            process.exit(0);
+        }
         
     } catch (error) {
         const errorMsg = `[ChatRoomViewer] Unexpected error: ${error.message}`;
@@ -630,13 +1387,30 @@ async function main() {
         const errorOutput = {
             "{{VCPChatStatus}}": errorMsg,
             "{{VCPChatTheme}}": errorMsg,
-            "{{VCPChatLogs}}": errorMsg,
-            "{{VCPChatSessionWatcher}}": errorMsg
+            "{{VCPChatSessionWatcher}}": errorMsg,
+            "{{VCPChatAgent}}": errorMsg,
+            "{{VCPChatModeBubbleTip}}": errorMsg,
+            "{{VCPChatSessionTimeElapsed}}": errorMsg,
+            "{{VCPChatGroupSessionWatcher}}": errorMsg
         };
         process.stdout.write(JSON.stringify(errorOutput));
-        process.exit(1);
+        
+        if (!isWatcherMode) {
+            process.exit(1);
+        }
     }
 }
+
+// 处理退出信号
+process.on('SIGTERM', () => {
+    cleanupFileWatchers();
+    process.exit(0);
+});
+
+process.on('SIGINT', () => {
+    cleanupFileWatchers();
+    process.exit(0);
+});
 
 // 执行主函数
 main().catch(error => {

--- a/VCPDistributedServer/Plugin/ChatRoomViewer/plugin-manifest.json
+++ b/VCPDistributedServer/Plugin/ChatRoomViewer/plugin-manifest.json
@@ -34,11 +34,19 @@
       {
         "placeholder": "{{VCPChatModeBubbleTip}}",
         "description": "主题模式自适应气泡实现指导，教授Agent如何创建亮暗模式自动切换的气泡样式"
+      },
+      {
+        "placeholder": "{{VCPChatSessionTimeElapsed}}",
+        "description": "当前会话时间流逝信息，包括距离上次对话的时间、会话持续时间、集中交流时段分析等"
+      },
+      {
+        "placeholder": "{{VCPChatGroupSessionWatcher}}",
+        "description": "群聊会话监控信息，包括当前监控的群聊会话文件地址和状态"
       }
     ],
     "invocationCommands": []
   },
-  "refreshIntervalCron": "*/2 * * * * *",
+  "refreshIntervalCron": "* * * * * *",
   "configSchema": {
     "DebugMode": {
       "type": "boolean",

--- a/modules/ipc/agentHandlers.js
+++ b/modules/ipc/agentHandlers.js
@@ -152,24 +152,78 @@ function initialize(context) {
     ipcMain.handle('save-combined-item-order', async (event, orderedItemsWithTypes) => {
         try {
             let settings = {};
+            let originalContent = null;
+            
             try {
                 if (await fs.pathExists(SETTINGS_FILE)) {
                     try {
-                        settings = await fs.readJson(SETTINGS_FILE);
+                        const fileContent = await fs.readFile(SETTINGS_FILE, 'utf8');
+                        originalContent = fileContent; // 保存原始内容作为备份
+                        settings = JSON.parse(fileContent);
                     } catch (parseError) {
                         console.error('[AgentHandlers] Error parsing settings.json in save-combined-item-order:', parseError.message);
-                        settings = {}; // 使用空对象而不是返回错误
+                        // 尝试从损坏文件中恢复数据
+                        settings = await recoverSettingsFromCorruptedFile(originalContent);
                     }
+                } else {
+                    // 使用与 settingsHandlers.js 相同的默认设置
+                    settings = {
+                        sidebarWidth: 260,
+                        notificationsSidebarWidth: 300,
+                        userName: '用户',
+                        vcpServerUrl: '',
+                        vcpApiKey: '',
+                        vcpLogUrl: '',
+                        vcpLogKey: '',
+                        networkNotesPaths: [],
+                        enableAgentBubbleTheme: false,
+                        enableSmoothStreaming: false,
+                        minChunkBufferSize: 1,
+                        smoothStreamIntervalMs: 25,
+                        assistantAgent: '',
+                        enableDistributedServer: true,
+                        agentMusicControl: false,
+                        enableDistributedServerLogs: false,
+                        enableVcpToolInjection: false
+                    };
                 }
             } catch (readError) {
                 if (readError.code !== 'ENOENT') {
                     console.error('Failed to read settings file for saving combined item order:', readError);
                     return { success: false, error: '读取设置文件失败' };
                 }
+                // 文件不存在时使用默认设置
+                settings = {
+                    sidebarWidth: 260,
+                    notificationsSidebarWidth: 300,
+                    userName: '用户',
+                    enableDistributedServerLogs: false
+                };
             }
+            
             settings.combinedItemOrder = orderedItemsWithTypes;
-            await fs.writeJson(SETTINGS_FILE, settings, { spaces: 2 });
-            return { success: true };
+            
+            // 使用安全的文件写入方式
+            const tempFile = SETTINGS_FILE + '.tmp';
+            try {
+                await fs.writeJson(tempFile, settings, { spaces: 2 });
+                
+                // 验证写入的文件是否正确
+                const verifyContent = await fs.readFile(tempFile, 'utf8');
+                JSON.parse(verifyContent); // 检查JSON格式是否正确
+                
+                // 如果验证成功，再重命名为正式文件
+                await fs.move(tempFile, SETTINGS_FILE, { overwrite: true });
+                
+                return { success: true };
+            } catch (tempWriteError) {
+                console.error('[AgentHandlers] Error writing temporary settings file for combined item order:', tempWriteError.message);
+                // 清理临时文件
+                if (await fs.pathExists(tempFile)) {
+                    await fs.remove(tempFile).catch(() => {});
+                }
+                throw tempWriteError;
+            }
         } catch (error) {
             console.error('Error saving combined item order:', error);
             return { success: false, error: error.message || '保存项目顺序时发生未知错误' };
@@ -179,23 +233,77 @@ function initialize(context) {
     ipcMain.handle('save-agent-order', async (event, orderedAgentIds) => {
         try {
             let settings = {};
+            let originalContent = null;
+            
             try {
                 if (await fs.pathExists(SETTINGS_FILE)) {
                     try {
-                        settings = await fs.readJson(SETTINGS_FILE);
+                        const fileContent = await fs.readFile(SETTINGS_FILE, 'utf8');
+                        originalContent = fileContent; // 保存原始内容作为备份
+                        settings = JSON.parse(fileContent);
                     } catch (parseError) {
                         console.error('[AgentHandlers] Error parsing settings.json in save-agent-order:', parseError.message);
-                        settings = {}; // 使用空对象而不是返回错误
+                        // 尝试从损坏文件中恢复数据
+                        settings = await recoverSettingsFromCorruptedFile(originalContent);
                     }
+                } else {
+                    // 使用默认设置
+                    settings = {
+                        sidebarWidth: 260,
+                        notificationsSidebarWidth: 300,
+                        userName: '用户',
+                        vcpServerUrl: '',
+                        vcpApiKey: '',
+                        vcpLogUrl: '',
+                        vcpLogKey: '',
+                        networkNotesPaths: [],
+                        enableAgentBubbleTheme: false,
+                        enableSmoothStreaming: false,
+                        minChunkBufferSize: 1,
+                        smoothStreamIntervalMs: 25,
+                        assistantAgent: '',
+                        enableDistributedServer: true,
+                        agentMusicControl: false,
+                        enableDistributedServerLogs: false,
+                        enableVcpToolInjection: false
+                    };
                 }
             } catch (readError) {
                 if (readError.code !== 'ENOENT') {
                     return { success: false, error: '读取设置文件失败' };
                 }
+                // 文件不存在时使用默认设置
+                settings = {
+                    sidebarWidth: 260,
+                    notificationsSidebarWidth: 300,
+                    userName: '用户',
+                    enableDistributedServerLogs: false
+                };
             }
-            settings.agentOrder = orderedAgentIds; 
-            await fs.writeJson(SETTINGS_FILE, settings, { spaces: 2 });
-            return { success: true };
+            
+            settings.agentOrder = orderedAgentIds;
+            
+            // 使用安全的文件写入方式
+            const tempFile = SETTINGS_FILE + '.tmp';
+            try {
+                await fs.writeJson(tempFile, settings, { spaces: 2 });
+                
+                // 验证写入的文件是否正确
+                const verifyContent = await fs.readFile(tempFile, 'utf8');
+                JSON.parse(verifyContent); // 检查JSON格式是否正确
+                
+                // 如果验证成功，再重命名为正式文件
+                await fs.move(tempFile, SETTINGS_FILE, { overwrite: true });
+                
+                return { success: true };
+            } catch (tempWriteError) {
+                console.error('[AgentHandlers] Error writing temporary settings file for agent order:', tempWriteError.message);
+                // 清理临时文件
+                if (await fs.pathExists(tempFile)) {
+                    await fs.remove(tempFile).catch(() => {});
+                }
+                throw tempWriteError;
+            }
         } catch (error) {
             console.error('Error saving agent order:', error);
             return { success: false, error: error.message || '保存Agent顺序时发生未知错误' };
@@ -442,3 +550,120 @@ module.exports = {
     initialize,
     getAgentConfigById
 };
+
+// 帮助函数：从损坏的设置文件中恢复数据
+async function recoverSettingsFromCorruptedFile(originalContent) {
+    const recovered = {
+        sidebarWidth: 260,
+        notificationsSidebarWidth: 300,
+        userName: '用户',
+        vcpServerUrl: '',
+        vcpApiKey: '',
+        vcpLogUrl: '',
+        vcpLogKey: '',
+        networkNotesPaths: [],
+        enableAgentBubbleTheme: false,
+        enableSmoothStreaming: false,
+        minChunkBufferSize: 1,
+        smoothStreamIntervalMs: 25,
+        assistantAgent: '',
+        enableDistributedServer: true,
+        agentMusicControl: false,
+        enableDistributedServerLogs: false,
+        enableVcpToolInjection: false
+    };
+    
+    if (!originalContent) {
+        return recovered;
+    }
+    
+    try {
+        // 尝试使用正则表达式提取可能的字段值
+        const patterns = {
+            userName: /"userName"\s*:\s*"([^"]*)"/,
+            vcpServerUrl: /"vcpServerUrl"\s*:\s*"([^"]*)"/,
+            vcpApiKey: /"vcpApiKey"\s*:\s*"([^"]*)"/,
+            vcpLogUrl: /"vcpLogUrl"\s*:\s*"([^"]*)"/,
+            vcpLogKey: /"vcpLogKey"\s*:\s*"([^"]*)"/,
+            sidebarWidth: /"sidebarWidth"\s*:\s*(\d+)/,
+            notificationsSidebarWidth: /"notificationsSidebarWidth"\s*:\s*(\d+)/,
+            enableDistributedServer: /"enableDistributedServer"\s*:\s*(true|false)/,
+            agentMusicControl: /"agentMusicControl"\s*:\s*(true|false)/,
+            enableDistributedServerLogs: /"enableDistributedServerLogs"\s*:\s*(true|false)/,
+            enableVcpToolInjection: /"enableVcpToolInjection"\s*:\s*(true|false)/,
+            enableAgentBubbleTheme: /"enableAgentBubbleTheme"\s*:\s*(true|false)/,
+            enableSmoothStreaming: /"enableSmoothStreaming"\s*:\s*(true|false)/,
+            minChunkBufferSize: /"minChunkBufferSize"\s*:\s*(\d+)/,
+            smoothStreamIntervalMs: /"smoothStreamIntervalMs"\s*:\s*(\d+)/,
+            assistantAgent: /"assistantAgent"\s*:\s*"([^"]*)"/
+        };
+        
+        for (const [key, pattern] of Object.entries(patterns)) {
+            const match = originalContent.match(pattern);
+            if (match) {
+                const value = match[1];
+                if (key === 'sidebarWidth' || key === 'notificationsSidebarWidth' || 
+                    key === 'minChunkBufferSize' || key === 'smoothStreamIntervalMs') {
+                    recovered[key] = parseInt(value, 10);
+                } else if (key === 'enableDistributedServer' || key === 'agentMusicControl' || 
+                          key === 'enableDistributedServerLogs' || key === 'enableVcpToolInjection' ||
+                          key === 'enableAgentBubbleTheme' || key === 'enableSmoothStreaming') {
+                    recovered[key] = value === 'true';
+                } else {
+                    recovered[key] = value;
+                }
+                console.log(`[AgentHandlers] Recovered ${key}: ${recovered[key]}`);
+            }
+        }
+        
+        // 尝试恢复 networkNotesPaths 数组
+        const networkPathsMatch = originalContent.match(/"networkNotesPaths"\s*:\s*\[([^\]]*)/s);
+        if (networkPathsMatch) {
+            try {
+                const arrayContent = '[' + networkPathsMatch[1] + ']';
+                const parsedArray = JSON.parse(arrayContent.replace(/,$/, ''));
+                if (Array.isArray(parsedArray)) {
+                    recovered.networkNotesPaths = parsedArray;
+                    console.log(`[AgentHandlers] Recovered networkNotesPaths:`, recovered.networkNotesPaths);
+                }
+            } catch (arrayParseError) {
+                console.warn('[AgentHandlers] Could not recover networkNotesPaths array, using default');
+            }
+        }
+        
+        // 尝试恢复 combinedItemOrder 数组
+        const combinedOrderMatch = originalContent.match(/"combinedItemOrder"\s*:\s*\[([^\]]*)/s);
+        if (combinedOrderMatch) {
+            try {
+                const arrayContent = '[' + combinedOrderMatch[1] + ']';
+                const parsedArray = JSON.parse(arrayContent.replace(/,$/, ''));
+                if (Array.isArray(parsedArray)) {
+                    recovered.combinedItemOrder = parsedArray;
+                    console.log(`[AgentHandlers] Recovered combinedItemOrder:`, recovered.combinedItemOrder);
+                }
+            } catch (arrayParseError) {
+                console.warn('[AgentHandlers] Could not recover combinedItemOrder array, using default');
+            }
+        }
+        
+        // 尝试恢复 agentOrder 数组
+        const agentOrderMatch = originalContent.match(/"agentOrder"\s*:\s*\[([^\]]*)/s);
+        if (agentOrderMatch) {
+            try {
+                const arrayContent = '[' + agentOrderMatch[1] + ']';
+                const parsedArray = JSON.parse(arrayContent.replace(/,$/, ''));
+                if (Array.isArray(parsedArray)) {
+                    recovered.agentOrder = parsedArray;
+                    console.log(`[AgentHandlers] Recovered agentOrder:`, recovered.agentOrder);
+                }
+            } catch (arrayParseError) {
+                console.warn('[AgentHandlers] Could not recover agentOrder array, using default');
+            }
+        }
+        
+    } catch (recoverError) {
+        console.error('[AgentHandlers] Error during settings recovery:', recoverError.message);
+    }
+    
+    return recovered;
+}

--- a/modules/ipc/settingsHandlers.js
+++ b/modules/ipc/settingsHandlers.js
@@ -17,15 +17,68 @@ function initialize(paths) {
     ipcMain.handle('load-settings', async () => {
         try {
             let settings = {};
+            let hasChanges = false;
+            
             if (await fs.pathExists(SETTINGS_FILE)) {
-                settings = await fs.readJson(SETTINGS_FILE);
+                try {
+                    settings = await fs.readJson(SETTINGS_FILE);
+                } catch (parseError) {
+                    console.error('[Main] Error parsing existing settings.json, creating new settings:', parseError.message);
+                    settings = {};
+                    hasChanges = true;
+                }
+            } else {
+                console.log('[Main] Settings file does not exist, creating new one');
+                hasChanges = true;
             }
+            
+            // 确保默认字段存在
+            const defaultSettings = {
+                sidebarWidth: 260,
+                notificationsSidebarWidth: 300,
+                userName: '用户',
+                vcpServerUrl: '',
+                vcpApiKey: '',
+                vcpLogUrl: '',
+                vcpLogKey: '',
+                networkNotesPaths: [],
+                enableAgentBubbleTheme: false,
+                enableSmoothStreaming: false,
+                minChunkBufferSize: 1,
+                smoothStreamIntervalMs: 25,
+                assistantAgent: '',
+                enableDistributedServer: true,
+                agentMusicControl: false,
+                enableDistributedServerLogs: false, // 修复：确保此字段始终存在
+                enableVcpToolInjection: false
+            };
+            
+            // 合并默认设置，只添加缺失的字段
+            for (const [key, defaultValue] of Object.entries(defaultSettings)) {
+                if (!(key in settings)) {
+                    settings[key] = defaultValue;
+                    hasChanges = true;
+                }
+            }
+            
             // Check for user avatar
             if (await fs.pathExists(USER_AVATAR_FILE)) {
                 settings.userAvatarUrl = `file://${USER_AVATAR_FILE}?t=${Date.now()}`;
             } else {
                 settings.userAvatarUrl = null; // Or a default path
             }
+            
+            // 如果有变化，保存设置文件
+            if (hasChanges) {
+                try {
+                    const { userAvatarUrl, ...settingsToSave } = settings;
+                    await fs.writeJson(SETTINGS_FILE, settingsToSave, { spaces: 2 });
+                    console.log('[Main] Settings file updated with missing default fields');
+                } catch (writeError) {
+                    console.error('[Main] Error writing updated settings:', writeError.message);
+                }
+            }
+            
             return settings;
         } catch (error) {
             console.error('加载设置失败:', error);
@@ -33,7 +86,8 @@ function initialize(paths) {
                 error: error.message,
                 sidebarWidth: 260,
                 notificationsSidebarWidth: 300,
-                userAvatarUrl: null
+                userAvatarUrl: null,
+                enableDistributedServerLogs: false // 修复：确保错误情况下也有默认值
             };
         }
     });
@@ -42,10 +96,33 @@ function initialize(paths) {
         try {
             // User avatar URL is handled by 'save-user-avatar', remove it from general settings to avoid saving a file path
             const { userAvatarUrl, ...settingsToSave } = settings;
-            await fs.writeJson(SETTINGS_FILE, settingsToSave, { spaces: 2 });
+            
+            // 确保必需的默认字段存在
+            if (settingsToSave.enableDistributedServerLogs === undefined) {
+                settingsToSave.enableDistributedServerLogs = false;
+            }
+            
+            // 使用安全的文件写入方式
+            const tempFile = SETTINGS_FILE + '.tmp';
+            await fs.writeJson(tempFile, settingsToSave, { spaces: 2 });
+            
+            // 验证写入的文件是否正确
+            const verifyContent = await fs.readFile(tempFile, 'utf8');
+            JSON.parse(verifyContent); // 检查JSON格式是否正确
+            
+            // 如果验证成功，再重命名为正式文件
+            await fs.move(tempFile, SETTINGS_FILE, { overwrite: true });
+            
             return { success: true };
         } catch (error) {
             console.error('保存设置失败:', error);
+            
+            // 清理可能存在的临时文件
+            const tempFile = SETTINGS_FILE + '.tmp';
+            if (await fs.pathExists(tempFile)) {
+                await fs.remove(tempFile).catch(() => {});
+            }
+            
             return { error: error.message };
         }
     });
@@ -60,21 +137,52 @@ function initialize(paths) {
                     try {
                         settings = await fs.readJson(SETTINGS_FILE);
                     } catch (parseError) {
-                        console.error('[Main] Error parsing settings.json in save-avatar-color, using empty object:', parseError.message);
-                        settings = {};
+                        console.error('[Main] Error parsing settings.json in save-avatar-color, attempting recovery:', parseError.message);
+                        const originalContent = await fs.readFile(SETTINGS_FILE, 'utf8').catch(() => null);
+                        settings = await recoverSettingsFromCorruptedFile(originalContent);
                     }
                 }
                 
                 settings.userAvatarCalculatedColor = color;
-                await fs.writeJson(SETTINGS_FILE, settings, { spaces: 2 });
+                
+                // 使用安全的文件写入方式
+                const tempFile = SETTINGS_FILE + '.tmp';
+                const { userAvatarUrl, ...settingsToSave } = settings; // 移除临时字段
+                await fs.writeJson(tempFile, settingsToSave, { spaces: 2 });
+                
+                // 验证写入的文件是否正确
+                const verifyContent = await fs.readFile(tempFile, 'utf8');
+                JSON.parse(verifyContent);
+                
+                // 如果验证成功，再重命名为正式文件
+                await fs.move(tempFile, SETTINGS_FILE, { overwrite: true });
+                
                 console.log(`[Main] User avatar color saved: ${color}`);
                 return { success: true };
             } else if (type === 'agent' && id) {
                 const configPath = path.join(AGENT_DIR, id, 'config.json');
                 if (await fs.pathExists(configPath)) {
-                    const agentConfig = await fs.readJson(configPath);
+                    let agentConfig;
+                    try {
+                        agentConfig = await fs.readJson(configPath);
+                    } catch (parseError) {
+                        console.error(`[Main] Error parsing agent config for ${id}, using basic structure:`, parseError.message);
+                        agentConfig = { id: id };
+                    }
+                    
                     agentConfig.avatarCalculatedColor = color;
-                    await fs.writeJson(configPath, agentConfig, { spaces: 2 });
+                    
+                    // 使用安全的文件写入方式
+                    const tempConfigPath = configPath + '.tmp';
+                    await fs.writeJson(tempConfigPath, agentConfig, { spaces: 2 });
+                    
+                    // 验证写入的文件是否正确
+                    const verifyContent = await fs.readFile(tempConfigPath, 'utf8');
+                    JSON.parse(verifyContent);
+                    
+                    // 如果验证成功，再重命名为正式文件
+                    await fs.move(tempConfigPath, configPath, { overwrite: true });
+                    
                     console.log(`[Main] Agent ${id} avatar color saved: ${color}`);
                     return { success: true };
                 } else {
@@ -84,6 +192,22 @@ function initialize(paths) {
             return { success: false, error: 'Invalid type or missing ID for saving avatar color.' };
         } catch (error) {
             console.error('Error saving avatar color:', error);
+            
+            // 清理可能存在的临时文件
+            const tempFile = SETTINGS_FILE + '.tmp';
+            const tempConfigPath = type === 'agent' && id ? path.join(AGENT_DIR, id, 'config.json') + '.tmp' : null;
+            
+            try {
+                if (await fs.pathExists(tempFile)) {
+                    await fs.remove(tempFile);
+                }
+                if (tempConfigPath && await fs.pathExists(tempConfigPath)) {
+                    await fs.remove(tempConfigPath);
+                }
+            } catch (cleanupError) {
+                console.error('Error cleaning up temporary files:', cleanupError.message);
+            }
+            
             return { success: false, error: error.message };
         }
     });
@@ -97,40 +221,176 @@ function initialize(paths) {
             // 安全地更新settings.json文件中的主题相关字段
             try {
                 let settings = {};
+                let originalContent = null;
                 
                 // 尝试读取现有设置文件
                 if (await fs.pathExists(SETTINGS_FILE)) {
                     try {
-                        settings = await fs.readJson(SETTINGS_FILE);
+                        const fileContent = await fs.readFile(SETTINGS_FILE, 'utf8');
+                        originalContent = fileContent; // 保存原始内容作为备份
+                        settings = JSON.parse(fileContent);
                         console.log('[Main] Successfully loaded existing settings for theme update');
                     } catch (parseError) {
-                        console.error('[Main] Error parsing existing settings.json, preserving file and only updating theme:', parseError.message);
-                        // 如果解析失败，读取原始文件内容作为备份
-                        const originalContent = await fs.readFile(SETTINGS_FILE, 'utf8');
-                        console.error('[Main] Original settings.json content (first 200 chars):', originalContent.substring(0, 200));
+                        console.error('[Main] Error parsing existing settings.json, attempting recovery:', parseError.message);
                         
-                        // 尝试部分恢复或使用空对象
-                        settings = {};
+                        // 记录原始文件内容
+                        if (originalContent) {
+                            console.error('[Main] Original settings.json content (first 500 chars):', originalContent.substring(0, 500));
+                        }
+                        
+                        // 尝试从损坏的文件中恢复部分设置
+                        settings = await recoverSettingsFromCorruptedFile(originalContent);
+                        console.log('[Main] Recovered settings:', Object.keys(settings));
                     }
                 } else {
                     console.log('[Main] Settings file does not exist, creating new one with theme info');
+                    // 使用与 load-settings 中相同的默认设置
+                    settings = {
+                        sidebarWidth: 260,
+                        notificationsSidebarWidth: 300,
+                        userName: '用户',
+                        vcpServerUrl: '',
+                        vcpApiKey: '',
+                        vcpLogUrl: '',
+                        vcpLogKey: '',
+                        networkNotesPaths: [],
+                        enableAgentBubbleTheme: false,
+                        enableSmoothStreaming: false,
+                        minChunkBufferSize: 1,
+                        smoothStreamIntervalMs: 25,
+                        assistantAgent: '',
+                        enableDistributedServer: true,
+                        agentMusicControl: false,
+                        enableDistributedServerLogs: false,
+                        enableVcpToolInjection: false
+                    };
                 }
                 
                 // 只更新主题相关字段，保留所有其他设置
                 settings.currentThemeMode = theme;
                 settings.themeLastUpdated = Date.now();
                 
-                // 安全地写入文件
-                await fs.writeJson(SETTINGS_FILE, settings, { spaces: 2 });
-                console.log(`[Main] Settings.json safely updated: currentThemeMode=${theme}, themeLastUpdated=${settings.themeLastUpdated}`);
+                // 安全地写入文件 - 先写入临时文件，再重命名
+                const tempFile = SETTINGS_FILE + '.tmp';
+                try {
+                    await fs.writeJson(tempFile, settings, { spaces: 2 });
+                    
+                    // 验证临时文件是否正确
+                    const verifyContent = await fs.readFile(tempFile, 'utf8');
+                    JSON.parse(verifyContent); // 检查JSON格式是否正确
+                    
+                    // 如果验证成功，再重命名为正式文件
+                    await fs.move(tempFile, SETTINGS_FILE, { overwrite: true });
+                    console.log(`[Main] Settings.json safely updated: currentThemeMode=${theme}, themeLastUpdated=${settings.themeLastUpdated}`);
+                    
+                } catch (tempWriteError) {
+                    console.error('[Main] Error writing temporary settings file:', tempWriteError.message);
+                    // 清理临时文件
+                    if (await fs.pathExists(tempFile)) {
+                        await fs.remove(tempFile).catch(() => {});
+                    }
+                    throw tempWriteError;
+                }
                 
             } catch (error) {
                 console.error('[Main] Error updating settings.json for theme change:', error);
-                // 主题更改失败不应该影响系统的其他功能
                 console.error('[Main] Theme change in nativeTheme was successful, but settings.json update failed');
+                
+                // 在发生错误时，尝试将主题更新传送给渲染进程
+                // 这样即使设置文件更新失败，用户界面也可以正确显示主题
+                if (event && event.sender && !event.sender.isDestroyed()) {
+                    event.sender.send('theme-updated', { theme, timestamp: Date.now() });
+                }
             }
         }
     });
+    
+    // 帮助函数：从损坏的设置文件中恢复数据
+    async function recoverSettingsFromCorruptedFile(originalContent) {
+        const recovered = {
+            sidebarWidth: 260,
+            notificationsSidebarWidth: 300,
+            userName: '用户',
+            vcpServerUrl: '',
+            vcpApiKey: '',
+            vcpLogUrl: '',
+            vcpLogKey: '',
+            networkNotesPaths: [],
+            enableAgentBubbleTheme: false,
+            enableSmoothStreaming: false,
+            minChunkBufferSize: 1,
+            smoothStreamIntervalMs: 25,
+            assistantAgent: '',
+            enableDistributedServer: true,
+            agentMusicControl: false,
+            enableDistributedServerLogs: false,
+            enableVcpToolInjection: false
+        };
+        
+        if (!originalContent) {
+            return recovered;
+        }
+        
+        try {
+            // 尝试使用正则表达式提取可能的字段值
+            const patterns = {
+                userName: /"userName"\s*:\s*"([^"]*)"/,
+                vcpServerUrl: /"vcpServerUrl"\s*:\s*"([^"]*)"/,
+                vcpApiKey: /"vcpApiKey"\s*:\s*"([^"]*)"/,
+                vcpLogUrl: /"vcpLogUrl"\s*:\s*"([^"]*)"/,
+                vcpLogKey: /"vcpLogKey"\s*:\s*"([^"]*)"/,
+                sidebarWidth: /"sidebarWidth"\s*:\s*(\d+)/,
+                notificationsSidebarWidth: /"notificationsSidebarWidth"\s*:\s*(\d+)/,
+                enableDistributedServer: /"enableDistributedServer"\s*:\s*(true|false)/,
+                agentMusicControl: /"agentMusicControl"\s*:\s*(true|false)/,
+                enableDistributedServerLogs: /"enableDistributedServerLogs"\s*:\s*(true|false)/,
+                enableVcpToolInjection: /"enableVcpToolInjection"\s*:\s*(true|false)/,
+                enableAgentBubbleTheme: /"enableAgentBubbleTheme"\s*:\s*(true|false)/,
+                enableSmoothStreaming: /"enableSmoothStreaming"\s*:\s*(true|false)/,
+                minChunkBufferSize: /"minChunkBufferSize"\s*:\s*(\d+)/,
+                smoothStreamIntervalMs: /"smoothStreamIntervalMs"\s*:\s*(\d+)/,
+                assistantAgent: /"assistantAgent"\s*:\s*"([^"]*)"/
+            };
+            
+            for (const [key, pattern] of Object.entries(patterns)) {
+                const match = originalContent.match(pattern);
+                if (match) {
+                    const value = match[1];
+                    if (key === 'sidebarWidth' || key === 'notificationsSidebarWidth' || 
+                        key === 'minChunkBufferSize' || key === 'smoothStreamIntervalMs') {
+                        recovered[key] = parseInt(value, 10);
+                    } else if (key === 'enableDistributedServer' || key === 'agentMusicControl' || 
+                              key === 'enableDistributedServerLogs' || key === 'enableVcpToolInjection' ||
+                              key === 'enableAgentBubbleTheme' || key === 'enableSmoothStreaming') {
+                        recovered[key] = value === 'true';
+                    } else {
+                        recovered[key] = value;
+                    }
+                    console.log(`[Main] Recovered ${key}: ${recovered[key]}`);
+                }
+            }
+            
+            // 尝试恢复 networkNotesPaths 数组
+            const networkPathsMatch = originalContent.match(/"networkNotesPaths"\s*:\s*\[([^\]]*)/s);
+            if (networkPathsMatch) {
+                try {
+                    const arrayContent = '[' + networkPathsMatch[1] + ']';
+                    const parsedArray = JSON.parse(arrayContent.replace(/,$/, ''));
+                    if (Array.isArray(parsedArray)) {
+                        recovered.networkNotesPaths = parsedArray;
+                        console.log(`[Main] Recovered networkNotesPaths:`, recovered.networkNotesPaths);
+                    }
+                } catch (arrayParseError) {
+                    console.warn('[Main] Could not recover networkNotesPaths array, using default');
+                }
+            }
+            
+        } catch (recoverError) {
+            console.error('[Main] Error during settings recovery:', recoverError.message);
+        }
+        
+        return recovered;
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
1. 为群聊加入当前会话文件地址的占位符 {{VCPChatGroupSessionWatcher}}
2. 修复关于 /AppData/settings.json 文件可能的不安全读写 bug
3. 更新 VCPDistributedServer.js 文件，为 /AppData/settings.json 添加可选的是否在终端中定期打印静态插件占位符信息的字段 "enableDistributedServerLogs": false
4. 为 ChatRoomViewer 插件添加 {{VCPChatSessionTimeElapsed}} 占位符。能够获取当前真实实时的时间戳信息，然后通过比对传递出与当前时间相比当前会话距离上一次对话过去了多久时间。同时还有其他信息：始末时间戳所显示的总共持续的时间，自动智能分类出哪几次对话明显是集中交流，完整列举出从第几次对话开始跳跃到新的时间点。