### PR TITLE
重构语音配置命名：统一本地SoVITS和网络供应商配置键名，添加向后兼容迁移逻辑

### DIFF
--- a/Voicechatmodules/voicechat.js
+++ b/Voicechatmodules/voicechat.js
@@ -228,8 +228,8 @@ document.addEventListener('DOMContentLoaded', () => {
             voiceMode: settings.voiceMode || 'local',
             speechRecognizerBrowserPath: settings.speechRecognizerBrowserPath || '',
             speechRecognizerPagePath: settings.speechRecognizerPagePath || 'Voicechatmodules/recognizer.html',
-            voiceNetworkSettings: settings.voiceNetworkSettings || { sovitsUrl: '', sovitsKey: '' },
-            voiceLocalSettings: settings.voiceLocalSettings || { providerUrl: '', providerKey: '' }
+            voiceLocalSovitsSettings: settings.voiceLocalSovitsSettings || { sovitsUrl: '', sovitsKey: '' },
+            voiceNetworkProviderSettings: settings.voiceNetworkProviderSettings || { providerUrl: '', providerKey: '' }
         };
     }
 
@@ -526,8 +526,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         console.log(`[VoiceChat] Requesting TTS for message ${msgId}`, {
             voiceMode: globalSettings.voiceMode || 'local',
-            networkSovitsUrl: globalSettings.voiceNetworkSettings?.sovitsUrl || '',
-            localProviderUrl: globalSettings.voiceLocalSettings?.providerUrl || ''
+            localSovitsUrl: globalSettings.voiceLocalSovitsSettings?.sovitsUrl || '',
+            networkProviderUrl: globalSettings.voiceNetworkProviderSettings?.providerUrl || ''
         });
         window.electronAPI.sovitsSpeak({
             text: text,

--- a/WebIndexTTS2/server.js
+++ b/WebIndexTTS2/server.js
@@ -68,7 +68,7 @@ function readMainSettings() {
 function getEnvConfig() {
   const env = readEnvFile(CONFIG_PATH);
   const mainSettings = readMainSettings();
-  const networkModeSettings = mainSettings.voiceLocalSettings || {};
+  const networkModeSettings = mainSettings.voiceNetworkProviderSettings || {};
 
   const resolvedUrl = (networkModeSettings.providerUrl || env.siliconflow_url || 'https://api.siliconflow.cn').replace(/\/+$/, '');
   const resolvedKey = networkModeSettings.providerKey || env.siliconflow_key || '';

--- a/main.html
+++ b/main.html
@@ -1351,13 +1351,13 @@
                                     </div>
 
                                     <div class="settings-form-group">
-                                        <label for="voiceLocalProviderUrl">网络供应商 URL:</label>
-                                        <input type="url" id="voiceLocalProviderUrl" name="voiceLocalProviderUrl"
+                                        <label for="voiceNetworkProviderUrl">网络供应商 URL:</label>
+                                        <input type="url" id="voiceNetworkProviderUrl" name="voiceNetworkProviderUrl"
                                             placeholder="例如: https://api.example.com/voice">
                                     </div>
                                     <div class="settings-form-group">
-                                        <label for="voiceLocalProviderKey">网络供应商 Key:</label>
-                                        <input type="password" id="voiceLocalProviderKey" name="voiceLocalProviderKey">
+                                        <label for="voiceNetworkProviderKey">网络供应商 Key:</label>
+                                        <input type="password" id="voiceNetworkProviderKey" name="voiceNetworkProviderKey">
                                     </div>
                                 </div>
 
@@ -1368,13 +1368,13 @@
                                     </div>
 
                                     <div class="settings-form-group">
-                                        <label for="voiceNetworkSovitsUrl">本地 SoVITS URL:</label>
-                                        <input type="url" id="voiceNetworkSovitsUrl" name="voiceNetworkSovitsUrl"
+                                        <label for="voiceLocalSovitsUrl">本地 SoVITS URL:</label>
+                                        <input type="url" id="voiceLocalSovitsUrl" name="voiceLocalSovitsUrl"
                                             placeholder="例如: http://127.0.0.1:9880">
                                     </div>
                                     <div class="settings-form-group">
-                                        <label for="voiceNetworkSovitsKey">本地 SoVITS Key:</label>
-                                        <input type="password" id="voiceNetworkSovitsKey" name="voiceNetworkSovitsKey"
+                                        <label for="voiceLocalSovitsKey">本地 SoVITS Key:</label>
+                                        <input type="password" id="voiceLocalSovitsKey" name="voiceLocalSovitsKey"
                                             placeholder="如无可留空">
                                     </div>
                                 </div>

--- a/modules/SovitsTTS.js
+++ b/modules/SovitsTTS.js
@@ -33,12 +33,8 @@ class SovitsTTS {
         }
 
         const voiceMode = settings?.voiceMode || 'local';
-        // 注意：由于历史原因，设置中的 key 命名与实际存储的内容是反的：
-        // voiceNetworkSettings.sovitsUrl 实际存储的是「本地 SoVITS」的 URL
-        // voiceLocalSettings.providerUrl 实际存储的是「网络供应商」的 URL
-        // 下方变量名以实际用途命名，而非 settings key 名
-        const localSovitsConfig = settings?.voiceNetworkSettings || {};
-        const networkProviderConfig = settings?.voiceLocalSettings || {};
+        const localSovitsConfig = settings?.voiceLocalSovitsSettings || {};
+        const networkProviderConfig = settings?.voiceNetworkProviderSettings || {};
 
         const baseUrl = voiceMode === 'network'
             ? ((networkProviderConfig.providerUrl || '').trim() || DEFAULT_SOVITS_API_BASE_URL)

--- a/modules/global-settings-manager.js
+++ b/modules/global-settings-manager.js
@@ -83,13 +83,13 @@ export async function handleSaveGlobalSettings(e, deps) {
         voiceMode,
         speechRecognizerBrowserPath,
         speechRecognizerPagePath,
-        voiceNetworkSettings: {
-            sovitsUrl: document.getElementById('voiceNetworkSovitsUrl')?.value.trim() || '',
-            sovitsKey: document.getElementById('voiceNetworkSovitsKey')?.value || ''
+        voiceLocalSovitsSettings: {
+            sovitsUrl: document.getElementById('voiceLocalSovitsUrl')?.value.trim() || '',
+            sovitsKey: document.getElementById('voiceLocalSovitsKey')?.value || ''
         },
-        voiceLocalSettings: {
-            providerUrl: document.getElementById('voiceLocalProviderUrl')?.value.trim() || '',
-            providerKey: document.getElementById('voiceLocalProviderKey')?.value || ''
+        voiceNetworkProviderSettings: {
+            providerUrl: document.getElementById('voiceNetworkProviderUrl')?.value.trim() || '',
+            providerKey: document.getElementById('voiceNetworkProviderKey')?.value || ''
         },
         enableDistributedServer: document.getElementById('enableDistributedServer').checked,
         agentMusicControl: document.getElementById('agentMusicControl').checked,

--- a/modules/utils/appSettingsManager.js
+++ b/modules/utils/appSettingsManager.js
@@ -98,11 +98,11 @@ class SettingsManager extends EventEmitter {
             voiceMode: 'local',
             speechRecognizerBrowserPath: '',
             speechRecognizerPagePath: 'Voicechatmodules/recognizer.html',
-            voiceNetworkSettings: {
+            voiceLocalSovitsSettings: {
                 sovitsUrl: '',
                 sovitsKey: ''
             },
-            voiceLocalSettings: {
+            voiceNetworkProviderSettings: {
                 providerUrl: '',
                 providerKey: ''
             },
@@ -143,6 +143,35 @@ class SettingsManager extends EventEmitter {
         await fs.remove(this.lockFile).catch(() => {});
     }
 
+    hasLegacyVoiceSettingsKeys(settings = {}) {
+        return Object.prototype.hasOwnProperty.call(settings, 'voiceNetworkSettings')
+            || Object.prototype.hasOwnProperty.call(settings, 'voiceLocalSettings');
+    }
+
+    normalizeVoiceSettings(settings = {}) {
+        const normalized = { ...settings };
+
+        const localSovitsSettings = settings?.voiceLocalSovitsSettings || {};
+        const networkProviderSettings = settings?.voiceNetworkProviderSettings || {};
+        const legacyLocalSovitsSettings = settings?.voiceLocalSettings || {};
+        const legacyNetworkProviderSettings = settings?.voiceNetworkSettings || {};
+
+        normalized.voiceLocalSovitsSettings = {
+            sovitsUrl: localSovitsSettings.sovitsUrl ?? legacyLocalSovitsSettings.sovitsUrl ?? '',
+            sovitsKey: localSovitsSettings.sovitsKey ?? legacyLocalSovitsSettings.sovitsKey ?? ''
+        };
+
+        normalized.voiceNetworkProviderSettings = {
+            providerUrl: networkProviderSettings.providerUrl ?? legacyNetworkProviderSettings.providerUrl ?? '',
+            providerKey: networkProviderSettings.providerKey ?? legacyNetworkProviderSettings.providerKey ?? ''
+        };
+
+        delete normalized.voiceNetworkSettings;
+        delete normalized.voiceLocalSettings;
+
+        return normalized;
+    }
+
     async readSettings() {
         try {
             // 使用缓存机制减少文件读取
@@ -152,7 +181,15 @@ class SettingsManager extends EventEmitter {
             }
 
             const content = await fs.readFile(this.settingsPath, 'utf8');
-            const settings = JSON.parse(content);
+            const parsedSettings = JSON.parse(content);
+            const hasLegacyVoiceKeys = this.hasLegacyVoiceSettingsKeys(parsedSettings);
+            const settings = this.normalizeVoiceSettings(parsedSettings);
+
+            if (hasLegacyVoiceKeys) {
+                await this.writeSettings(settings);
+                console.log('Migrated legacy voice settings keys to the new schema.');
+                return { ...settings };
+            }
             
             // 更新缓存
             this.cache = settings;
@@ -171,7 +208,7 @@ class SettingsManager extends EventEmitter {
             if (await fs.pathExists(backupPath)) {
                 try {
                     const backupContent = await fs.readFile(backupPath, 'utf8');
-                    const backupSettings = JSON.parse(backupContent);
+                    const backupSettings = this.normalizeVoiceSettings(JSON.parse(backupContent));
                     
                     // 验证备份数据是否有效且包含用户自定义数据（例如 Agent 列表顺序或非默认用户名）
                     const isNonDefault = backupSettings && (
@@ -201,8 +238,12 @@ class SettingsManager extends EventEmitter {
         const backupFile = this.settingsPath + '.backup';
         
         try {
+            const normalizedSettings = this.normalizeVoiceSettings(settings);
+
             // 验证设置
-            const { validated } = SettingsValidator.validate(settings, this.defaultSettings);
+            const { validated } = SettingsValidator.validate(normalizedSettings, this.defaultSettings);
+            delete validated.voiceNetworkSettings;
+            delete validated.voiceLocalSettings;
             
             // 写入临时文件
             await fs.writeJson(tempFile, validated, { spaces: 2 });

--- a/renderer.js
+++ b/renderer.js
@@ -33,12 +33,12 @@ let globalSettings = {
     voiceMode: 'local',
     speechRecognizerBrowserPath: '',
     speechRecognizerPagePath: 'Voicechatmodules/recognizer.html',
-    voiceNetworkSettings: {
-        sovitsUrl: 'https://api.siliconflow.cn',
+    voiceLocalSovitsSettings: {
+        sovitsUrl: 'http://127.0.0.1:8000',
         sovitsKey: ''
     },
-    voiceLocalSettings: {
-        providerUrl: '',
+    voiceNetworkProviderSettings: {
+        providerUrl: 'https://api.siliconflow.cn',
         providerKey: ''
     }
 };
@@ -2000,10 +2000,10 @@ async function syncGlobalSettingsToUI() {
     safeCheck('voiceModeNetwork', (globalSettings.voiceMode || 'local') === 'network');
     safeSet('speechRecognizerBrowserPath', globalSettings.speechRecognizerBrowserPath || '');
     safeSet('speechRecognizerPagePath', globalSettings.speechRecognizerPagePath || 'Voicechatmodules/recognizer.html');
-    safeSet('voiceNetworkSovitsUrl', globalSettings.voiceNetworkSettings?.sovitsUrl || '');
-    safeSet('voiceNetworkSovitsKey', globalSettings.voiceNetworkSettings?.sovitsKey || '');
-    safeSet('voiceLocalProviderUrl', globalSettings.voiceLocalSettings?.providerUrl || '');
-    safeSet('voiceLocalProviderKey', globalSettings.voiceLocalSettings?.providerKey || '');
+    safeSet('voiceLocalSovitsUrl', globalSettings.voiceLocalSovitsSettings?.sovitsUrl || '');
+    safeSet('voiceLocalSovitsKey', globalSettings.voiceLocalSovitsSettings?.sovitsKey || '');
+    safeSet('voiceNetworkProviderUrl', globalSettings.voiceNetworkProviderSettings?.providerUrl || '');
+    safeSet('voiceNetworkProviderKey', globalSettings.voiceNetworkProviderSettings?.providerKey || '');
     
     // Network Notes Paths
     const networkNotesPathsContainer = document.getElementById('networkNotesPathsContainer');


### PR DESCRIPTION
描述
变更概述
    重构了语音配置的内部数据结构命名，使配置键名更清晰地反映其实际用途，同时添加了向后兼容的自动迁移逻辑。

具体改动
1. 配置键名重命名
     - voiceNetworkSettings -> voiceLocalSovitsSettings (本地SoVITS配置)
     - voiceLocalSettings -> voiceNetworkProviderSettings (网络供应商配置)

    2. 修改的文件
     - Voicechatmodules/voicechat.js - 更新配置引用
     - WebIndexTTS2/server.js - 更新配置引用
     - main.html - 更新表单元素ID和name属性
     - modules/SovitsTTS.js - 更新配置引用，移除历史注释
     - modules/global-settings-manager.js - 更新保存逻辑
     - modules/utils/appSettingsManager.js - 添加迁移逻辑
     - renderer.js - 更新默认配置和UI同步

变更原因
    之前的命名存在历史遗留问题：
     - voiceNetworkSettings 实际存储的是本地SoVITS配置
     - voiceLocalSettings 实际存储的是网络供应商配置

我没经过测试，建议审查测试无误后再合并（