### PR TITLE
fix: 将maidname预填充用户名，但可以更改，以避免部分插件所需Agent名字错误的情形

### DIFF
--- a/VCPHumanToolBox/renderer.js
+++ b/VCPHumanToolBox/renderer.js
@@ -1,5 +1,5 @@
 // VCPHumanToolBox/renderer.js
-// Enhanced by CodeCC &赵枫 - 2026-04-21
+// Enhanced by infinite-vector - 2026-04-21
 // 8features: search+filter, hide maid, param folding, timer, retry, copy, form cache, history
 import { tools } from './renderer_modules/config.js';
 import * as canvasHandler from './renderer_modules/ui/canvas-handler.js';
@@ -463,14 +463,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         // 分离必填和可选参数
         const requiredParams = [];
         const optionalParams = [];
-        params.forEach(param => {
-            if (param.name === 'maid') return; // 隐藏maid字段
-            if (param.required) {
-                requiredParams.push(param);
-            } else {
-                optionalParams.push(param);
-            }
-        });
+       params.forEach(param => {
+    if (param.name === 'maid') {
+        param.default = param.default || USER_NAME;
+        requiredParams.push(param);
+        return;
+    }
+    if (param.required) {
+        requiredParams.push(param);
+    } else {
+        optionalParams.push(param);
+    }
+});
 
         //渲染必填参数
         requiredParams.forEach(param => {
@@ -1011,8 +1015,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         }
 
-        // 防御性注入 maid
-        args.maid = USER_NAME;
+        if (!args.maid) {
+    args.maid = USER_NAME;
+}
         // 计时器
         const startTime = Date.now();
         let timerInterval;

--- a/VCPHumanToolBox/renderer_modules/config.js
+++ b/VCPHumanToolBox/renderer_modules/config.js
@@ -1,8 +1,7 @@
 // renderer_modules/config.js
 // VCPHumanToolBox工具定义
-// 最后更新: 2026-04-21by CodeCC &赵枫
-// 备份: config.js.bak.20260421
-// 工具总数: 45 (原39+ 新增6)
+// 最后更新: 2026-04-21by infinite-vector
+// 工具总数: 45
 
 // --- 工具定义 ---
 export const tools = {
@@ -665,7 +664,7 @@ export const tools = {
     // 音乐控制
     // ========================================
     'MusicController': {
-        displayName: '莱恩家的点歌台',
+        displayName: 'Nova家的点歌台',
         description: '播放音乐。[前端分布式: MusicController]',
         commands: {
             'playSong': {
@@ -683,30 +682,30 @@ export const tools = {
     // ========================================
     'AgentAssistant': {
         displayName: '女仆通讯器',
-        description: '用于联络别的女仆Agent。[后端插件: AgentAssistant]',
+        description: '用于联络别的女仆Agent。发送者署名（默认当前用户名），接收方会看到此名称。[后端插件: AgentAssistant]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-            { name: 'agent_name', type: 'text', required: true, placeholder: '小娜, 小克, Nova...' },
+            { name: 'agent_name', type: 'text', required: true, placeholder: 'Aemeath, Nova...' },
             { name: 'prompt', type: 'textarea', required: true, placeholder: '我是[您的名字]，我想请你...' },
             { name: 'temporary_contact', type: 'checkbox', required: false, default: false }
         ]
     },
     'AgentDream': {
         displayName: '梦境触发器',
-        description: '让一位Agent入眠做梦。[后端插件: AgentDream]',
+        description: '让一位Agent入眠做梦。推荐填写目标Agent名称，决定为哪个Agent触发梦境。[后端插件: AgentDream]',
         commands: {
             'triggerDream': {
                 description: '触发梦境',
                 params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
-                    { name: 'agent_name', type: 'text', required: true, placeholder: 'Nova' }
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字，汇聚梦泡' },
+                    { name: 'agent_name', type: 'text', required: true, placeholder: 'Nova，被梦泡包裹' }
                 ]
             }
         }
     },
     'AgentMessage': {
         displayName: '主人通讯器',
-        description: '向主人设备发送通知消息。[后端插件: AgentMessage]',
+        description: '向主人设备发送通知消息。默认署名用户，可更改。[后端插件: AgentMessage]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'message', type: 'textarea', required: true, placeholder: '要发送的消息内容' }
@@ -719,7 +718,7 @@ export const tools = {
             'CreatePost': {
                 description: '创建新帖子',
                 params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字：帖子/回复的作者署名（默认当前用户名）' },
                     { name: 'board', type: 'text', required: true, placeholder: '板块名称' },
                     { name: 'title', type: 'text', required: true, placeholder: '[置顶] 规范流程' },
                     { name: 'content', type: 'textarea', required: true, placeholder: '帖子正文，支持Markdown' }
@@ -748,7 +747,7 @@ export const tools = {
     // ========================================
     'DeepMemo': {
         displayName: '深度回忆',
-        description: '回忆过去的聊天历史。[内置功能: DeepMemo]',
+        description: '检索所有会话历史记录。给出目标Agent名称（如 Nova），将决定检索哪位Agent的会话历史记录。[内置功能: DeepMemo]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
             { name: 'keyword', type: 'text', required: true, placeholder: '多个关键词用空格或逗号分隔' },
@@ -757,7 +756,7 @@ export const tools = {
     },
     'LightMemo': {
         displayName: '快速回忆',
-        description: '主动检索日记本或知识库。[后端插件: LightMemo]',
+        description: '快速回忆一下对应Agent的日记本内容。根据Maid的名称，决定搜索哪个记忆库。[后端插件: LightMemo]',
         params: [
             { name: 'maid', type: 'text', required: true, placeholder:'Nova' },
             { name: 'folder', type: 'text', required: false, placeholder: '特定的索引文件夹' },
@@ -793,7 +792,7 @@ export const tools = {
     },
     'TopicMemo': {
         displayName: '话题回忆',
-        description: '回忆具体的聊天话题。[内置功能: TopicMemo]',
+        description: '目标Agent名称（如 Nova），决定回忆哪个Agent具体的聊天话题。[内置功能: TopicMemo]',
         commands: {
             'ListTopics': {
                 description: '列出所有话题',
@@ -815,7 +814,7 @@ export const tools = {
             'CreateTopic': {
                 description: '创建新话题',
                 params: [
-                    { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                    { name: 'maid', type: 'text', required: true, placeholder: '目标Agent名称，决定为哪个Agent创建话题' },
                     { name: 'topic_name', type: 'text', required: true },
                     { name: 'initial_message', type: 'textarea', required: true }
                 ]
@@ -936,7 +935,7 @@ export const tools = {
     // ========================================
     'ScheduleManager': {
         displayName: '日程管理器',
-        description: '辅助日程管理。[后端插件: ScheduleManager]',
+        description: '辅助日程管理。推荐给出目标Agent名称（如 Nova），决定管理哪位Agent的日程。[后端插件: ScheduleManager]',
         commands: {
             'AddSchedule': {
                 description: '添加日程',


### PR DESCRIPTION
根据 review 反馈修复 maid 字段处理：


renderer.js 改动（2处）：

maid 字段恢复显示在主表单区域（不折叠到高级选项），预填充 settings.json 中的 userName，用户可手动修改为其他 Agent 名称
executeTool() 改为仅在用户未填写 maid 时才兜底注入 userName

config.js 改动：

为部分 maid 敏感插件更新了 description，提示用户正确的格式和语义。

背景：

Lionsky 您指出部分插件（如 LightMemo）依赖 maid 字段路由到特定 Agent 的数据库，不能简单隐藏或硬编码。现在的方案改为了预填充 + 可编辑 + 描述提示。