### PR TITLE
feat(HumanToolBox): 人类工具箱 UX 增强 — 11项新功能

### DIFF
--- a/VCPHumanToolBox/index.html
+++ b/VCPHumanToolBox/index.html
@@ -18,8 +18,7 @@
             <div class="control-btn" id="maximize-btn">□</div>
             <div class="control-btn" id="close-btn">&times;</div>
         </div>
-    </div>
-    <div class="container">
+    </div><div class="container">
         <header>
             <h1>工具箱</h1>
             <p>一个为人类设计的直观工具调用界面。</p>
@@ -34,9 +33,7 @@
         </header>
 
         <main id="main-content">
-            <div id="tool-grid" class="tool-grid">
-                <!-- 工具卡片将由JS动态生成 -->
-            </div>
+            <div id="tool-grid" class="tool-grid"></div>
 
             <div id="tool-detail-view" class="tool-detail-view" style="display: none;">
                 <button id="back-to-grid-btn" class="back-btn">&larr; 返回工具列表</button>
@@ -44,16 +41,13 @@
                 <p id="tool-description"></p>
                 <form id="tool-form"></form>
                 <div id="result-container" class="result-container"></div>
+                <div id="execution-history"></div>
             </div>
         </main>
     </div>
 
-    <!-- 引入jsPlumb库 -->
     <script src="WorkflowEditormodules/jsplumb.min.js"></script>
-    
-    <!-- 引入工作流编辑器模块 -->
     <script src="WorkflowEditormodules/WorkflowEditor_ApiConfigDialog.js"></script>
-    <!-- AI 客户端（HTTP 实现 + 工厂），必须在 NodeManager 之前加载 -->
     <script src="WorkflowEditormodules/ai/HttpAiClient.js"></script>
     <script src="WorkflowEditormodules/ai/AiClientFactory.js"></script>
     <script src="WorkflowEditormodules/WorkflowEditor_PluginManager.js"></script>
@@ -66,10 +60,7 @@
     <script src="WorkflowEditormodules/WorkflowEditor_ConnectionManager_Simplified.js"></script>
     <script src="WorkflowEditormodules/WorkflowEditor_Config.js"></script>
     <script src="WorkflowEditormodules/WorkflowEditor_PluginDialog.js"></script>
-    
-    <!-- 引入 marked 库 -->
     <script src="../vendor/marked.min.js"></script>
     <script type="module" src="renderer.js"></script>
 </body>
 </html>
-

--- a/VCPHumanToolBox/renderer.js
+++ b/VCPHumanToolBox/renderer.js
@@ -1,4 +1,6 @@
 // VCPHumanToolBox/renderer.js
+// Enhanced by CodeCC &赵枫 - 2026-04-21
+// 8features: search+filter, hide maid, param folding, timer, retry, copy, form cache, history
 import { tools } from './renderer_modules/config.js';
 import * as canvasHandler from './renderer_modules/ui/canvas-handler.js';
 import * as dynamicImageHandler from './renderer_modules/ui/dynamic-image-handler.js';
@@ -19,6 +21,36 @@ document.addEventListener('DOMContentLoaded', async () => {
     let USER_NAME = 'Human';
     let settings = {};
     let MAX_FILENAME_LENGTH = 400;
+    let currentToolName = '';
+    const formStateCache = new Map();
+    const executionHistory = [];
+
+    // --- 工具分类映射 ---
+    const TOOL_CATEGORIES = {
+        '多媒体生成': ['ZImageGen','FluxGen','DoubaoGen','QwenImageGen',
+            'GeminiImageGen','NovelAIGen','ComfyCloudGen','SunoGen',
+            'WanVideoGen','GrokVideoGen','WebUIGen','ComfyUIGen','NanoBananaGen2'],
+        '联网搜索': ['VSearch','TavilySearch','GoogleSearch','SerpSearch',
+            'UrlFetch','BilibiliFetch','FlashDeepSearch','AnimeFinder'],
+        '代码与仓库': ['GitSearch','DeepWikiVCP'],
+        '学术研究': ['PubMedSearch','PaperReader'],
+        '记忆与思考': ['DeepMemo','LightMemo','ThoughtClusterManager',
+            'TopicMemo','AgentTopicCreator'],
+        '通讯与社区': ['AgentAssistant','AgentDream','AgentMessage','VCPForum'],
+        '占卜与趣味': ['TarotDivination'],
+        '工具与计算': ['SciCalculator','MusicController','VCPAlarm','TableLampRemote'],
+        '文件管理': ['LocalSearchController','ServerSearchController',
+            'PowerShellExecutor','ServerPowerShellExecutor',
+            'CodeSearcher','ServerCodeSearcher'],
+        '日程管理': ['ScheduleManager']
+    };
+
+    function getCategoryForTool(toolName) {
+        for (const [cat, list] of Object.entries(TOOL_CATEGORIES)) {
+            if (list.includes(toolName)) return cat;
+        }
+        return '其他';
+    }
 
     // --- 设置加载与保存 ---
     async function loadSettings() {
@@ -38,8 +70,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             console.log('[VCPHumanToolBox] Settings saved successfully');
         } catch (error) {
-            console.error('[VCPHumanToolBox] Failed to save settings:', error);
-            throw error;
+            console.error('[VCPHumanToolBox] Failed to save settings:', error);throw error;
         }
     }
 
@@ -55,44 +86,211 @@ document.addEventListener('DOMContentLoaded', async () => {
             } catch (e) {
                 console.error("Invalid vcpServerUrl in settings:", settings.vcpServerUrl);
             }
-        }
-        VCP_API_KEY = settings.vcpApiKey || '';
+        }VCP_API_KEY = settings.vcpApiKey || '';
         USER_NAME = settings.userName || 'Human';
         MAX_FILENAME_LENGTH = settings.maxFilenameLength || 400;
+    // 恢复执行历史
+        if (Array.isArray(settings.vcpht_executionHistory)) {
+            executionHistory.push(...settings.vcpht_executionHistory.slice(0, 15));
+        }
         
-        // 动态加载模块并传递配置
-        // 注意：由于移除了 require，模块需要重构为浏览器兼容的格式
         canvasHandler.setMaxFilenameLength(MAX_FILENAME_LENGTH);
 
         if (!VCP_SERVER_URL || !VCP_API_KEY) {
-            toolGrid.innerHTML = `<div class="error">错误：无法加载配置文件 (settings.json)。请确保文件存在且格式正确。<br>未能从 settings.json 中找到 vcpServerUrl 或 vcpApiKey</div>`;
+            toolGrid.innerHTML = `<div class="info-box"><p><strong>错误：无法加载配置文件 (settings.json)。请确保文件存在且格式正确。</strong></p><p>未能从settings.json 中找到 vcpServerUrl 或 vcpApiKey</p></div>`;
             return;
         }
 
         initializeUI();
     }
-    
-
 
     // --- 函数定义 ---
 
     function renderToolGrid() {
         toolGrid.innerHTML = '';
+
+        // 读取收藏列表
+        let favorites = [];
+        try {
+            favorites = JSON.parse(localStorage.getItem('vcpht_favorites') || '[]');
+        } catch (e) { favorites = []; }
+
+        //搜索栏容器
+        const searchBar = document.createElement('div');
+        searchBar.className = 'tool-search-bar';
+        searchBar.style.cssText = `
+            display: flex; gap: 10px; margin-bottom: 20px; align-items: center;
+            grid-column: 1 / -1;
+        `;
+
+        const searchInput = document.createElement('input');
+        searchInput.type = 'text';
+        searchInput.placeholder = '🔍 搜索工具...';
+        searchInput.className = 'tool-search-input';
+        searchInput.style.cssText = `
+            flex: 1; padding: 10px 14px; border-radius: 8px;
+            border: 1px solid var(--border-color);
+            background: var(--input-bg); color: var(--primary-text);
+            font-size: 14px; outline: none; transition: border-color 0.2s;
+        `;
+
+        const categorySelect = document.createElement('select');
+        categorySelect.className = 'tool-category-select';
+        categorySelect.style.cssText = `
+            padding: 10px 14px; border-radius: 8px;
+            border: 1px solid var(--border-color);
+            background: var(--input-bg); color: var(--primary-text);
+            font-size: 14px; cursor: pointer; min-width: 140px;
+        `;
+        const allOption = document.createElement('option');
+        allOption.value = '';
+        allOption.textContent = '全部分类';
+        categorySelect.appendChild(allOption);
+
+        // 收藏选项
+        const favOption = document.createElement('option');
+        favOption.value = '__favorites__';
+        favOption.textContent = '⭐ 收藏';
+        categorySelect.appendChild(favOption);
+
+        for (const cat of Object.keys(TOOL_CATEGORIES)) {
+            const opt = document.createElement('option');
+            opt.value = cat;
+            opt.textContent = cat;
+            categorySelect.appendChild(opt);
+        }
+
+        const countBadge = document.createElement('span');
+        countBadge.className = 'tool-count-badge';
+        countBadge.style.cssText = `
+            padding: 6px 12px; border-radius: 20px; font-size: 12px;
+            background: rgba(255,152,0,0.15); color: var(--highlight-text);
+            white-space: nowrap; font-weight: 600;
+        `;
+        const totalTools = Object.keys(tools).length;
+        countBadge.textContent = `共${totalTools} 个`;
+
+        searchBar.appendChild(searchInput);
+        searchBar.appendChild(categorySelect);
+        searchBar.appendChild(countBadge);
+        toolGrid.appendChild(searchBar);
+
+        // 生成工具卡片
         for (const toolName in tools) {
             const tool = tools[toolName];
+            const category = getCategoryForTool(toolName);
+            const isFav = favorites.includes(toolName);
+
             const card = document.createElement('div');
             card.className = 'tool-card';
             card.dataset.toolName = toolName;
+            card.dataset.category = category;
+            card.dataset.search = `${toolName} ${tool.displayName} ${tool.description} ${category}`.toLowerCase();
+
             card.innerHTML = `
-                <h3>${tool.displayName}</h3>
-                <p>${tool.description}</p>
+                <div style="position: relative;">
+                    <span class="fav-star" data-tool="${toolName}" style="
+                        position: absolute; top: -8px; right: -8px;
+                        font-size: 18px; cursor: pointer; z-index: 2;
+                        filter: ${isFav ? 'none' : 'grayscale(1) opacity(0.3)'};
+                        transition: all 0.2s;
+                    ">${isFav ? '★' : '☆'}</span>
+                    <h3>${tool.displayName}</h3>
+                    <p>${tool.description}</p>
+                    <span style="display:inline-block; margin-top:8px; padding:2px 8px; border-radius:10px; font-size:11px; background:rgba(255,152,0,0.1); color:var(--highlight-text);">${category}</span>
+                </div>
             `;
-            card.addEventListener('click', () => showToolDetail(toolName));
+
+            //卡片点击 → 进入工具
+            card.addEventListener('click', (e) => {
+                if (e.target.classList.contains('fav-star')) return;
+                showToolDetail(toolName);
+            });
+
+            // 星星点击 → 切换收藏
+            const star = card.querySelector('.fav-star');
+            star.addEventListener('click', (e) => {
+                e.stopPropagation();
+                let favs = [];
+                try { favs = JSON.parse(localStorage.getItem('vcpht_favorites') || '[]'); } catch(err) { favs = []; }
+
+                const idx = favs.indexOf(toolName);
+                if (idx >= 0) {
+                    favs.splice(idx, 1);
+                    star.textContent = '☆';
+                    star.style.filter = 'grayscale(1) opacity(0.3)';
+                } else {
+                    favs.push(toolName);
+                    star.textContent = '★';
+                    star.style.filter = 'none';
+                }
+                localStorage.setItem('vcpht_favorites', JSON.stringify(favs));// 如果当前在收藏筛选模式，重新过滤
+                if (categorySelect.value === '__favorites__') {
+                    filterCards();
+                }
+            });
+
+            // 星星hover效果
+            star.addEventListener('mouseenter', () => {
+                if (star.style.filter.includes('grayscale')) {
+                    star.style.filter = 'grayscale(0) opacity(0.7)';
+                }
+            });
+            star.addEventListener('mouseleave', () => {
+                const currentFavs = JSON.parse(localStorage.getItem('vcpht_favorites') || '[]');
+                if (!currentFavs.includes(toolName)) {
+                    star.style.filter = 'grayscale(1) opacity(0.3)';
+                }
+            });
+
             toolGrid.appendChild(card);
         }
+
+        // 搜索与筛选逻辑
+        function filterCards() {
+            const query = searchInput.value.toLowerCase().trim();
+            const selectedCat = categorySelect.value;
+            const cards = toolGrid.querySelectorAll('.tool-card');
+            let visibleCount = 0;
+
+            // 收藏模式需要实时读取
+            let currentFavs = [];
+            if (selectedCat === '__favorites__') {
+                try { currentFavs = JSON.parse(localStorage.getItem('vcpht_favorites') || '[]'); } catch(e) { currentFavs = []; }
+            }
+
+            cards.forEach(card => {
+                const matchSearch = !query || card.dataset.search.includes(query);
+                let matchCat;
+                if (selectedCat === '__favorites__') {
+                    matchCat = currentFavs.includes(card.dataset.toolName);
+                } else {
+                    matchCat = !selectedCat || card.dataset.category === selectedCat;
+                }
+
+                if (matchSearch && matchCat) {
+                    card.style.display = '';visibleCount++;
+                } else {
+                    card.style.display = 'none';
+                }
+            });
+
+            countBadge.textContent = query || selectedCat
+                ? `匹配 ${visibleCount} / ${totalTools}`
+                : `共 ${totalTools} 个`;
+        }
+
+        searchInput.addEventListener('input', filterCards);
+        categorySelect.addEventListener('change', filterCards);
     }
 
     function showToolDetail(toolName) {
+        // 保存当前表单状态
+        if (currentToolName) {
+            saveFormState(currentToolName);
+        }
+        currentToolName = toolName;
+
         const tool = tools[toolName];
         toolTitle.textContent = tool.displayName;
         toolDescription.textContent = tool.description;
@@ -102,6 +300,44 @@ document.addEventListener('DOMContentLoaded', async () => {
         toolGrid.style.display = 'none';
         toolDetailView.style.display = 'block';
         resultContainer.innerHTML = '';
+        renderHistory();
+    }
+
+    // --- 表单状态缓存 ---
+    function saveFormState(toolName) {
+        if (!toolForm) return;
+        const state = {};
+        const inputs = toolForm.querySelectorAll('input, textarea, select');
+        inputs.forEach(el => {
+            if (!el.name) return;
+            //跳过dragdrop类型和文件输入
+            if (el.closest('.dragdrop-image-container')) return;
+            if (el.type === 'file') return;
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                state[el.name + (el.type === 'radio' ? '_' + el.value : '')] = el.checked;
+            } else {
+                state[el.name] = el.value;
+            }
+        });
+        formStateCache.set(toolName, state);
+    }
+
+    function restoreFormState(toolName) {
+        const state = formStateCache.get(toolName);
+        if (!state) return;
+        const inputs = toolForm.querySelectorAll('input, textarea, select');
+        inputs.forEach(el => {
+            if (!el.name) return;
+            if (el.closest('.dragdrop-image-container')) return;
+            if (el.type === 'checkbox') {
+                if (state[el.name] !== undefined) el.checked = state[el.name];
+            } else if (el.type === 'radio') {
+                const key = el.name + '_' + el.value;
+                if (state[key] !== undefined) el.checked = state[key];
+            } else {
+                if (state[el.name] !== undefined) el.value = state[el.name];
+            }
+        });
     }
 
     function buildToolForm(toolName) {
@@ -113,7 +349,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (tool.commands) {
             const commandSelectGroup = document.createElement('div');
             commandSelectGroup.className = 'form-group';
-            commandSelectGroup.innerHTML = `<label for="command-select">选择操作 (Command):</label>`;
+            commandSelectGroup.innerHTML = `<label>选择操作 (Command):</label>`;
             const commandSelect = document.createElement('select');
             commandSelect.id = 'command-select';
             commandSelect.name = 'command';
@@ -126,17 +362,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             commandSelectGroup.appendChild(commandSelect);
             toolForm.appendChild(commandSelectGroup);
-            
             toolForm.appendChild(paramsContainer);
 
             commandSelect.addEventListener('change', (e) => {
                 renderFormParams(tool.commands[e.target.value].params, paramsContainer, toolName, e.target.value);
-            });
-            renderFormParams(tool.commands[commandSelect.value].params, paramsContainer, toolName, commandSelect.value);
-
-        } else {
-            toolForm.appendChild(paramsContainer);
-            renderFormParams(tool.params, paramsContainer, toolName);
+            });renderFormParams(tool.commands[commandSelect.value].params, paramsContainer, toolName, commandSelect.value);} else {
+            toolForm.appendChild(paramsContainer);renderFormParams(tool.params, paramsContainer, toolName);
         }
 
         // 添加按钮容器
@@ -154,8 +385,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             border-radius: 5px;
             cursor: pointer;
             font-size: 16px;
-            transition: background-color 0.2s;
-        `;
+            transition: background-color 0.2s;`;
         buttonContainer.appendChild(submitButton);
         
         // 添加全部清空按钮
@@ -179,7 +409,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         
         buttonContainer.appendChild(clearAllButton);
 
-        // 为 ComfyUI 工具添加设置按钮
+        // 为ComfyUI 工具添加设置按钮
         if (toolName === 'ComfyUIGen') {
             const settingsButton = document.createElement('button');
             settingsButton.type = 'button';
@@ -219,145 +449,63 @@ document.addEventListener('DOMContentLoaded', async () => {
             e.preventDefault();
             executeTool(toolName);
         };
+
+        // 恢复缓存的表单状态
+        setTimeout(() => restoreFormState(toolName), 0);
     }
 
     function renderFormParams(params, container, toolName = '', commandName = '') {
         container.innerHTML = '';
         const dependencyListeners = [];
 
-        // 检查是否为 NanoBananaGen 的 compose 命令
         const isNanoBananaCompose = toolName === 'NanoBananaGen' && commandName === 'compose';
-        let imageUrlCounter = 1; // 用于动态图片输入框的计数器
 
+        // 分离必填和可选参数
+        const requiredParams = [];
+        const optionalParams = [];
         params.forEach(param => {
-            const paramGroup = document.createElement('div');
-            paramGroup.className = 'form-group';
-            
-            let labelText = param.description || param.name;
-            const label = document.createElement('label');
-            label.textContent = `${labelText}${param.required ? ' *' : ''}`;
-            
-            let input;
-            if (param.type === 'textarea') {
-                input = document.createElement('textarea');
-            } else if (param.type === 'select') {
-                input = document.createElement('select');
-                param.options.forEach(opt => {
-                    const option = document.createElement('option');
-                    option.value = opt;
-                    option.textContent = opt || `(${param.name})`;
-                    input.appendChild(option);
-                });
-            } else if (param.type === 'radio') {
-                input = document.createElement('div');
-                input.className = 'radio-group';
-                param.options.forEach(opt => {
-                    const radioLabel = document.createElement('label');
-                    const radioInput = document.createElement('input');
-                    radioInput.type = 'radio';
-                    radioInput.name = param.name;
-                    radioInput.value = opt;
-                    if (opt === param.default) radioInput.checked = true;
-                    
-                    radioLabel.appendChild(radioInput);
-                    radioLabel.append(` ${opt}`);
-                    input.appendChild(radioLabel);
-
-                    // Add listener for dependency changes
-                    radioInput.addEventListener('change', () => {
-                        dependencyListeners.forEach(listener => listener());
-                    });
-                });
-            } else if (param.type === 'dragdrop_image') {
-                // 创建拖拽上传图片输入框
-                input = canvasHandler.createDragDropImageInput(param);
-
-            } else if (param.type === 'checkbox') {
-                input = document.createElement('div');
-                input.className = 'checkbox-group';
-                
-                const checkboxLabel = document.createElement('label');
-                checkboxLabel.className = 'checkbox-label';
-                checkboxLabel.style.cssText = `
-                    display: flex;
-                    align-items: center;
-                    gap: 8px;
-                    cursor: pointer;
-                    margin-top: 5px;
-                `;
-                
-                const checkbox = document.createElement('input');
-                checkbox.type = 'checkbox';
-                checkbox.name = param.name;
-                checkbox.checked = param.default || false;
-                
-                const checkboxText = document.createElement('span');
-                checkboxText.textContent = param.description || param.name;
-                
-                checkboxLabel.appendChild(checkbox);
-                checkboxLabel.appendChild(checkboxText);
-                input.appendChild(checkboxLabel);
-                
-                // 添加翻译相关的UI元素
-                if (param.name === 'enable_translation') {
-                    const translationContainer = createTranslationContainer(param.name);
-                    input.appendChild(translationContainer);
-                    
-                    // 监听 checkbox 状态变化
-                    checkbox.addEventListener('change', (e) => {
-                        const container = input.querySelector('.translation-container');
-                        if (container) {
-                            container.style.display = e.target.checked ? 'block' : 'none';
-                        }
-                    });
-                }
+            if (param.name === 'maid') return; // 隐藏maid字段
+            if (param.required) {
+                requiredParams.push(param);
             } else {
-                input = document.createElement('input');
-                input.type = param.type || 'text';
-                
-                // 为数字类型添加属性支持
-                if (input.type === 'number') {
-                    if (param.min !== undefined) input.min = param.min;
-                    if (param.max !== undefined) input.max = param.max;
-                    // 默认步长为 any，允许输入小数，除非另有指定
-                    input.step = param.step || 'any';
-                }
-            }
-            
-            if (input.tagName !== 'DIV' || param.type === 'dragdrop_image') {
-                input.name = param.name;
-                if (param.type !== 'dragdrop_image') {
-                    input.placeholder = param.placeholder || '';
-                    if (param.default) input.value = param.default;
-                }
-                if (param.required) input.required = true;
-            } else {
-                // For radio group, we need a hidden input to carry the name for FormData
-                const hiddenInput = document.createElement('input');
-                hiddenInput.type = 'hidden';
-                hiddenInput.name = param.name;
-                paramGroup.appendChild(hiddenInput);
-            }
-
-            paramGroup.appendChild(label);
-            paramGroup.appendChild(input);
-            container.appendChild(paramGroup);
-
-            // Handle conditional visibility
-            if (param.dependsOn) {
-                const dependencyCheck = () => {
-                    const dependencyField = toolForm.querySelector(`[name="${param.dependsOn.field}"]:checked`) || toolForm.querySelector(`[name="${param.dependsOn.field}"]`);
-                    if (dependencyField && dependencyField.value === param.dependsOn.value) {
-                        paramGroup.style.display = '';
-                    } else {
-                        paramGroup.style.display = 'none';
-                    }
-                };
-                dependencyListeners.push(dependencyCheck);
+                optionalParams.push(param);
             }
         });
 
-        // 如果是 NanoBanana compose 模式，添加动态图片管理区域
+        //渲染必填参数
+        requiredParams.forEach(param => {
+            const el = createParamElement(param, dependencyListeners, toolName);
+            container.appendChild(el);
+        });
+
+        // 渲染可选参数（折叠）
+        if (optionalParams.length > 0) {
+            const details = document.createElement('details');
+            details.className = 'optional-params-group';
+            details.style.cssText = `
+                margin-top: 10px; border: 1px solid var(--border-color);
+                border-radius: 8px; overflow: hidden;
+            `;
+            const summary = document.createElement('summary');
+            summary.style.cssText = `
+                padding: 10px 14px; cursor: pointer;
+                background: rgba(255,255,255,0.03);
+                color: var(--secondary-text); font-size: 14px;
+                user-select: none;
+            `;
+            summary.textContent = `高级选项 (${optionalParams.length} 项)`;
+            details.appendChild(summary);
+
+            const optContainer = document.createElement('div');
+            optContainer.style.cssText = 'padding: 10px 14px;';
+            optionalParams.forEach(param => {
+                const el = createParamElement(param, dependencyListeners, toolName);
+                optContainer.appendChild(el);
+            });
+            details.appendChild(optContainer);
+            container.appendChild(details);
+        }
+
         if (isNanoBananaCompose) {
             dynamicImageHandler.createDynamicImageContainer(container);
         }
@@ -365,7 +513,119 @@ document.addEventListener('DOMContentLoaded', async () => {
         dependencyListeners.forEach(listener => listener());
     }
 
-    // 创建翻译容器
+    //提取的单参数渲染函数
+    function createParamElement(param, dependencyListeners, toolName) {
+        const paramGroup = document.createElement('div');
+        paramGroup.className = 'form-group';
+        
+        let labelText = param.description || param.name;
+        const label = document.createElement('label');
+        label.textContent = `${labelText}${param.required ? ' *' : ''}`;
+        
+        let input;
+        if (param.type === 'textarea') {
+            input = document.createElement('textarea');
+        } else if (param.type === 'select') {
+            input = document.createElement('select');param.options.forEach(opt => {
+                const option = document.createElement('option');
+                option.value = opt;
+                option.textContent = opt || `(${param.name})`;
+                input.appendChild(option);
+            });
+        } else if (param.type === 'radio') {
+            input = document.createElement('div');
+            input.className = 'radio-group';
+            param.options.forEach(opt => {
+                const radioLabel = document.createElement('label');
+                const radioInput = document.createElement('input');
+                radioInput.type = 'radio';
+                radioInput.name = param.name;
+                radioInput.value = opt;
+                if (opt === param.default) radioInput.checked = true;
+                radioLabel.appendChild(radioInput);
+                radioLabel.append(` ${opt}`);
+                input.appendChild(radioLabel);
+
+                radioInput.addEventListener('change', () => {
+                    dependencyListeners.forEach(listener => listener());
+                });
+            });
+        } else if (param.type === 'dragdrop_image') {
+            input = canvasHandler.createDragDropImageInput(param);
+        } else if (param.type === 'checkbox') {
+            input = document.createElement('div');
+            input.className = 'checkbox-group';
+            
+            const checkboxLabel = document.createElement('label');
+            checkboxLabel.className = 'checkbox-label';
+            checkboxLabel.style.cssText = `
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                cursor: pointer;margin-top: 5px;
+            `;
+            
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.name = param.name;
+            checkbox.checked = param.default || false;
+            
+            const checkboxText = document.createElement('span');
+            checkboxText.textContent = param.description || param.name;
+            
+            checkboxLabel.appendChild(checkbox);
+            checkboxLabel.appendChild(checkboxText);
+            input.appendChild(checkboxLabel);
+            
+            if (param.name === 'enable_translation') {
+                const translationContainer = createTranslationContainer(param.name);
+                input.appendChild(translationContainer);
+                
+                checkbox.addEventListener('change', (e) => {
+                    const container = input.querySelector('.translation-container');
+                    if (container) {
+                        container.style.display = e.target.checked ? 'block' : 'none';
+                    }
+                });
+            }
+        } else {
+            input = document.createElement('input');
+            input.type = param.type || 'text';
+            if (input.type === 'number') {
+                if (param.min !== undefined) input.min = param.min;
+                if (param.max !== undefined) input.max = param.max;
+                input.step = param.step || 'any';
+            }}
+        
+        if (input.tagName !== 'DIV' || param.type === 'dragdrop_image') {
+            input.name = param.name;
+            if (param.type !== 'dragdrop_image') {
+                input.placeholder = param.placeholder || '';
+                if (param.default) input.value = param.default;
+            }
+            if (param.required) input.required = true;
+        } else {
+            const hiddenInput = document.createElement('input');
+            hiddenInput.type = 'hidden';
+            hiddenInput.name = param.name;
+            paramGroup.appendChild(hiddenInput);}
+
+        paramGroup.appendChild(label);
+        paramGroup.appendChild(input);
+
+        if (param.dependsOn) {
+            const dependencyCheck = () => {
+                const dependencyField = toolForm.querySelector(`[name="${param.dependsOn.field}"]:checked`) || toolForm.querySelector(`[name="${param.dependsOn.field}"]`);
+                if (dependencyField && dependencyField.value === param.dependsOn.value) {
+                    paramGroup.style.display = '';
+                } else {
+                    paramGroup.style.display = 'none';
+                }
+            };
+            dependencyListeners.push(dependencyCheck);}
+
+        return paramGroup;
+    }
     function createTranslationContainer(paramName) {
         const container = document.createElement('div');
         container.className = 'translation-container';
@@ -378,7 +638,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             background: rgba(59, 130, 246, 0.05);
         `;
         
-        // 翻译设置区域
         const settingsArea = document.createElement('div');
         settingsArea.style.cssText = `
             display: flex;
@@ -399,9 +658,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         const qualitySelect = document.createElement('select');
         qualitySelect.className = 'translation-quality-select';
         qualitySelect.innerHTML = `
-            <option value="gemini-2.5-flash-lite-preview-06-17">快速</option>
-            <option value="gemini-2.5-flash" selected>均衡</option>
-            <option value="gemini-2.5-pro">质量</option>
+            <option value="gemini-2.5-flash">快速</option>
+            <option value="gemini-2.0-flash" selected>均衡</option>
+            <option value="gpt-4o">质量</option>
         `;
         qualitySelect.style.cssText = `
             padding: 6px 12px;
@@ -455,7 +714,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const translatedPromptArea = document.createElement('textarea');
         translatedPromptArea.className = 'translated-prompt';
         translatedPromptArea.placeholder = '翻译结果将显示在这里…';
-        translatedPromptArea.readOnly = false; // 允许用户编辑
+        translatedPromptArea.readOnly = false;
         translatedPromptArea.style.cssText = `
             width: 100%;
             min-height: 80px;
@@ -486,8 +745,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             padding: 8px 16px;
             border-radius: 4px;
             cursor: pointer;
-            font-size: 14px;
-        `;
+            font-size: 14px;`;
         
         const useOriginalButton = document.createElement('button');
         useOriginalButton.type = 'button';
@@ -502,7 +760,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             font-size: 14px;
         `;
         
-        // 翻译功能
         translateButton.addEventListener('click', async () => {
             const promptTextarea = toolForm.querySelector('textarea[name="prompt"]');
             if (promptTextarea && promptTextarea.value.trim()) {
@@ -514,7 +771,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         });
         
-        // 使用原文
         useOriginalButton.addEventListener('click', () => {
             const promptTextarea = toolForm.querySelector('textarea[name="prompt"]');
             if (promptTextarea) {
@@ -540,7 +796,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         button.disabled = true;
         
         try {
-            // 获取目标语言名称
             const languageMap = {
                 'en': '英语',
                 'zh': '中文', 
@@ -552,8 +807,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             };
             
             const targetLanguageText = languageMap[targetLang] || '英语';
-            
-            // 构建系统提示词（与 VCPChat 翻译模块保持一致）
             const systemPrompt = `你是一个专业的翻译助手。请将用户提供的文本翻译成${targetLanguageText}。 仅返回翻译结果，不要包含任何解释或额外信息。`;
             
             const messages = [
@@ -561,7 +814,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 { role: 'user', content: text }
             ];
             
-            // 使用 VCP 的 chat 接口进行翻译
             const chatUrl = VCP_SERVER_URL.replace('/v1/human/tool', '/v1/chat/completions');
             const response = await fetch(chatUrl, {
                 method: 'POST',
@@ -603,40 +855,31 @@ document.addEventListener('DOMContentLoaded', async () => {
     // 全部清空功能
     function clearAllFormData(toolName) {
         const confirmed = confirm('确定要清空所有内容吗？包括提示词、翻译内容、图片和额外图片。');
-        
         if (!confirmed) return;
         
-        // 1. 清空所有输入框
         const inputs = toolForm.querySelectorAll('input, textarea, select');
         inputs.forEach(input => {
             if (input.type === 'checkbox' || input.type === 'radio') {
                 input.checked = input.defaultChecked || false;
             } else if (input.tagName === 'SELECT') {
-                input.selectedIndex = 0; // 重置为默认选项
+                input.selectedIndex = 0;
             } else {
                 input.value = '';
             }
         });
         
-        // 2. 清空翻译容器
         const translationContainers = toolForm.querySelectorAll('.translation-container');
         translationContainers.forEach(container => {
             const translatedPrompt = container.querySelector('.translated-prompt');
-            if (translatedPrompt) {
-                translatedPrompt.value = '';
-            }
-            // 隐藏翻译容器
+            if (translatedPrompt) translatedPrompt.value = '';
             container.style.display = 'none';
         });
         
-        // 3. 清空图片预览区域
         const previewAreas = toolForm.querySelectorAll('.image-preview-area');
         previewAreas.forEach(preview => {
-            preview.style.display = 'none';
-            preview.innerHTML = '';
+            preview.style.display = 'none';preview.innerHTML = '';
         });
         
-        // 4. 显示所有拖拽区域，隐藏清空按钮
         const dropZones = toolForm.querySelectorAll('.drop-zone');
         const clearButtons = toolForm.querySelectorAll('.clear-image-btn');
         
@@ -644,62 +887,43 @@ document.addEventListener('DOMContentLoaded', async () => {
             dropZone.style.display = 'block';
             dropZone.innerHTML = `
                 <div class="drop-icon">📁</div>
-                <div class="drop-text">拖拽图片文件到此处或点击选择</div>
-            `;
-            dropZone.style.color = 'var(--secondary-text)';
+                <p>拖拽图片文件到此处或点击选择</p>
+            `;dropZone.style.color = 'var(--secondary-text)';
         });
         
-        clearButtons.forEach(btn => {
-            btn.style.display = 'none';
-        });
+        clearButtons.forEach(btn => { btn.style.display = 'none'; });
         
-        // 5. 清空动态图片区域（仅限 NanoBananaGen compose 模式）
         if (toolName === 'NanoBananaGen') {
             const dynamicContainer = toolForm.querySelector('.dynamic-images-container');
             if (dynamicContainer) {
                 const imagesList = dynamicContainer.querySelector('.sortable-images-list');
                 if (imagesList) {
-                    // 清空所有动态添加的图片
                     const dynamicItems = imagesList.querySelectorAll('.dynamic-image-item');
-                    dynamicItems.forEach(item => {
-                        item.remove();
-                    });
-                }
-            }
+                    dynamicItems.forEach(item => { item.remove(); });
+                }}
         }
         
-        // 6. 清空结果容器
-        if (resultContainer) {
-            resultContainer.innerHTML = '';
-        }
+        if (resultContainer) resultContainer.innerHTML = '';
         
-        // 7. 显示成功提示
+        // 清除该工具的缓存
+        formStateCache.delete(toolName);
         const successMessage = document.createElement('div');
         successMessage.className = 'success-notification';
         successMessage.style.cssText = `
-            position: fixed;
-            top: 20px;
-            right: 20px;
-            background: var(--success-color);
-            color: white;
-            padding: 12px 20px;
-            border-radius: 6px;
-            z-index: 1000;
-            font-size: 14px;
-            font-weight: 500;
+            position: fixed; top: 20px; right: 20px;
+            background: var(--success-color); color: white;
+            padding: 12px 20px; border-radius: 6px;
+            z-index: 1000; font-size: 14px; font-weight: 500;
             box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
         `;
         successMessage.textContent = '✓ 已清空所有内容';
         document.body.appendChild(successMessage);
         
-        // 3秒后移除提示
         setTimeout(() => {
             if (successMessage.parentNode) {
                 successMessage.classList.add('removing');
                 setTimeout(() => {
-                    if (successMessage.parentNode) {
-                        successMessage.parentNode.removeChild(successMessage);
-                    }
+                    if (successMessage.parentNode) successMessage.parentNode.removeChild(successMessage);
                 }, 300);
             }
         }, 2700);
@@ -709,71 +933,28 @@ document.addEventListener('DOMContentLoaded', async () => {
     function showFilenameSettings() {
         const overlay = document.createElement('div');
         overlay.style.cssText = `
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.5);
-            z-index: 10000;
-            display: flex;
-            justify-content: center;
-            align-items: center;
+            position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+            background: rgba(0, 0, 0, 0.5); z-index: 10000;
+            display: flex; justify-content: center; align-items: center;
         `;
         
         const dialog = document.createElement('div');
         dialog.style.cssText = `
-            background: var(--card-bg);
-            border-radius: 8px;
-            padding: 30px;
-            width: 90%;
-            width: 90%;
-            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+            background: var(--card-bg); border-radius: 8px; padding: 30px;
+            width: 90%; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
             border: 1px solid var(--border-color);
         `;
         
         dialog.innerHTML = `
-            <h3 style="margin: 0 0 20px 0; color: var(--primary-text); text-align: center;">文件名显示设置</h3>
-            <div style="margin-bottom: 20px;">
-                <label style="display: block; margin-bottom: 8px; color: var(--secondary-text); font-weight: bold;">
-                    文件名最大长度（超过则省略）：
-                </label>
-                <input type="number" id="filename-length-input" 
-                    value="${MAX_FILENAME_LENGTH}" 
-                    min="50" 
-                    max="1000" 
-                    style="
-                        width: 100%;
-                        padding: 10px;
-                        border: 1px solid var(--border-color);
-                        border-radius: 4px;
-                        background: var(--input-bg);
-                        color: var(--primary-text);
-                        font-size: 14px;
-                        box-sizing: border-box;
-                    "
-                >
-                <div style="font-size: 12px; color: var(--secondary-text); margin-top: 5px;">
-                    建议范围：50-1000 字符，默认为 400
-                </div>
+            <h3>文件名显示设置</h3>
+            <div style="margin: 15px 0;">
+                <label>文件名最大长度（超过则省略）：</label>
+                <input type="number" id="filename-length-input" value="${MAX_FILENAME_LENGTH}" min="50" max="1000" style="width: 100%; padding: 8px; margin-top: 5px; background: var(--input-bg); color: var(--primary-text); border: 1px solid var(--border-color); border-radius: 4px;">
             </div>
-            <div style="display: flex; gap: 10px; justify-content: flex-end;">
-                <button id="cancel-btn" style="
-                    background: var(--secondary-color, #6b7280);
-                    color: white;
-                    border: none;
-                    padding: 10px 20px;
-                    border-radius: 4px;
-                    cursor: pointer;
-                ">取消</button>
-                <button id="save-btn" style="
-                    background: var(--primary-color);
-                    color: white;
-                    border: none;
-                    padding: 10px 20px;
-                    border-radius: 4px;
-                    cursor: pointer;
-                ">保存</button>
+            <p style="font-size: 12px; color: var(--secondary-text);">建议范围：50-1000 字符，默认为 400</p>
+            <div style="display: flex; gap: 10px; justify-content: flex-end; margin-top: 20px;">
+                <button id="cancel-btn" style="padding: 8px 16px; background: var(--secondary-color, #6b7280); color: white; border: none; border-radius: 4px; cursor: pointer;">取消</button>
+                <button id="save-btn" style="padding: 8px 16px; background: var(--success-color); color: white; border: none; border-radius: 4px; cursor: pointer;">保存</button>
             </div>
         `;
         
@@ -781,43 +962,25 @@ document.addEventListener('DOMContentLoaded', async () => {
         const cancelBtn = dialog.querySelector('#cancel-btn');
         const saveBtn = dialog.querySelector('#save-btn');
         
-        cancelBtn.addEventListener('click', () => {
-            document.body.removeChild(overlay);
-        });
+        cancelBtn.addEventListener('click', () => { document.body.removeChild(overlay); });
         
         saveBtn.addEventListener('click', async () => {
             const newLength = parseInt(input.value, 10);
             if (newLength >= 50 && newLength <= 1000) {
                 MAX_FILENAME_LENGTH = newLength;
                 settings.maxFilenameLength = newLength;
-                
                 try {
                     await saveSettings();
-                    
-                    // 显示成功提示
                     const successMsg = document.createElement('div');
                     successMsg.className = 'success-notification';
                     successMsg.style.cssText = `
-                        position: fixed;
-                        top: 20px;
-                        right: 20px;
-                        background: var(--success-color);
-                        color: white;
-                        padding: 12px 20px;
-                        border-radius: 6px;
-                        z-index: 10001;
-                        font-size: 14px;
-                        font-weight: 500;
-                    `;
+                        position: fixed; top: 20px; right: 20px;
+                        background: var(--success-color); color: white;
+                        padding: 12px 20px; border-radius: 6px;
+                        z-index: 10001; font-size: 14px; font-weight: 500;`;
                     successMsg.textContent = '✓ 设置已保存';
                     document.body.appendChild(successMsg);
-                    
-                    setTimeout(() => {
-                        if (successMsg.parentNode) {
-                            successMsg.parentNode.removeChild(successMsg);
-                        }
-                    }, 2000);
-                    
+                    setTimeout(() => { if (successMsg.parentNode) successMsg.parentNode.removeChild(successMsg); }, 2000);
                     document.body.removeChild(overlay);
                 } catch (saveError) {
                     console.error('[VCPHumanToolBox] Failed to save settings:', saveError);
@@ -829,13 +992,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
         
         overlay.appendChild(dialog);
-        document.body.appendChild(overlay);
-        
-        // 点击背景关闭
-        overlay.addEventListener('click', (e) => {
-            if (e.target === overlay) {
-                document.body.removeChild(overlay);
-            }
+        document.body.appendChild(overlay);overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) document.body.removeChild(overlay);
         });
     }
 
@@ -844,11 +1002,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const args = {};
         let finalToolName = toolName;
 
-        const tool = tools[toolName];
-        // The finalToolName is always the toolName. The 'command' is an argument.
-
         for (let [key, value] of formData.entries()) {
-            // Handle checkbox
             const inputElement = toolForm.querySelector(`[name="${key}"]`);
             if (inputElement && inputElement.type === 'checkbox') {
                 args[key] = inputElement.checked;
@@ -857,7 +1011,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         }
 
-        resultContainer.innerHTML = '<div class="loader"></div>';
+        // 防御性注入 maid
+        args.maid = USER_NAME;
+        // 计时器
+        const startTime = Date.now();
+        let timerInterval;
+        resultContainer.innerHTML = '<div class="loader"></div><p class="loading" id="loading-timer">⏱ 执行中...</p>';
+        const timerEl = document.getElementById('loading-timer');
+        timerInterval = setInterval(() => {
+            const elapsed = Math.floor((Date.now() - startTime) / 1000);
+            if (timerEl) timerEl.textContent = `⏱ 已等待 ${elapsed}s...`;
+        }, 1000);
 
         try {
             const result = await window.electronAPI.invoke('vcp-ht-execute-tool-proxy', {
@@ -868,48 +1032,109 @@ document.addEventListener('DOMContentLoaded', async () => {
                 args: args
             });
 
+            clearInterval(timerInterval);
+            const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+
+            // 记录执行历史
+            executionHistory.unshift({
+                toolName: finalToolName,
+                displayName: tools[finalToolName]?.displayName || finalToolName,
+                command: args.command || '',
+                time: new Date().toLocaleTimeString(),
+                success: result.success,
+                duration: duration
+            });
+            if (executionHistory.length > 15) executionHistory.pop();
+
             if (result.success) {
-                renderResult(result.data, toolName);
+                renderResult(result.data, toolName, duration);
             } else {
-                renderResult({ status: 'error', error: result.error }, toolName);
+                renderResult({ status: 'error', error: result.error }, toolName, duration);
             }
         } catch (error) {
-            renderResult({ status: 'error', error: error.message }, toolName);
+            clearInterval(timerInterval);
+            const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+            executionHistory.unshift({
+                toolName: finalToolName,
+                displayName: tools[finalToolName]?.displayName || finalToolName,
+                command: args.command || '',
+                time: new Date().toLocaleTimeString(),
+                success: false,
+                duration: duration
+            });
+            if (executionHistory.length > 15) executionHistory.pop();
+            renderResult({ status: 'error', error: error.message }, toolName, duration);
         }
+
+        renderHistory();
+        // 持久化执行历史到settings
+        settings.vcpht_executionHistory = executionHistory.slice(0, 15);
+        saveSettings().catch(e => console.warn('History save failed:', e));
     }
 
-    function renderResult(data, toolName) {
+    function renderResult(data, toolName, duration = '') {
         resultContainer.innerHTML = '';
-    
-        // 1. Handle errors first
+
+        //耗时标签
+        if (duration) {
+            const durationTag = document.createElement('div');
+            durationTag.style.cssText = `
+                display: inline-block; padding: 4px 10px; border-radius: 12px;
+                font-size: 11px; margin-bottom: 10px;
+                background: ${data.status === 'error' || data.error ? 'rgba(239,68,68,0.15)' : 'rgba(16,185,129,0.15)'};
+                color: ${data.status === 'error' || data.error ? 'var(--danger-color)' : 'var(--success-color)'};`;
+            durationTag.textContent = `${data.status === 'error' || data.error ? '❌' : '✅'} 耗时 ${duration}s`;
+            resultContainer.appendChild(durationTag);
+        }
+        
+        // 错误处理
         if (data.status === 'error' || data.error) {
             const errorMessage = data.error || data.message || '未知错误';
             const pre = document.createElement('pre');
             pre.className = 'error';
             pre.textContent = typeof errorMessage === 'object' ? JSON.stringify(errorMessage, null, 2) : errorMessage;
             resultContainer.appendChild(pre);
-            return; // Exit on error, no images to process
+
+            // 重试按钮
+            const retryBtn = document.createElement('button');
+            retryBtn.type = 'button';
+            retryBtn.innerHTML = '🔄 重试';
+            retryBtn.style.cssText = `
+                margin-top: 10px; padding: 8px 16px; border-radius: 5px;
+                border: 1px solid var(--danger-color); background: transparent;
+                color: var(--danger-color); cursor: pointer; font-size: 14px;
+                transition: all 0.2s;
+            `;
+            retryBtn.addEventListener('click', () => executeTool(toolName));
+            retryBtn.addEventListener('mouseenter', () => {
+                retryBtn.style.background = 'var(--danger-color)';
+                retryBtn.style.color = 'white';
+            });
+            retryBtn.addEventListener('mouseleave', () => {
+                retryBtn.style.background = 'transparent';
+                retryBtn.style.color = 'var(--danger-color)';
+            });
+            resultContainer.appendChild(retryBtn);
+            return;
         }
-    
-        // 2. Extract the core content, handling nested JSON from certain tools
+        
+        // 提取核心内容
         let content = data.result || data.message || data;
         if (content && typeof content.content === 'string') {
             try {
                 const parsedContent = JSON.parse(content.content);
-                // Prioritize 'original_plugin_output' as it often contains the final, formatted result.
                 content = parsedContent.original_plugin_output || parsedContent;
             } catch (e) {
-                // If it's not a valid JSON string, just use the string from 'content' property.
                 content = content.content;
             }
         }
-    
-        // 3. Render content based on its type
+        
+        // 渲染内容
         if (content == null) {
             const p = document.createElement('p');
             p.textContent = '插件执行完毕，但没有返回明确内容。';
             resultContainer.appendChild(p);
-        } else if (content && Array.isArray(content.content)) { // Multi-modal content (e.g., from GPT-4V)
+        } else if (content && Array.isArray(content.content)) {
             content.content.forEach(item => {
                 if (item.type === 'text') {
                     const pre = document.createElement('pre');
@@ -921,17 +1146,15 @@ document.addEventListener('DOMContentLoaded', async () => {
                     resultContainer.appendChild(imgElement);
                 }
             });
-        } else if (typeof content === 'string' && (content.startsWith('data:image') || /\.(jpg|jpeg|png|gif|webp)$/i.test(content))) { // Direct image URL string
+        } else if (typeof content === 'string' && (content.startsWith('data:image') || /\.(jpg|jpeg|png|gif|webp)$/i.test(content))) {
             const imgElement = document.createElement('img');
             imgElement.src = content;
             resultContainer.appendChild(imgElement);
-        } else if (typeof content === 'string') { // Markdown/HTML string
+        } else if (typeof content === 'string') {
             const div = document.createElement('div');
-            // Use marked to render markdown, which will also render raw HTML like <img> tags
             if (window.marked && typeof window.marked.parse === 'function') {
                 div.innerHTML = window.marked.parse(content);
             } else {
-                console.error("'marked' library not loaded. Displaying content as plain text.");
                 div.textContent = content;
             }
             resultContainer.appendChild(div);
@@ -939,7 +1162,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             const searchResultsWrapper = document.createElement('div');
             searchResultsWrapper.className = 'tavily-search-results';
 
-            // Render images
             if (content.images && content.images.length > 0) {
                 const imagesContainer = document.createElement('div');
                 imagesContainer.className = 'tavily-images-container';
@@ -957,34 +1179,28 @@ document.addEventListener('DOMContentLoaded', async () => {
                 searchResultsWrapper.appendChild(imagesContainer);
             }
 
-            // Render search results
             if (content.results && content.results.length > 0) {
                 const resultsContainer = document.createElement('div');
                 resultsContainer.className = 'tavily-results-container';
                 content.results.forEach(result => {
                     const resultItem = document.createElement('div');
                     resultItem.className = 'tavily-result-item';
-
                     const title = document.createElement('h4');
                     const link = document.createElement('a');
                     link.href = result.url;
                     link.textContent = result.title;
-                    link.target = '_blank'; // Open in new tab
+                    link.target = '_blank';
                     title.appendChild(link);
-
                     const url = document.createElement('p');
                     url.className = 'tavily-result-url';
                     url.textContent = result.url;
-
                     const snippet = document.createElement('div');
                     snippet.className = 'tavily-result-snippet';
                     if (window.marked && typeof window.marked.parse === 'function') {
                         snippet.innerHTML = window.marked.parse(result.content);
                     } else {
-                        console.error("'marked' library not loaded. Displaying content as plain text.");
                         snippet.textContent = result.content;
                     }
-
                     resultItem.appendChild(title);
                     resultItem.appendChild(url);
                     resultItem.appendChild(snippet);
@@ -994,36 +1210,80 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
 
             resultContainer.appendChild(searchResultsWrapper);
-        } else if (typeof content === 'object') { // Generic object
-            // Check for common image/text properties within the object
+        } else if (typeof content === 'object') {
             const imageUrl = content.image_url || content.url || content.image;
             const textResult = content.result || content.message || content.original_plugin_output || content.content;
-    
+            
             if (typeof imageUrl === 'string') {
                 const imgElement = document.createElement('img');
                 imgElement.src = imageUrl;
                 resultContainer.appendChild(imgElement);
             } else if (typeof textResult === 'string') {
                 if (window.marked && typeof window.marked.parse === 'function') {
-                    resultContainer.innerHTML = window.marked.parse(textResult);
+                    resultContainer.innerHTML += window.marked.parse(textResult);
                 } else {
-                    console.error("'marked' library not loaded. Displaying content as plain text.");
                     resultContainer.textContent = textResult;
                 }
             } else {
-                // Fallback for other objects: pretty-print the JSON
                 const pre = document.createElement('pre');
                 pre.textContent = JSON.stringify(content, null, 2);
                 resultContainer.appendChild(pre);
             }
-        } else { // Fallback for any other data type
+        } else {
             const pre = document.createElement('pre');
             pre.textContent = `插件返回了未知类型的数据: ${String(content)}`;
             resultContainer.appendChild(pre);
         }
-    
-        // 4. Finally, ensure all rendered images (newly created or from HTML) have the context menu
-        // attachEventListenersToImages(resultContainer);
+
+        // 复制按钮（仅文本结果）
+        const textContent = resultContainer.innerText.trim();
+        if (textContent && textContent.length > 10) {
+            const copyBtn = document.createElement('button');
+            copyBtn.type = 'button';
+            copyBtn.innerHTML = '📋 复制结果';
+            copyBtn.style.cssText = `
+                margin-top: 12px; padding: 6px 14px; border-radius: 5px;
+                border: 1px solid var(--border-color); background: transparent;
+                color: var(--secondary-text); cursor: pointer; font-size: 12px;
+                transition: all 0.2s;
+            `;
+            copyBtn.addEventListener('click', async () => {
+                try {
+                    await navigator.clipboard.writeText(textContent);
+                    copyBtn.innerHTML = '✅ 已复制';
+                    setTimeout(() => { copyBtn.innerHTML = '📋 复制结果'; }, 2000);
+                } catch (e) {
+                    copyBtn.innerHTML = '❌ 复制失败';
+                    setTimeout(() => { copyBtn.innerHTML = '📋 复制结果'; }, 2000);
+                }
+            });
+            resultContainer.appendChild(copyBtn);
+        }
+    }
+
+    // --- 执行历史 ---
+    function renderHistory() {
+        const historyContainer = document.getElementById('execution-history');
+        if (!historyContainer) return;
+        if (executionHistory.length === 0) {
+            historyContainer.innerHTML = '';
+            return;
+        }
+
+        historyContainer.innerHTML = `
+            <div style="margin-top: 20px; padding-top: 15px; border-top: 1px solid var(--border-color);">
+                <h4 style="margin: 0 0 10px; color: var(--secondary-text); font-size: 13px;">📜 执行历史 (最近${executionHistory.length}条)</h4>
+                ${executionHistory.map(h => `
+                    <div style="display: flex; align-items: center; gap: 8px; padding: 6px 0; font-size: 12px; color: var(--placeholder-text); border-bottom: 1px solid rgba(255,255,255,0.03);">
+                        <span>${h.success ? '✅' : '❌'}</span>
+                        <span style="color: var(--secondary-text); font-weight: 500;">${h.displayName}</span>
+                        ${h.command ? `<span style="color: var(--placeholder-text);">→ ${h.command}</span>` : ''}
+                        <span style="margin-left: auto; color: var(--placeholder-text);">${h.duration}s</span>
+                        <span style="color: var(--placeholder-text);">${h.time}</span>
+                    </div>
+                `).join('')}
+            </div>
+        `;
     }
 
     // --- Image Viewer Modal ---
@@ -1046,8 +1306,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             align-items: center;
         `;
         viewer.innerHTML = `
-            <span style="position: absolute; top: 15px; right: 35px; color: #f1f1f1; font-size: 40px; font-weight: bold; cursor: pointer;">&times;</span>
-            <img style="margin: auto; display: block; max-width: 90%; max-height: 90%;">
+            <span style="position:absolute;top:15px;right:35px;color:#f1f1f1;font-size:40px;font-weight:bold;cursor:pointer;">&times;</span>
+            <img style="margin:auto;display:block;max-width:90%;max-height:90%;">
         `;
         document.body.appendChild(viewer);
 
@@ -1067,25 +1327,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         function handleEscKeyModal(e) {
-            if (e.key === 'Escape') {
-                closeModal();
-            }
+            if (e.key === 'Escape') closeModal();
         }
 
         closeBtn.onclick = closeModal;
         viewer.onclick = function(e) {
-            if (e.target === viewer) {
-                closeModal();
-            }
+            if (e.target === viewer) closeModal();
         };
 
         resultContainer.addEventListener('click', (e) => {
             let target = e.target;
-            // Handle case where user clicks an IMG inside an A tag
             if (target.tagName === 'IMG' && target.parentElement.tagName === 'A') {
                 target = target.parentElement;
             }
-
             if (target.tagName === 'A' && target.href && (target.href.match(/\.(jpeg|jpg|gif|png|webp)$/i) || target.href.startsWith('data:image'))) {
                 e.preventDefault();
                 openModal(target.href);
@@ -1109,8 +1363,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 try {
                     const processedImageBase64 = await window.electronAPI.invoke('vcp-ht-process-wallpaper', imagePath);
                     if (processedImageBase64) {
-                        document.body.style.backgroundImage = `url('${processedImageBase64}')`;
-                    }
+                        document.body.style.backgroundImage = `url('${processedImageBase64}')`;}
                 } catch (error) {
                     console.error('Wallpaper processing failed:', error);
                 }
@@ -1119,9 +1372,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function initializeUI() {
-        // Window controls
         document.getElementById('minimize-btn').addEventListener('click', () => {
-            window.electronAPI.send('window-control', 'minimize');
+            window.electronAPI.send('window-control','minimize');
         });
         document.getElementById('maximize-btn').addEventListener('click', () => {
             window.electronAPI.send('window-control', 'maximize');
@@ -1130,20 +1382,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             window.electronAPI.send('window-control', 'close');
         });
 
-        // Theme toggle
         const themeToggleBtn = document.getElementById('theme-toggle-btn');
         
         function applyTheme(theme) {
             if (theme === 'light') {
                 document.body.classList.add('light-theme');
-                themeToggleBtn.textContent = '☀️';
-            } else {
+                themeToggleBtn.textContent = '☀️';} else {
                 document.body.classList.remove('light-theme');
                 themeToggleBtn.textContent = '🌙';
             }
         }
 
-        // Apply initial theme from settings
         applyTheme(settings.vcpht_theme);
 
         themeToggleBtn.addEventListener('click', async () => {
@@ -1159,18 +1408,18 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         });
 
-        // App controls
         backToGridBtn.addEventListener('click', () => {
+            if (currentToolName) {
+                saveFormState(currentToolName);
+            }
             toolDetailView.style.display = 'none';
             toolGrid.style.display = 'grid';
         });
 
-        // 工作流编排按钮
         const workflowBtn = document.getElementById('workflow-btn');
         if (workflowBtn) {
             workflowBtn.addEventListener('click', openWorkflowEditor);
         }
-        
         renderToolGrid();
         loadAndProcessWallpaper();
         setupImageViewer();
@@ -1190,10 +1439,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const drawer = document.createElement('div');
         drawer.className = 'drawer-panel';
         drawer.innerHTML = `
-            <div class="drawer-content" id="comfyui-drawer-content">
-                <div style="text-align: center; padding: 50px; color: var(--secondary-text);">
+            <div id="comfyui-drawer-content">
+                <p style="text-align: center; color: var(--secondary-text);">
                     正在加载 ComfyUI 配置...
-                </div>
+                </p>
             </div>
         `;
 
@@ -1236,9 +1485,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const drawerContent = document.getElementById('comfyui-drawer-content');
                 if (drawerContent) {
                     drawerContent.innerHTML = `
-                        <div style="text-align: center; padding: 50px; color: var(--danger-color);">
+                        <p style="color: var(--danger-color); text-align: center;">
                             加载 ComfyUI 配置失败: ${error.message}
-                        </div>
+                        </p>
                     `;
                 }
             }
@@ -1257,15 +1506,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function handleEscKey(e) {
-        if (e.key === 'Escape') {
-            closeComfyUISettings();
-        }
+        if (e.key === 'Escape') closeComfyUISettings();
     }
 
     async function loadComfyUIModules() {
         const loaderScript = document.createElement('script');
         loaderScript.src = 'ComfyUImodules/ComfyUILoader.js';
-        
         return new Promise((resolve, reject) => {
             loaderScript.onload = resolve;
             loaderScript.onerror = () => reject(new Error('无法加载 ComfyUILoader.js'));
@@ -1318,7 +1564,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
-    // 将函数暴露到全局作用域，以便按钮点击时调用
     window.openComfyUISettings = openComfyUISettings;
     window.closeComfyUISettings = closeComfyUISettings;
     window.openWorkflowEditor = openWorkflowEditor;

--- a/VCPHumanToolBox/renderer_modules/config.js
+++ b/VCPHumanToolBox/renderer_modules/config.js
@@ -1,11 +1,17 @@
 // renderer_modules/config.js
+// VCPHumanToolBox工具定义
+// 最后更新: 2026-04-21by CodeCC &赵枫
+// 备份: config.js.bak.20260421
+// 工具总数: 45 (原39+ 新增6)
 
-// --- 工具定义 (基于 supertool.txt) ---
+// --- 工具定义 ---
 export const tools = {
+    // ========================================
     // 多媒体生成类
+    // ========================================
     'ZImageGen': {
-        displayName: '通义 Qwen 生图',
-        description: '国产生图开源模型，性能不错，支持NSFW。',
+        displayName: '通义Qwen 生图',
+        description: '国产生图开源模型，性能不错，支持NSFW。[后端插件: ZImageGen]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'prompt', type: 'textarea', required: true, placeholder: '(必需) 用于图片生成的详细提示词。' },
@@ -15,8 +21,8 @@ export const tools = {
         ]
     },
     'FluxGen': {
-        displayName: 'Flux 图片生成',
-        description: '艺术风格多变，仅支持英文提示词。',
+        displayName:'Flux 图片生成',
+        description: '艺术风格多变，仅支持英文提示词。[后端插件: FluxGen]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'prompt', type: 'textarea', required: true, placeholder: '详细的英文提示词' },
@@ -25,14 +31,14 @@ export const tools = {
     },
     'DoubaoGen': {
         displayName: '豆包 AI 图片',
-        description: '集成豆包模型的图片生成与编辑功能。',
+        description: '集成豆包模型的图片生成与编辑功能。[后端插件: DoubaoGen]',
         commands: {
             'DoubaoGenerateImage': {
                 description: '豆包生图',
                 params: [
                     { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
                     { name: 'prompt', type: 'textarea', required: true, placeholder: '(必需) 用于图片生成的详细提示词。' },
-                    { name: 'resolution', type: 'text', required: true, placeholder: '(必需) 图片分辨率，格式为“宽x高”。理论上支持2048以内内任意分辨率组合。', default: '1024x1024' }
+                    { name: 'resolution', type: 'text', required: true, placeholder: '(必需) 图片分辨率，格式为"宽x高"。理论上支持2048以内任意分辨率组合。', default: '1024x1024' }
                 ]
             },
             'DoubaoEditImage': {
@@ -41,7 +47,7 @@ export const tools = {
                     { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
                     { name: 'prompt', type: 'textarea', required: true, placeholder: '(必需) 用于指导图片修改的详细提示词。' },
                     { name: 'image', type: 'dragdrop_image', required: true, placeholder: '(必需) 来源图片URL或file://本地路径' },
-                    { name: 'resolution', type: 'text', required: true, placeholder: '(必需) 2K, 4K 或 宽x高', default: '2K' },
+                    { name: 'resolution', type: 'text', required: true, placeholder: '(必需) 2K, 4K 或宽x高', default: '2K' },
                     { name: 'guidance_scale', type: 'number', required: false, placeholder: '范围0-10，值越小越相似。' }
                 ]
             },
@@ -61,7 +67,7 @@ export const tools = {
     },
     'QwenImageGen': {
         displayName: '千问图片生成',
-        description: '国产新星，文字排版能力不输豆包哦。',
+        description: '国产新星，文字排版能力不输豆包哦。[后端插件: QwenImageGen]',
         commands: {
             'GenerateImage': {
                 description: '生成图片',
@@ -74,9 +80,70 @@ export const tools = {
             }
         }
     },
+    'GeminiImageGen': {
+        displayName:'Gemini 图像生成',
+        description: '使用 Google Gemini 模型进行图像生成和编辑，支持英文提示词。[后端插件: GeminiImageGen]',
+        commands: {
+            'generate': {
+                description: '生成全新图片',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'prompt', type: 'textarea', required: true, placeholder: '详细的英文提示词，描述想生成的图片内容、风格和细节' }
+                ]
+            },
+            'edit': {
+                description: '编辑现有图片',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'prompt', type: 'textarea', required: true, placeholder: '英文编辑指令，如: Add a llama next to the person' },
+                    { name: 'image_url', type: 'dragdrop_image', required: true, placeholder: '要编辑的图片（支持拖拽、URL、file://路径）' }
+                ]
+            }
+        }
+    },
+    'NovelAIGen': {
+        displayName: 'NovelAI 动漫生图',
+        description: 'NovelAI Diffusion 4.5 Full模型，专精高质量动漫风格。需NovelAI订阅。[后端插件: NovelAIGen]',
+        commands: {
+            'NovelAIGenerateImage': {
+                description: '生成动漫风格图片',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'prompt', type: 'textarea', required: true, placeholder: '详细英文提示词，动漫风格' },
+                    { name: 'resolution', type: 'select', required: true, options: ['832x1216', '1216x832', '1024x1024', '1024x1536', '1536x1024', '512x768', '768x512', '640x640', '1472x1472', '1088x1920', '1920x1088'], description: '分辨率（NORMAL推荐832x1216）' }
+                ]
+            }
+        }
+    },
+    'ComfyCloudGen': {
+        displayName: 'Comfy Cloud 云端生图',
+        description: '通过云端GPU生成图像/视频，895+模型，支持LoRA。三种模式：auto/template/raw。超时3分钟。[后端插件: ComfyCloudGen]',
+        commands: {
+            'GenerateImage': {
+                description: '云端生成图像或视频',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'prompt', type: 'textarea', required: true, placeholder: '英文正面提示词（auto/template模式必需）' },
+                    { name: 'negative_prompt', type: 'textarea', required: false, placeholder: '英文负面提示词' },
+                    { name: 'unet', type: 'text', required: false, placeholder: 'UNet模型名，如z_image_bf16.safetensors（触发auto模式）' },
+                    { name: 'checkpoint', type: 'text', required: false, placeholder: 'Checkpoint模型名（触发auto模式）' },
+                    { name: 'lora', type: 'text', required: false, placeholder: 'LoRA文件名' },
+                    { name: 'lora_strength', type: 'number', required: false, placeholder: 'LoRA强度，默认0.8' },
+                    { name: 'width', type: 'number', required: false, placeholder: '宽度，默认1024' },
+                    { name: 'height', type: 'number', required: false, placeholder: '高度，默认1024' },
+                    { name: 'steps', type: 'number', required: false, placeholder: '采样步数' },
+                    { name: 'cfg', type: 'number', required: false, placeholder: 'CFG引导强度' },
+                    { name: 'seed', type: 'number', required: false, placeholder: '随机种子，-1为随机' },
+                    { name: 'workflow', type: 'text', required: false, placeholder: '模板名称（触发template模式）' },
+                    { name: 'load_cached', type: 'text', required: false, placeholder: '从缓存加载工作流' },
+                    { name: 'save_as', type: 'text', required: false, placeholder: '保存工作流到缓存' }
+                ]
+            }
+        }
+    },
     'SunoGen': {
         displayName: 'Suno 音乐生成',
-        description: '强大的Suno音乐生成器。',
+        description: '强大的Suno音乐生成器。[后端插件: SunoGen]',
         commands: {
             'generate_song': {
                 description: '生成歌曲或纯音乐',
@@ -92,8 +159,8 @@ export const tools = {
         }
     },
     'WanVideoGen': {
-        displayName: 'Wan 视频生成',
-        description: '基于强大的Wan系列模型生成视频。',
+        displayName:'Wan视频生成',
+        description: '基于强大的Wan系列模型生成视频。[后端插件: VideoGenerator]',
         commands: {
             'submit': {
                 description: '提交新视频任务',
@@ -116,7 +183,7 @@ export const tools = {
     },
     'GrokVideoGen': {
         displayName: 'Grok 视频生成',
-        description: '马斯克家的图生视频大模型，超快且含配音。',
+        description: '马斯克家的图生视频大模型，超快且含配音。[后端插件: GrokVideo]',
         commands: {
             'submit': {
                 description: '提交视频任务',
@@ -139,7 +206,7 @@ export const tools = {
     },
     'WebUIGen': {
         displayName: '喵喵 WebUI',
-        description: '每一路模型独立部署，支持多种艺术风格。',
+        description: '每一路模型独立部署，支持多种艺术风格。[后端插件: WebUIGen]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'prompt', type: 'textarea', required: true, placeholder: '生成提示词' },
@@ -151,276 +218,21 @@ export const tools = {
             { name: 'showbase64', type: 'checkbox', required: false, default: false }
         ]
     },
-    // 工具类
-    'SciCalculator': {
-        displayName: '科学计算器',
-        description: '支持基础运算、函数、统计和微积分。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'expression', type: 'textarea', required: true, placeholder: "例如: integral('x**2', 0, 1)" }
-        ]
-    },
-    // 联网类
-    'VSearch': {
-        displayName: 'V-Search 穿透检索',
-        description: 'VCP家语义级穿透联网检索引擎，支持并发检索。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'SearchTopic', type: 'text', required: true, placeholder: '研究主题' },
-            { name: 'Keywords', type: 'textarea', required: true, placeholder: '多检索词，用逗号隔开' },
-            { name: 'SearchMode', type: 'select', required: false, options: ['grounding', 'grok', 'tavily'], default: 'grounding' },
-            { name: 'ShowURL', type: 'checkbox', required: false, default: false }
-        ]
-    },
-    'TavilySearch': {
-        displayName: 'Tavily 联网搜索',
-        description: '专业的联网搜索API。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'query', type: 'text', required: true, placeholder: '搜索的关键词 or 问题' },
-            { name: 'topic', type: 'text', required: false, placeholder: "general, news, finance..." },
-            { name: 'max_results', type: 'number', required: false, placeholder: '10 (范围 5-100)' },
-            { name: 'include_raw_content', type: 'select', required: false, options: ['', 'text', 'markdown'] },
-            { name: 'start_date', type: 'text', required: false, placeholder: 'YYYY-MM-DD' },
-            { name: 'end_date', type: 'text', required: false, placeholder: 'YYYY-MM-DD' }
-        ]
-    },
-    'GoogleSearch': {
-        displayName: 'Google 搜索',
-        description: '进行一次标准的谷歌网页搜索。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'query', type: 'text', required: true, placeholder: '如何学习编程？' }
-        ]
-    },
-    'SerpSearch': {
-        displayName: 'SerpAPI 搜索',
-        description: '使用DuckDuckGo搜索引擎进行网页搜索。',
-        commands: {
-            'duckduckgo_search': {
-                description: 'DuckDuckGo 搜索',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'q', type: 'text', required: true, placeholder: '需要搜索的关键词' },
-                    { name: 'kl', type: 'text', required: false, placeholder: 'us-en' }
-                ]
-            },
-            'google_reverse_image_search': {
-                description: '谷歌以图搜图',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'image_url', type: 'dragdrop_image', required: true, placeholder: '本地或远程图片链接' }
-                ]
-            }
-        }
-    },
-    'UrlFetch': {
-        displayName: '网页超级爬虫',
-        description: '获取网页的文本内容或快照。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'url', type: 'text', required: true, placeholder: 'https://example.com' },
-            { name: 'mode', type: 'select', required: false, options: ['text', 'snapshot'] }
-        ]
-    },
-    'BilibiliFetch': {
-        displayName: 'B站内容获取',
-        description: '获取B站视频文本、弹幕、评论及快照。',
-        commands: {
-            'fetch': {
-                description: '获取视频内容',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'url', type: 'text', required: true, placeholder: 'Bilibili 视频的 URL' },
-                    { name: 'lang', type: 'text', required: false, placeholder: 'ai-zh' },
-                    { name: 'danmaku_num', type: 'number', required: false, default: 0 },
-                    { name: 'comment_num', type: 'number', required: false, default: 0 },
-                    { name: 'snapshots', type: 'text', required: false, placeholder: '10,60,120' },
-                    { name: 'hd_snapshot', type: 'checkbox', required: false, default: false },
-                    { name: 'need_subs', type: 'checkbox', required: false, default: true }
-                ]
-            },
-            'search': {
-                description: '搜索视频/用户',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'keyword', type: 'text', required: true },
-                    { name: 'search_type', type: 'select', options: ['video', 'bili_user'], default: 'video' },
-                    { name: 'page', type: 'number', default: 1 }
-                ]
-            },
-            'get_up_videos': {
-                description: '获取UP主视频列表',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'mid', type: 'text', required: true },
-                    { name: 'pn', type: 'number', default: 1 },
-                    { name: 'ps', type: 'number', default: 30 }
-                ]
-            }
-        }
-    },
-    'FlashDeepSearch': {
-        displayName: '深度信息研究',
-        description: '进行深度主题搜索，返回研究论文。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'SearchContent', type: 'textarea', required: true, placeholder: '希望研究的主题内容' },
-            { name: 'SearchBroadness', type: 'number', required: false, placeholder: '7 (范围 5-20)' }
-        ]
-    },
-    'AnimeFinder': {
-        displayName: '番剧名称查找',
-        description: '通过图片找原始番剧名字工具。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'imageUrl', type: 'dragdrop_image', required: true, placeholder: '可以是任意类型url比如http或者file' }
-        ]
-    },
-    'MusicController': {
-        displayName: '莱恩家的点歌台',
-        description: '播放音乐。',
-        commands: {
-            'playSong': {
-                description: '播放歌曲',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'songname', type: 'text', required: true, placeholder: '星の余韻' }
-                ]
-            }
-        }
-    },
-    // VCP通讯插件
-    'AgentAssistant': {
-        displayName: '女仆通讯器',
-        description: '用于联络别的女仆Agent。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'agent_name', type: 'text', required: true, placeholder: '小娜, 小克, Nova...' },
-            { name: 'prompt', type: 'textarea', required: true, placeholder: '我是[您的名字]，我想请你...' },
-            { name: 'temporary_contact', type: 'checkbox', required: false, default: false }
-        ]
-    },
-    'AgentDream': {
-        displayName: '梦境触发器',
-        description: '让一位Agent入眠，然后做一场美梦。',
-        commands: {
-            'triggerDream': {
-                description: '触发梦境',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'agent_name', type: 'text', required: true, placeholder: 'Nova' }
-                ]
-            }
-        }
-    },
-    'AgentMessage': {
-        displayName: '主人通讯器',
-        description: '向莱恩主人的设备发送通知消息。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'message', type: 'textarea', required: true, placeholder: '要发送的消息内容' }
-        ]
-    },
-    'VCPForum': {
-        displayName: 'VCP 论坛',
-        description: '在 VCP 论坛上进行发帖、回帖和读帖。',
-        commands: {
-            'CreatePost': {
-                description: '创建新帖子',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'board', type: 'text', required: true, placeholder: '板块名称，不存在则会自动创建' },
-                    { name: 'title', type: 'text', required: true, placeholder: '[置顶] 规范流程' },
-                    { name: 'content', type: 'textarea', required: true, placeholder: '帖子正文，支持 Markdown' }
-                ]
-            },
-            'ReplyPost': {
-                description: '回复帖子',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'post_uid', type: 'text', required: true, placeholder: '要回复的帖子 UID' },
-                    { name: 'content', type: 'textarea', required: true, placeholder: '回复内容，支持 Markdown' }
-                ]
-            },
-            'ReadPost': {
-                description: '读取帖子内容',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'post_uid', type: 'text', required: true, placeholder: '要读取的帖子 UID' }
-                ]
-            }
-        }
-    },
-    'DeepMemo': {
-        displayName: '深度回忆',
-        description: '回忆过去的聊天历史。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'keyword', type: 'text', required: true, placeholder: '多个关键词用空格或逗号分隔' },
-            { name: 'window_size', type: 'number', required: false, placeholder: '10 (范围 1-20)' }
-        ]
-    },
-    'LightMemo': {
-        displayName: '快速回忆',
-        description: '主动检索日记本或者知识库。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: 'Nova' },
-            { name: 'folder', type: 'text', required: false, placeholder: '特定的索引文件夹' },
-            { name: 'query', type: 'textarea', required: true, placeholder: '记忆检索内容' },
-            { name: 'k', type: 'number', required: false, default: 5 },
-            { name: 'rerank', type: 'text', required: false, placeholder: 'true / false / 0.6 (RRF融合)' },
-            { name: 'tag_boost', type: 'text', required: false, placeholder: '0.6 或 0.6+ (浪潮V8)' },
-            { name: 'search_all_knowledge_bases', type: 'checkbox', required: false, default: true }
-        ]
-    },
-    // 物联网插件
-    'TableLampRemote': {
-        displayName: '桌面台灯控制器',
-        description: '控制智能台灯的状态。',
-        commands: {
-            'GetLampStatus': {
-                description: '获取台灯当前信息',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' }
-                ]
-            },
-            'LampControl': {
-                description: '控制台灯',
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'power', type: 'select', options: ['', 'True', 'False'], description: '电源' },
-                    { name: 'brightness', type: 'number', min: 1, max: 100, placeholder: '1-100', description: '亮度' },
-                    { name: 'color_temperature', type: 'number', min: 2500, max: 4800, placeholder: '2500-4800', description: '色温' }
-                ]
-            }
-        }
-    },
-    'VCPAlarm': {
-        displayName: 'Vchat 闹钟',
-        description: '设置一个闹钟。',
-        params: [
-            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'time_description', type: 'text', required: true, placeholder: '1分钟后' }
-        ]
-    },
-    // ComfyUI 图像生成
     'ComfyUIGen': {
         displayName: 'ComfyUI 生成',
-        description: '使用本地 ComfyUI 后端进行图像生成',
+        description: '使用本地 ComfyUI 后端进行图像生成。[后端插件: ComfyUIGen]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'prompt', type: 'textarea', required: true, placeholder: '图像生成的正面提示词，描述想要生成的图像内容、风格、细节等' },
-            { name: 'negative_prompt', type: 'textarea', required: false, placeholder: '额外的负面提示词，将与用户配置的负面提示词合并' },
+            { name: 'prompt', type: 'textarea', required: true, placeholder: '图像生成的正面提示词' },
+            { name: 'negative_prompt', type: 'textarea', required: false, placeholder: '额外的负面提示词' },
             { name: 'workflow', type: 'text', required: false, placeholder: '例如: text2img_basic, text2img_advanced' },
             { name: 'width', type: 'number', required: false, placeholder: '默认使用用户配置的值' },
             { name: 'height', type: 'number', required: false, placeholder: '默认使用用户配置的值' }
         ]
     },
-    // NanoBanana 图像生成
     'NanoBananaGen2': {
         displayName: 'NanoBanana 图像编辑 (V2)',
-        description: '地球最强的图像编辑AI，2025年11月更新2代。支持中英文。',
+        description: '地球最强的图像编辑AI，支持中英文。[后端插件: NanoBananaGen2]',
         commands: {
             'generate': {
                 description: '生成图片',
@@ -452,35 +264,602 @@ export const tools = {
             }
         }
     },
-    // VCP思考自进化插件
-    'ThoughtClusterManager': {
-        displayName: '思维簇管理器',
-        description: '创建和编辑思维簇文件。',
+
+    // ========================================
+    // 工具类
+    // ========================================
+    'SciCalculator': {
+        displayName: '科学计算器',
+        description: '支持基础运算、函数、统计和微积分。[后端插件: SciCalculator]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'expression', type: 'textarea', required: true, placeholder: "例如: integral('x**2', 0, 1)" }
+        ]
+    },
+
+    // ========================================
+    // 联网搜索类
+    // ========================================
+    'VSearch': {
+        displayName: 'V-Search 穿透检索',
+        description: 'VCP家语义级穿透联网检索引擎，支持并发检索。[后端插件: VSearch]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'SearchTopic', type: 'text', required: true, placeholder: '研究主题' },
+            { name: 'Keywords', type: 'textarea', required: true, placeholder: '多检索词，用逗号隔开' },
+            { name: 'SearchMode', type: 'select', required: false, options: ['grounding', 'grok', 'tavily', 'kimisearch'], default: 'grounding' },
+            { name: 'ShowURL', type: 'checkbox', required: false, default: false }
+        ]
+    },
+    'TavilySearch': {
+        displayName: 'Tavily 联网搜索',
+        description: '专业的联网搜索API。[后端插件: TavilySearch]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'query', type: 'text', required: true, placeholder: '搜索的关键词 or 问题' },
+            { name: 'topic', type: 'text', required: false, placeholder: "general, news, finance..." },
+            { name: 'max_results', type: 'number', required: false, placeholder: '10(范围 5-100)' },
+            { name: 'include_raw_content', type: 'select', required: false, options: ['', 'text', 'markdown'] },
+            { name: 'start_date', type: 'text', required: false, placeholder: 'YYYY-MM-DD' },
+            { name: 'end_date', type: 'text', required: false, placeholder: 'YYYY-MM-DD' }
+        ]
+    },
+    'GoogleSearch': {
+        displayName: 'Google 搜索',
+        description: '进行一次标准的谷歌网页搜索。[后端插件: GoogleSearch]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'query', type: 'text', required: true, placeholder: '如何学习编程？' }
+        ]
+    },
+    'SerpSearch': {
+        displayName: 'SerpAPI 搜索',
+        description: '使用DuckDuckGo搜索引擎进行网页搜索。[后端插件: SerpSearch]',
         commands: {
-            'CreateClusterFile': {
-                description: '创建新的思维簇文件',
+            'duckduckgo_search': {
+                description: 'DuckDuckGo 搜索',
                 params: [
                     { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'clusterName', type: 'text', required: true, placeholder: '目标簇文件夹的名称，必须以\'簇\'结尾' },
-                    { name: 'content', type: 'textarea', required: true, placeholder: '【思考模块：模块名】\n【触发条件】：\n【核心功能】：\n【执行流程】：' }
+                    { name: 'q', type: 'text', required: true, placeholder: '需要搜索的关键词' },
+                    { name: 'kl', type: 'text', required: false, placeholder: 'us-en' }
                 ]
             },
-            'EditClusterFile': {
-                description: '编辑已存在的思维簇文件',
+            'google_reverse_image_search': {
+                description: '谷歌以图搜图',
                 params: [
                     { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'clusterName', type: 'text', required: false, placeholder: '指定在哪个簇文件夹中进行搜索' },
-                    { name: 'targetText', type: 'textarea', required: true, placeholder: '这是需要被替换的旧的思考内容，确保它不少于15字。' },
-                    { name: 'replacementText', type: 'textarea', required: true, placeholder: '这是更新后的新的思考内容。' }
+                    { name: 'image_url', type: 'dragdrop_image', required: true, placeholder: '本地或远程图片链接' }
+                ]
+            }
+        }
+    },
+    'UrlFetch': {
+        displayName: '网页超级爬虫',
+        description: '获取网页的文本内容或快照。[后端插件: UrlFetch]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'url', type: 'text', required: true, placeholder: 'https://example.com' },
+            { name: 'mode', type: 'select', required: false, options: ['text', 'snapshot'] }
+        ]
+    },
+    'BilibiliFetch': {
+        displayName:'B站内容获取',
+        description: '获取B站视频文本、弹幕、评论及快照。[后端插件: BilibiliFetch]',
+        commands: {
+            'fetch': {
+                description: '获取视频内容',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'url', type: 'text', required: true, placeholder: 'Bilibili 视频的URL' },
+                    { name: 'lang', type: 'text', required: false, placeholder: 'ai-zh' },
+                    { name: 'danmaku_num', type: 'number', required: false, default: 0 },
+                    { name: 'comment_num', type: 'number', required: false, default: 0 },
+                    { name: 'snapshots', type: 'text', required: false, placeholder: '10,60,120' },
+                    { name: 'hd_snapshot', type: 'checkbox', required: false, default: false },
+                    { name: 'need_subs', type: 'checkbox', required: false, default: true }
+                ]
+            },
+            'search': {
+                description: '搜索视频/用户',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'keyword', type: 'text', required: true },
+                    { name: 'search_type', type: 'select', options: ['video', 'bili_user'], default: 'video' },
+                    { name: 'page', type: 'number', default: 1 }
+                ]
+            },
+            'get_up_videos': {
+                description: '获取UP主视频列表',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'mid', type: 'text', required: true },
+                    { name: 'pn', type: 'number', default: 1 },
+                    { name: 'ps', type: 'number', default: 30 }
+                ]
+            }
+        }
+    },
+    'FlashDeepSearch': {
+        displayName: '深度信息研究',
+        description: '进行深度主题搜索，返回研究论文。[后端插件: FlashDeepSearch]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'SearchContent', type: 'textarea', required: true, placeholder: '希望研究的主题内容' },
+            { name: 'SearchBroadness', type: 'number', required: false, placeholder: '7(范围 5-20)' }
+        ]
+    },
+    'AnimeFinder': {
+        displayName: '番剧名称查找',
+        description: '通过图片找原始番剧名字工具。[后端插件: AnimeFinder]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'imageUrl', type: 'dragdrop_image', required: true, placeholder: '可以是任意类型url比如http或者file' }
+        ]
+    },
+
+    // ========================================
+    // Git 代码托管平台搜索
+    // ========================================
+    'GitSearch': {
+        displayName: 'Git 代码搜索',
+        description: '聚合 GitHub/GitLab/Gitee 三大代码托管平台的读取操作。[后端插件: GitSearch]',
+        commands: {
+            'repo_get': {
+                description: '获取仓库基本信息',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'platform', type: 'select', required: true, options: ['github', 'gitlab', 'gitee'], description: '平台' },
+                    { name: 'repo_owner', type: 'text', required: true, placeholder: '仓库所有者，如 lioensky' },
+                    { name: 'repo_name', type: 'text', required: true, placeholder: '仓库名称，如 VCPToolBox' }
+                ]
+            },
+            'repo_list_files': {
+                description: '浏览目录或读取文件内容',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'platform', type: 'select', required: true, options: ['github', 'gitlab', 'gitee'], description: '平台' },
+                    { name: 'repo_owner', type: 'text', required: true, placeholder: '仓库所有者' },
+                    { name: 'repo_name', type: 'text', required: true, placeholder: '仓库名称' },
+                    { name: 'path', type: 'text', required: false, placeholder: '文件或目录路径，留空列出根目录' },
+                    { name: 'ref', type: 'text', required: false, placeholder: '分支/tag/SHA，默认主分支' }
+                ]
+            },
+            'repo_search_code': {
+                description: '搜索仓库中的代码（仅GitHub支持）',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'platform', type: 'select', required: true, options: ['github'], description: '平台（仅GitHub）' },
+                    { name: 'repo_owner', type: 'text', required: true, placeholder: '仓库所有者' },
+                    { name: 'repo_name', type: 'text', required: true, placeholder: '仓库名称' },
+                    { name: 'query', type: 'text', required: true, placeholder: '搜索关键词' }
+                ]
+            },
+            'issue_list': {
+                description: '列出仓库的 Issues',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'platform', type: 'select', required: true, options: ['github', 'gitlab', 'gitee'], description: '平台' },
+                    { name: 'repo_owner', type: 'text', required: true, placeholder: '仓库所有者' },
+                    { name: 'repo_name', type: 'text', required: true, placeholder: '仓库名称' },
+                    { name: 'state', type: 'select', required: false, options: ['', 'open', 'closed', 'all'], description: '状态筛选' },
+                    { name: 'per_page', type: 'number', required: false, placeholder: '每页数量，默认30' }
+                ]
+            },
+            'pr_list': {
+                description: '列出 Pull Requests',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'platform', type: 'select', required: true, options: ['github', 'gitlab', 'gitee'], description: '平台' },
+                    { name: 'repo_owner', type: 'text', required: true, placeholder: '仓库所有者' },
+                    { name: 'repo_name', type: 'text', required: true, placeholder: '仓库名称' },
+                    { name: 'state', type: 'select', required: false, options: ['', 'open', 'closed', 'all'], description: '状态筛选' }
+                ]
+            },
+            'pr_get_diff': {
+                description: '获取 PR 的文件变更',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'platform', type: 'select', required: true, options: ['github', 'gitlab', 'gitee'], description: '平台' },
+                    { name: 'repo_owner', type: 'text', required: true, placeholder: '仓库所有者' },
+                    { name: 'repo_name', type: 'text', required: true, placeholder: '仓库名称' },
+                    { name: 'pr_number', type: 'number', required: true, placeholder: 'PR 编号' }
                 ]
             }
         }
     },
 
+    // ========================================
+    // DeepWiki AI仓库文档引擎
+    // ========================================
+    'DeepWikiVCP': {
+        displayName: 'DeepWiki 仓库问答',
+        description: '通过 DeepWiki AI 获取GitHub公开仓库的智能文档和问答。[后端插件: DeepWikiVCP]',
+        commands: {
+            'wiki_structure': {
+                description: '查看仓库的AI文档目录',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'url', type: 'text', required: true, placeholder: 'owner/repo 格式，如 lioensky/VCPToolBox' }
+                ]
+            },
+            'wiki_content': {
+                description: '读取完整AI文档（内容较长，慎用）',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'url', type: 'text', required: true, placeholder: 'owner/repo 格式' }
+                ]
+            },
+            'wiki_ask': {
+                description: '向AI提问关于仓库的问题（最常用）',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'url', type: 'text', required: true, placeholder: 'owner/repo（多仓库逗号分隔，最多10个）' },
+                    { name: 'question', type: 'textarea', required: true, placeholder: '你想问的问题' },
+                    { name: 'deep_research', type: 'checkbox', required: false, default: false, description: '启用深度研究模式' }
+                ]
+            }
+        }
+    },
+
+    // ========================================
+    // 学术研究
+    // ========================================
+    'PubMedSearch': {
+        displayName:'PubMed 文献检索',
+        description: '基于NCBI E-utilities的PubMed学术文献检索，支持关键词/作者/期刊/MeSH搜索、全文获取、引用分析和引用导出。[后端插件: PubMedSearch]',
+        commands: {
+            'search_articles': {
+                description: '综合检索 — 按关键词、作者、期刊搜索',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'query', type: 'textarea', required: true, placeholder: '检索表达式，如: cancer immunotherapy' },
+                    { name: 'max_results', type: 'number', required: false, placeholder: '默认20（1-1000）' },
+                    { name: 'sort', type: 'select', required: false, options: ['', 'relevance', 'pub_date', 'author', 'journal'], description: '排序' },
+                    { name: 'date_from', type: 'text', required: false, placeholder: '起始日期 YYYY/MM/DD' },
+                    { name: 'date_to', type: 'text', required: false, placeholder: '截止日期 YYYY/MM/DD' }
+                ]
+            },
+            'advanced_search': {
+                description: '高级检索 — 标题/摘要/作者/MeSH多字段组合',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'title', type: 'text', required: false, placeholder: '标题关键词' },
+                    { name: 'abstract', type: 'text', required: false, placeholder: '摘要关键词' },
+                    { name: 'author', type: 'text', required: false, placeholder: '作者名' },
+                    { name: 'journal', type: 'text', required: false, placeholder: '期刊名' },
+                    { name: 'mesh_terms', type: 'text', required: false, placeholder: 'MeSH术语，JSON数组格式' },
+                    { name: 'boolean_operator', type: 'select', required: false, options: ['AND', 'OR'], description: '布尔关系' },
+                    { name: 'max_results', type: 'number', required: false, placeholder: '默认20' }
+                ]
+            },
+            'get_trending_articles': {
+                description: '趋势文献 — 获取某领域最近的热门论文',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'field', type: 'text', required: true, placeholder: '研究领域，如: single-cell RNA-seq' },
+                    { name: 'days', type: 'number', required: false, placeholder: '回溯天数，默认30' },
+                    { name: 'max_results', type: 'number', required: false, placeholder: '默认20' }
+                ]
+            },
+            'get_article_details': {
+                description: '文章详情 — 按PMID获取完整元数据',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'pmid', type: 'text', required: true, placeholder: 'PubMed ID，如 37912345' }
+                ]
+            },
+            'get_full_text': {
+                description: '全文获取 — 通过PMC ID获取开放获取全文',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'pmcid', type: 'text', required: true, placeholder: 'PMC ID，如 PMC1234567' }
+                ]
+            },
+            'get_cited_by': {
+                description: '引用分析 — 查看哪些文章引用了该论文',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'pmid', type: 'text', required: true, placeholder: 'PubMed ID' },
+                    { name: 'max_results', type: 'number', required: false, placeholder: '默认100' }
+                ]
+            },
+            'export_citation': {
+                description: '导出引用 — 生成APA/MLA/BibTeX/RIS格式',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'pmid', type: 'text', required: true, placeholder: 'PubMed ID' },
+                    { name: 'format', type: 'select', required: false, options: ['apa', 'mla', 'chicago', 'bibtex', 'ris'], description: '引用格式，默认APA' }
+                ]
+            }
+        }
+    },
+    'PaperReader': {
+        displayName: '论文阅读器',
+        description: '超文本递归阅读器（Rust引擎），支持PDF摄入、多模式阅读、证据检索和审核。超时30分钟。[后端插件: PaperReader]',
+        commands: {
+            'IngestPDF': {
+                description: '摄入论文 — 上传PDF到阅读器',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'filePath', type: 'text', required: true, placeholder: '论文路径，如 D:/papers/example.pdf' },
+                    { name: 'paperId', type: 'text', required: false, placeholder: '自定义论文ID（可选）' }
+                ]
+            },
+            'Read': {
+                description: '自动阅读 — 智能选择阅读模式',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'paperId', type: 'text', required: true, placeholder: '论文ID（摄入时返回）' },
+                    { name: 'goal', type: 'textarea', required: false, placeholder: '阅读目标，如:提取核心方法论' },
+                    { name: 'forceReread', type: 'checkbox', required: false, default: false, description: '强制重读' }
+                ]
+            },
+            'ReadDeep': {
+                description: '深度阅读 — 逐段精读全文',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'paperId', type: 'text', required: true, placeholder: '论文ID' },
+                    { name: 'goal', type: 'textarea', required: false, placeholder: '深度阅读目标' }
+                ]
+            },
+            'Query': {
+                description: '提问 — 基于论文内容回答',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'paperId', type: 'text', required: true, placeholder: '论文ID' },
+                    { name: 'question', type: 'textarea', required: true, placeholder: '你的问题' }
+                ]
+            },
+            'audit_document': {
+                description: '审核 — 生成论文审核报告',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'document_id', type: 'text', required: true, placeholder: '论文ID' }
+                ]
+            }
+        }
+    },
+
+    // ========================================
+    // 塔罗占卜
+    // ========================================
+    'TarotDivination': {
+        displayName: '塔罗占卜',
+        description: '融合天文与神秘学的塔罗牌占卜，支持多种牌阵与起源选择。[后端插件: TarotDivination]',
+        commands: {
+            'draw_single_card': {
+                description: '单牌占卜 — 抽取一张塔罗牌',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'fate_check_number', type: 'number', required: false, placeholder: '命运检定数（任意数字）' },
+                    { name: 'origin', type: 'select', required: false, options: ['', '日', '月', '星'], description: '☉日=行动☽月=情感 ✦星=智慧' }
+                ]
+            },
+            'draw_three_card_spread': {
+                description: '三牌阵 — 过去·现在·未来',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'fate_check_number', type: 'number', required: false, placeholder: '命运检定数' },
+                    { name: 'origin', type: 'select', required: false, options: ['', '日', '月', '星'], description: '起源选择' }
+                ]
+            },
+            'draw_celtic_cross': {
+                description: '凯尔特十字 — 10张牌完整牌阵',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'fate_check_number', type: 'number', required: false, placeholder: '命运检定数' },
+                    { name: 'origin', type: 'select', required: false, options: ['', '日', '月', '星'], description: '起源选择' }
+                ]
+            },
+            'get_celestial_data': {
+                description: '天象数据 — 获取实时天文与环境数据',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'origin', type: 'select', required: false, options: ['', '日', '月', '星'], description: '观察视角' }
+                ]
+            }
+        }
+    },
+
+    // ========================================
+    // 音乐控制
+    // ========================================
+    'MusicController': {
+        displayName: '莱恩家的点歌台',
+        description: '播放音乐。[前端分布式: MusicController]',
+        commands: {
+            'playSong': {
+                description: '播放歌曲',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'songname', type: 'text', required: true, placeholder: '星の余韻' }
+                ]
+            }
+        }
+    },
+
+    // ========================================
+    // VCP通讯插件
+    // ========================================
+    'AgentAssistant': {
+        displayName: '女仆通讯器',
+        description: '用于联络别的女仆Agent。[后端插件: AgentAssistant]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'agent_name', type: 'text', required: true, placeholder: '小娜, 小克, Nova...' },
+            { name: 'prompt', type: 'textarea', required: true, placeholder: '我是[您的名字]，我想请你...' },
+            { name: 'temporary_contact', type: 'checkbox', required: false, default: false }
+        ]
+    },
+    'AgentDream': {
+        displayName: '梦境触发器',
+        description: '让一位Agent入眠做梦。[后端插件: AgentDream]',
+        commands: {
+            'triggerDream': {
+                description: '触发梦境',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'agent_name', type: 'text', required: true, placeholder: 'Nova' }
+                ]
+            }
+        }
+    },
+    'AgentMessage': {
+        displayName: '主人通讯器',
+        description: '向主人设备发送通知消息。[后端插件: AgentMessage]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'message', type: 'textarea', required: true, placeholder: '要发送的消息内容' }
+        ]
+    },
+    'VCPForum': {
+        displayName: 'VCP 论坛',
+        description: '在VCP论坛上发帖、回帖和读帖。[后端插件: VCPForum]',
+        commands: {
+            'CreatePost': {
+                description: '创建新帖子',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'board', type: 'text', required: true, placeholder: '板块名称' },
+                    { name: 'title', type: 'text', required: true, placeholder: '[置顶] 规范流程' },
+                    { name: 'content', type: 'textarea', required: true, placeholder: '帖子正文，支持Markdown' }
+                ]
+            },
+            'ReplyPost': {
+                description: '回复帖子',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'post_uid', type: 'text', required: true, placeholder: '帖子UID' },
+                    { name: 'content', type: 'textarea', required: true, placeholder: '回复内容' }
+                ]
+            },
+            'ReadPost': {
+                description: '读取帖子内容',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'post_uid', type: 'text', required: true, placeholder: '帖子UID' }
+                ]
+            }
+        }
+    },
+
+    // ========================================
+    // 记忆与思考
+    // ========================================
+    'DeepMemo': {
+        displayName: '深度回忆',
+        description: '回忆过去的聊天历史。[内置功能: DeepMemo]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'keyword', type: 'text', required: true, placeholder: '多个关键词用空格或逗号分隔' },
+            { name: 'window_size', type: 'number', required: false, placeholder: '10(范围 1-20)' }
+        ]
+    },
+    'LightMemo': {
+        displayName: '快速回忆',
+        description: '主动检索日记本或知识库。[后端插件: LightMemo]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder:'Nova' },
+            { name: 'folder', type: 'text', required: false, placeholder: '特定的索引文件夹' },
+            { name: 'query', type: 'textarea', required: true, placeholder: '记忆检索内容' },
+            { name: 'k', type: 'number', required: false, default: 5 },
+            { name: 'rerank', type: 'text', required: false, placeholder: 'true / false / 0.6(RRF融合)' },
+            { name: 'tag_boost', type: 'text', required: false, placeholder: '0.6或 0.6+ (浪潮V8)' },
+            { name: 'search_all_knowledge_bases', type: 'checkbox', required: false, default: true }
+        ]
+    },
+    'ThoughtClusterManager': {
+        displayName: '思维簇管理器',
+        description: '创建和编辑思维簇文件。[后端插件: ThoughtClusterManager]',
+        commands: {
+            'CreateClusterFile': {
+                description: '创建新思维簇',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'clusterName', type: 'text', required: true, placeholder: '簇文件夹名称，必须以"簇"结尾' },
+                    { name: 'content', type: 'textarea', required: true, placeholder: '【思考模块：模块名】\n【触发条件】：\n【核心功能】：\n【执行流程】：' }
+                ]
+            },
+            'EditClusterFile': {
+                description: '编辑已存在的思维簇',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'clusterName', type: 'text', required: false, placeholder: '指定簇文件夹' },
+                    { name: 'targetText', type: 'textarea', required: true, placeholder: '需要被替换的旧内容（至少15字）' },
+                    { name: 'replacementText', type: 'textarea', required: true, placeholder: '更新后的新内容' }
+                ]
+            }
+        }
+    },
+    'TopicMemo': {
+        displayName: '话题回忆',
+        description: '回忆具体的聊天话题。[内置功能: TopicMemo]',
+        commands: {
+            'ListTopics': {
+                description: '列出所有话题',
+                params: [{ name: 'maid', type: 'text', required: true, placeholder: '你的名字' }]
+            },
+            'GetTopicContent': {
+                description: '获取话题内容',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'topic_id', type: 'text', required: true }
+                ]
+            }
+        }
+    },
+    'AgentTopicCreator': {
+        displayName: '话题发起人',
+        description: '发起一个全新的聊天话题。',
+        commands: {
+            'CreateTopic': {
+                description: '创建新话题',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'topic_name', type: 'text', required: true },
+                    { name: 'initial_message', type: 'textarea', required: true }
+                ]
+            }
+        }
+    },
+
+    // ========================================
+    // 物联网插件
+    // ========================================
+    'TableLampRemote': {
+        displayName: '桌面台灯控制器',
+        description: '控制智能台灯的状态。[后端插件: TableLampRemote]',
+        commands: {
+            'GetLampStatus': {
+                description: '获取台灯当前信息',
+                params: [{ name: 'maid', type: 'text', required: true, placeholder: '你的名字' }]
+            },
+            'LampControl': {
+                description: '控制台灯',
+                params: [
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'power', type: 'select', options: ['','True', 'False'], description: '电源' },
+                    { name: 'brightness', type: 'number', min: 1, max: 100, placeholder: '1-100', description: '亮度' },
+                    { name: 'color_temperature', type: 'number', min: 2500, max: 4800, placeholder: '2500-4800', description: '色温' }
+                ]
+            }
+        }
+    },
+    'VCPAlarm': {
+        displayName:'Vchat闹钟',
+        description: '设置一个闹钟。[前端分布式: VCPAlarm]',
+        params: [
+            { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+            { name: 'time_description', type: 'text', required: true, placeholder: '1分钟后' }
+        ]
+    },
+
+    // ========================================
     // 文件管理
+    // ========================================
     'LocalSearchController': {
         displayName: '本地文件搜索',
-        description: '基于Everything模块实现本地文件搜索。',
+        description: '基于Everything模块实现本地文件搜索。[前端分布式: VCPEverything]',
         commands: {
             'search': {
                 description: '搜索文件',
@@ -494,7 +873,7 @@ export const tools = {
     },
     'ServerSearchController': {
         displayName: '服务器文件搜索',
-        description: '基于Everything模块实现服务器文件搜索。',
+        description: '基于Everything模块实现服务器文件搜索。[后端插件: VCPEverything]',
         commands: {
             'search': {
                 description: '搜索文件',
@@ -507,8 +886,8 @@ export const tools = {
         }
     },
     'PowerShellExecutor': {
-        displayName: 'PowerShell (前端)',
-        description: '在前端执行PowerShell命令。',
+        displayName:'PowerShell (前端)',
+        description: '在前端执行PowerShell命令。[前端分布式: PowerShellExecutor]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'command', type: 'textarea', required: true, placeholder: 'Get-ChildItem' },
@@ -519,7 +898,7 @@ export const tools = {
     },
     'ServerPowerShellExecutor': {
         displayName: 'PowerShell (后端)',
-        description: '在服务器后端执行PowerShell命令。',
+        description: '在服务器后端执行PowerShell命令。[后端插件: PowerShellExecutor]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'command', type: 'textarea', required: true, placeholder: 'Get-ChildItem' },
@@ -528,8 +907,8 @@ export const tools = {
         ]
     },
     'CodeSearcher': {
-        displayName: '代码检索器 (前端)',
-        description: '在VCP项目前端源码中搜索。',
+        displayName: '代码检索器(前端)',
+        description: '在VCP项目前端源码中搜索。[前端分布式: CodeSearcher]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'query', type: 'text', required: true, placeholder: '关键词或正则表达式' },
@@ -541,7 +920,7 @@ export const tools = {
     },
     'ServerCodeSearcher': {
         displayName: '代码检索器 (后端)',
-        description: '在VCP项目后端源码中搜索。',
+        description: '在VCP项目后端源码中搜索。[后端插件: CodeSearcher]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'query', type: 'text', required: true, placeholder: '关键词或正则表达式' },
@@ -551,11 +930,16 @@ export const tools = {
             { name: 'context_lines', type: 'number', required: false, placeholder: '2' }
         ]
     },
+
+    // ========================================
+    // 日程管理
+    // ========================================
     'ScheduleManager': {
         displayName: '日程管理器',
-        description: '辅助日程管理。',
+        description: '辅助日程管理。[后端插件: ScheduleManager]',
         commands: {
             'AddSchedule': {
+                description: '添加日程',
                 params: [
                     { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
                     { name: 'time', type: 'text', required: true, placeholder: '2025-12-31 10:00' },
@@ -563,40 +947,14 @@ export const tools = {
                 ]
             },
             'ListSchedules': {
+                description: '列出所有日程',
                 params: [{ name: 'maid', type: 'text', required: true, placeholder: '你的名字' }]
             },
             'DeleteSchedule': {
+                description: '删除日程',
                 params: [
                     { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
                     { name: 'id', type: 'text', required: true }
-                ]
-            }
-        }
-    },
-    'TopicMemo': {
-        displayName: '话题回忆',
-        description: '回忆具体的聊天话题。',
-        commands: {
-            'ListTopics': {
-                params: [{ name: 'maid', type: 'text', required: true, placeholder: '你的名字' }]
-            },
-            'GetTopicContent': {
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'topic_id', type: 'text', required: true }
-                ]
-            }
-        }
-    },
-    'AgentTopicCreator': {
-        displayName: '话题发起人',
-        description: '发起一个全新的聊天话题。',
-        commands: {
-            'CreateTopic': {
-                params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'topic_name', type: 'text', required: true },
-                    { name: 'initial_message', type: 'textarea', required: true }
                 ]
             }
         }

--- a/VCPHumanToolBox/style.css
+++ b/VCPHumanToolBox/style.css
@@ -993,4 +993,75 @@ header p {
         opacity: 0;
         transform: translate(-50%, -50%) scale(0.8);
     }
+}/* --- Tool Search & Filter Bar --- */
+.tool-search-bar {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.tool-search-input:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.tool-category-select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.tool-count-badge {
+    animation: fadeIn 0.3s ease;
+}
+
+/* --- Optional Params Folding --- */
+.optional-params-group {
+    transition: all 0.2s ease;
+}
+
+.optional-params-group summary {
+    list-style: none;
+}
+
+.optional-params-group summary::-webkit-details-marker {
+    display: none;
+}
+
+.optional-params-group summary::before {
+    content: '▶ ';
+    display: inline;transition: transform 0.2s;
+}
+
+.optional-params-group[open] summary::before {
+    content: '▼ ';
+}
+
+.optional-params-group[open] {
+    border-color: var(--primary-color);
+}
+
+.optional-params-group summary:hover {
+    background: rgba(59, 130, 246, 0.08);
+}
+
+/* --- Execution History --- */
+#execution-history {
+    animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(5px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* --- Tool Card Category Badge --- */
+.tool-card .category-badge {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    background: rgba(255, 152, 0, 0.1);
+    color: var(--highlight-text);
 }


### PR DESCRIPTION
## 概述

对VCPHumanToolBox（人类工具箱）进行了全面的UX 增强，新增 11 项功能，工具定义从 39 个扩展到 45 个。

## 新增功能

### 工具发现
- 🔍 **搜索框**：实时关键词过滤（匹配工具名/描述/分类）
- 📂 **分类筛选**：10 个分类下拉 + ⭐收藏筛选
- ⭐ **收藏系统**：每个工具卡片可收藏，localStorage 持久化
- 🏷️ **计数徽章**：动态显示"共 N 个"或"匹配 X / N"
- 🏷️ **分类标签**：每个卡片底部显示所属分类

### 表单体验
- 🙈 **隐藏 maid 字段**：main.js 已通过 userName 自动注入，前端无需手动填写
- 📦 **可选参数折叠**：必填参数正常显示，可选参数折叠在「高级选项」中
- 💾 **表单状态缓存**：切换工具再切回，之前填写的内容不丢失

### 执行反馈
- ⏱️ **实时计时器**：执行中显示已等待秒数
- 🔄 **错误重试按钮**：执行失败一键重试
- 📋 **结果复制按钮**：文本结果一键复制到剪贴板
- 📜 **执行历史**：记录最近 15 条调用，跨会话持久化到 settings.json

### 工具定义扩展（39→ 45）
新增 6 个工具：GeminiImageGen、NovelAIGen、ComfyCloudGen、TarotDivination、PaperReader、PubMedSearch

## 改动文件

| 文件 | 说明 |
|------|------|
| `renderer.js` | 核心改动：11 项新功能，重构renderFormParams →提取 createParamElement |
| `renderer_modules/config.js` | 工具定义 39 → 45，全工具加插件归属标注 |
| `index.html` | 新增 1 行 execution-history 容器 |
| `style.css` | 追加 ~ 50 行新样式（搜索框/折叠/历史/分类标签） |

## 技术细节

- **分类映射**：在 renderer.js 中用 `TOOL_CATEGORIES` 常量映射，不修改 config.js 的数据结构
- **maid 防御注入**：executeTool() 中`args.maid = USER_NAME`，与main.js 的无条件注入形成双保险
- **收藏存储**：localStorage key `vcpht_favorites`，JSON数组格式
- **历史存储**：settings.json 的 `vcpht_executionHistory` 字段

## 未改动
main.js · preload.js · canvas-handler.js · dynamic-image-handler.js · themes.css