### PR TITLE
feat: WorkflowEditor 执行引擎小优化——分层并行 / 可视化反馈 / 连线着色

### DIFF
--- a/VCPHumanToolBox/WorkflowEditormodules/WorkflowEditor_CanvasManager_JSPlumb.js
+++ b/VCPHumanToolBox/WorkflowEditormodules/WorkflowEditor_CanvasManager_JSPlumb.js
@@ -1,5 +1,5 @@
 // WorkflowEditor Canvas Manager with JSPlumb integration
-(function() {
+(function () {
     'use strict';
 
     class WorkflowEditor_CanvasManager {
@@ -7,17 +7,17 @@
             if (WorkflowEditor_CanvasManager.instance) {
                 return WorkflowEditor_CanvasManager.instance;
             }
-            
+
             this.canvas = null;
             this.viewport = null;
             this.content = null;
             this.stateManager = null;
             this.jsPlumbInstance = null;
-            
+
             // 节点管理
             this.nodes = new Map();
             this.connections = new Map();
-            
+
             WorkflowEditor_CanvasManager.instance = this;
         }
 
@@ -34,12 +34,12 @@
             this.canvas = document.getElementById('workflowCanvas');
             this.viewport = document.getElementById('canvasViewport');
             this.content = document.getElementById('canvasContent');
-            
+
             this.initJSPlumb();
             this.bindEvents();
-            
+
             console.log('[WorkflowEditor_CanvasManager] Initialized with JSPlumb');
-            
+
             // 添加全局测试函数
             window.testConnectionEvent = () => {
                 this.testConnectionEvent();
@@ -51,7 +51,7 @@
             console.log('[CanvasManager] 🧪 Testing connection event...');
             const sourceNode = document.querySelector('[data-node-id="node_4"]');
             const targetNode = document.querySelector('[data-node-id="node_1"]');
-            
+
             if (sourceNode && targetNode) {
                 console.log('[CanvasManager] 🧪 Found test nodes:', sourceNode.id, targetNode.id);
                 const connection = this.jsPlumbInstance.connect({
@@ -69,10 +69,10 @@
         // 重新绑定连线事件
         rebindConnectionEvents() {
             console.log('[CanvasManager] 🔄 Rebinding connection events after workflow load...');
-            
+
             // 解绑现有事件
             this.jsPlumbInstance.unbind('connection');
-            
+
             // 重新绑定事件
             this.jsPlumbInstance.bind('connection', (info) => {
                 console.log('[CanvasManager] 🔗 Connection event triggered (rebound):', info);
@@ -81,7 +81,7 @@
                 console.log('[CanvasManager] 🔗 Target:', info.target);
                 this.handleConnectionCreated(info);
             });
-            
+
             console.log('[CanvasManager] ✅ Connection events rebound successfully');
         }
 
@@ -178,7 +178,7 @@
                         this.deleteConnection(connection);
                         if (originalEvent && originalEvent.preventDefault) originalEvent.preventDefault();
                     }
-                } catch (_) {}
+                } catch (_) { }
             });
 
             // 画布级右键菜单兜底：识别连接线右键
@@ -195,7 +195,7 @@
                             e.preventDefault();
                             this.showConnectionContextMenu(hit, e);
                         }
-                    } catch (_) {}
+                    } catch (_) { }
                 });
             }
         }
@@ -206,7 +206,7 @@
 
             // 画布缩放和平移
             this.viewport.addEventListener('wheel', (e) => this.handleCanvasWheel(e));
-            
+
             // 画布拖拽
             let isDraggingCanvas = false;
             let dragStart = { x: 0, y: 0 };
@@ -216,7 +216,7 @@
                     isDraggingCanvas = true;
                     dragStart = { x: e.clientX, y: e.clientY };
                     this.viewport.style.cursor = 'grabbing';
-                    
+
                     // 清除选择
                     this.stateManager.clearSelection();
                 }
@@ -227,12 +227,12 @@
                     const deltaX = e.clientX - dragStart.x;
                     const deltaY = e.clientY - dragStart.y;
                     const currentOffset = this.stateManager.getCanvasOffset();
-                    
+
                     this.stateManager.setCanvasOffset({
                         x: currentOffset.x + deltaX,
                         y: currentOffset.y + deltaY
                     });
-                    
+
                     dragStart = { x: e.clientX, y: e.clientY };
                 }
             });
@@ -252,10 +252,10 @@
                 }
             });
 
-        // 键盘事件
-        document.addEventListener('keydown', (e) => this.handleKeyDown(e));
+            // 键盘事件
+            document.addEventListener('keydown', (e) => this.handleKeyDown(e));
 
-        // 状态管理器事件
+            // 状态管理器事件
             if (this.stateManager) {
                 this.stateManager.on('nodeAdded', (node) => this.renderNode(node));
                 this.stateManager.on('nodeRemoved', (data) => this.removeNode(data.nodeId));
@@ -267,6 +267,10 @@
                             const nodeElement = this.nodes.get(data.nodeId);
                             if (nodeElement && data.node && data.node.position) {
                                 this.updateNode(data.nodeId, data.node);
+                                // 如果节点状态发生变化，同步更新视觉样式
+                                if (data.node && data.node.status) {
+                                    this.updateNodeStatus(data.nodeId, data.node.status);
+                                }
                             }
                         } catch (error) {
                             console.warn('[CanvasManager] Failed to update node on nodeUpdated event:', error);
@@ -278,7 +282,7 @@
                 this.stateManager.on('canvasOffsetChanged', () => this.updateCanvasTransform());
                 this.stateManager.on('canvasZoomChanged', () => this.updateCanvasTransform());
                 this.stateManager.on('selectionChanged', (data) => this.updateSelection(data));
-                
+
                 // 监听工作流加载完成事件：先全局重绘，再对图片上传节点做安全 revalidate
                 this.stateManager.on('workflowLoaded', (data) => {
                     console.log('[CanvasManager] Workflow loaded, fixing image upload node connections...');
@@ -311,24 +315,24 @@
         // 处理画布滚轮缩放
         handleCanvasWheel(e) {
             e.preventDefault();
-            
+
             const rect = this.viewport.getBoundingClientRect();
             const mouseX = e.clientX - rect.left;
             const mouseY = e.clientY - rect.top;
-            
+
             const currentZoom = this.stateManager.getCanvasZoom();
             const currentOffset = this.stateManager.getCanvasOffset();
-            
+
             const zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;
             const newZoom = Math.max(0.1, Math.min(3, currentZoom * zoomFactor));
-            
+
             // 计算缩放中心点
             const zoomRatio = newZoom / currentZoom;
             const newOffset = {
                 x: mouseX - (mouseX - currentOffset.x) * zoomRatio,
                 y: mouseY - (mouseY - currentOffset.y) * zoomRatio
             };
-            
+
             this.stateManager.setCanvasZoom(newZoom);
             this.stateManager.setCanvasOffset(newOffset);
         }
@@ -383,24 +387,24 @@
 
             const nodeElement = document.createElement('div');
             let nodeClasses = `canvas-node ${node.category === 'auxiliary' ? 'auxiliary' : ''}`;
-            
+
             // 为URL渲染节点添加特殊类
             if (node.type === 'urlRenderer' || node.pluginId === 'urlRenderer') {
                 nodeClasses += ' url-renderer';
             }
-            
+
             // 为图片上传节点添加特殊类
             if (node.type === 'imageUpload' || node.pluginId === 'imageUpload') {
                 nodeClasses += ' image-upload';
             }
-            
+
             nodeElement.className = nodeClasses;
             nodeElement.id = node.id; // 直接使用节点ID，不添加前缀
             nodeElement.setAttribute('data-node-id', node.id); // 添加数据属性
             nodeElement.style.left = node.position.x + 'px';
             nodeElement.style.top = node.position.y + 'px';
             nodeElement.style.position = 'absolute';
-            
+
             // 为图片上传节点创建特殊UI
             if (node.type === 'imageUpload' || node.pluginId === 'imageUpload') {
                 nodeElement.innerHTML = `
@@ -440,10 +444,10 @@
 
             // 使节点可拖拽
             this.makeNodeDraggable(nodeElement, node);
-            
+
             // 添加连接点
             this.addEndpoints(nodeElement, node);
-            
+
             // 绑定节点事件
             this.bindNodeEvents(nodeElement, node);
 
@@ -454,13 +458,49 @@
         getNodeIcon(node) {
             const icons = {
                 assistant: '🤖', music: '🎵', note: '📝', search: '🔍',
-                TodoManager: '✅', FluxGen: '🎨', ComfyUIGen: '🖼️', 
+                TodoManager: '✅', FluxGen: '🎨', ComfyUIGen: '🖼️',
                 BilibiliFetch: '📺', VideoGenerator: '🎬',
                 regex: '🔤', dataTransform: '🔄', codeEdit: '💻',
                 condition: '🔀', loop: '🔁', delay: '⏱️', urlRenderer: '🖼️',
                 imageUpload: '📤'
             };
             return icons[node.pluginId || node.type] || '⚙️';
+        }
+
+        // 获取节点类型颜色（用于端点和连线着色）
+        getNodeTypeColors(node) {
+            const colorMap = {
+                // 数据源 - 绿色系
+                'contentInput': { main: '#22c55e', dark: '#16a34a', hover: '#4ade80' },
+                'imageUpload': { main: '#10b981', dark: '#059669', hover: '#34d399' },
+                // 文本处理 - 青色系
+                'regex': { main: '#06b6d4', dark: '#0891b2', hover: '#22d3ee' },
+                'urlExtractor': { main: '#0ea5e9', dark: '#0284c7', hover: '#38bdf8' },
+                // 数据变换 - 紫色系
+                'dataTransform': { main: '#a855f7', dark: '#9333ea', hover: '#c084fc' },
+                'codeEdit': { main: '#8b5cf6', dark: '#7c3aed', hover: '#a78bfa' },
+                // 控制流 - 粉橙色系
+                'condition': { main: '#ec4899', dark: '#db2777', hover: '#f472b6' },
+                'loop': { main: '#f97316', dark: '#ea580c', hover: '#fb923c' },
+                'delay': { main: '#f59e0b', dark: '#d97706', hover: '#fbbf24' },
+                // 渲染/展示 - 靛蓝色系
+                'urlRenderer': { main: '#6366f1', dark: '#4f46e5', hover: '#818cf8' },
+                'textDisplay': { main: '#64748b', dark: '#475569', hover: '#94a3b8' },
+                'imageDisplay': { main: '#64748b', dark: '#475569', hover: '#94a3b8' },
+                'htmlDisplay': { main: '#64748b', dark: '#475569', hover: '#94a3b8' },
+                'jsonDisplay': { main: '#64748b', dark: '#475569', hover: '#94a3b8' },
+                // AI节点 - 金色
+                'aiCompose': { main: '#eab308', dark: '#ca8a04', hover: '#facc15' },
+            };
+
+            const pluginId = node.pluginId || node.type;
+            const colors = colorMap[pluginId];
+            if (colors) return colors;
+
+            // 非辅助节点按 category 区分
+            if (node.category === 'vcpToolBox') return { main: '#f59e0b', dark: '#d97706', hover: '#fbbf24' };
+            // 默认蓝色（vcpChat和未知类型）
+            return { main: '#3b82f6', dark: '#2563eb', hover: '#60a5fa' };
         }
 
         // 获取节点描述
@@ -503,13 +543,13 @@
                         // 标记正在拖拽，避免频繁重新验证连接
                         nodeElement._isDragging = true;
                         // 在拖动期间暂停大规模绘制，减少端点漂移
-                        try { this.jsPlumbInstance.setSuspendDrawing(true); } catch (_) {}
+                        try { this.jsPlumbInstance.setSuspendDrawing(true); } catch (_) { }
                     },
                     drag: (params) => {
                         // 拖拽过程中：仅重绘当前元素，提升跟随稳定性
-                        try { this.jsPlumbInstance.repaint(params.el); } catch (_) {}
+                        try { this.jsPlumbInstance.repaint(params.el); } catch (_) { }
                         // 同步容器级连线，降低视觉延迟
-                        try { this.jsPlumbInstance.repaintEverything(); } catch (_) {}
+                        try { this.jsPlumbInstance.repaintEverything(); } catch (_) { }
                     },
                     stop: (params) => {
                         // 拖拽结束后更新最终位置
@@ -517,21 +557,21 @@
                             x: parseInt(params.el.style.left) || 0,
                             y: parseInt(params.el.style.top) || 0
                         };
-                        
+
                         // 清除拖拽标记
                         nodeElement._isDragging = false;
-                        
+
                         // 更新StateManager中的节点位置
                         if (this.stateManager && this.stateManager.updateNode) {
                             this.stateManager.updateNode(node.id, { position: newPos });
                         }
-                        
+
                         // 继续与画布同步：恢复绘制，并多次repaint降低错位
-                        try { this.jsPlumbInstance.setSuspendDrawing(false, true); } catch (_) {}
+                        try { this.jsPlumbInstance.setSuspendDrawing(false, true); } catch (_) { }
                         const safeRepaint = () => {
                             if (this.jsPlumbInstance && nodeElement.offsetParent !== null) {
-                                try { this.jsPlumbInstance.revalidate(nodeElement); } catch (_) {}
-                                try { this.jsPlumbInstance.repaint(nodeElement); } catch (_) {}
+                                try { this.jsPlumbInstance.revalidate(nodeElement); } catch (_) { }
+                                try { this.jsPlumbInstance.repaint(nodeElement); } catch (_) { }
                             }
                         };
                         safeRepaint();
@@ -540,7 +580,7 @@
                         if (typeof requestAnimationFrame === 'function') {
                             requestAnimationFrame(safeRepaint);
                         }
-                        
+
                         console.log(`[CanvasManager] Node ${node.id} moved to:`, newPos);
                     }
                 });
@@ -556,7 +596,7 @@
         // 添加连接点
         addEndpoints(nodeElement, node) {
             if (!this.jsPlumbInstance) return;
-
+            const typeColors = this.getNodeTypeColors(node);
             console.log('[CanvasManager] Adding endpoints for node:', node.id, node.category);
 
             let inputEndpoint = null;
@@ -575,26 +615,31 @@
                     isTarget: false,
                     maxConnections: -1,
                     endpoint: ['Dot', { radius: 8 }],
-                    paintStyle: { 
-                        fill: '#f59e0b', 
-                        stroke: '#d97706',
+                    paintStyle: {
+                        fill: typeColors.main,
+                        stroke: typeColors.dark,
                         strokeWidth: 3
                     },
-                    hoverPaintStyle: { 
-                        fill: '#b45309', 
-                        stroke: '#92400e',
+                    hoverPaintStyle: {
+                        fill: typeColors.hover,
+                        stroke: typeColors.dark,
                         strokeWidth: 3
                     },
-                    connectorStyle: { stroke: '#3b82f6', strokeWidth: 2 },
-                    connectorHoverStyle: { stroke: '#1d4ed8', strokeWidth: 3 },
-                    dragOptions: { cursor: 'pointer', zIndex: 2000 },
+                    connectorStyle: {
+                        stroke: typeColors.main,
+                        strokeWidth: 2
+                    },
+                    connectorHoverStyle: {
+                        stroke: typeColors.dark,
+                        strokeWidth: 3
+                    },
                     // 启用连接拖拽重连
                     connectionsDetachable: true,
                     reattachConnections: true,
                     // 启用端点拖拽
                     dragOptions: { cursor: 'pointer', zIndex: 2000 }
                 });
-                
+
                 // 设置端点的节点ID，用于连接创建时的识别
                 if (outputEndpoint) {
                     outputEndpoint.nodeId = node.id;
@@ -611,13 +656,13 @@
                     isSource: false,
                     maxConnections: -1,
                     endpoint: ['Dot', { radius: 8 }],
-                    paintStyle: { 
-                        fill: '#10b981', 
+                    paintStyle: {
+                        fill: '#10b981',
                         stroke: '#059669',
                         strokeWidth: 3
                     },
-                    hoverPaintStyle: { 
-                        fill: '#047857', 
+                    hoverPaintStyle: {
+                        fill: '#047857',
                         stroke: '#065f46',
                         strokeWidth: 3
                     },
@@ -637,18 +682,24 @@
                     isTarget: false,
                     maxConnections: -1,
                     endpoint: ['Dot', { radius: 8 }],
-                    paintStyle: { 
-                        fill: '#f59e0b', 
-                        stroke: '#d97706',
+                    paintStyle: {
+                        fill: typeColors.main,
+                        stroke: typeColors.dark,
                         strokeWidth: 3
                     },
-                    hoverPaintStyle: { 
-                        fill: '#b45309', 
-                        stroke: '#92400e',
+                    hoverPaintStyle: {
+                        fill: typeColors.hover,
+                        stroke: typeColors.dark,
                         strokeWidth: 3
                     },
-                    connectorStyle: { stroke: '#3b82f6', strokeWidth: 2 },
-                    connectorHoverStyle: { stroke: '#1d4ed8', strokeWidth: 3 },
+                    connectorStyle: {
+                        stroke: typeColors.main,
+                        strokeWidth: 2
+                    },
+                    connectorHoverStyle: {
+                        stroke: typeColors.dark,
+                        strokeWidth: 3
+                    },
                     dragOptions: { cursor: 'pointer', zIndex: 2000 },
                     // 启用连接拖拽重连
                     connectionsDetachable: true,
@@ -656,7 +707,7 @@
                     // 启用端点拖拽
                     dragOptions: { cursor: 'pointer', zIndex: 2000 }
                 });
-                
+
                 // 设置端点的节点ID和参数名，用于连接创建时的识别
                 if (inputEndpoint) {
                     inputEndpoint.nodeId = node.id;
@@ -679,12 +730,12 @@
             // 为辅助节点确保端点正确设置 (现在已经包含在上面的逻辑中，但保留以防万一)
             if (node.category === 'auxiliary') {
                 console.log('[CanvasManager] Setting up auxiliary node endpoints:', node.id);
-                
+
                 if (inputEndpoint) {
                     inputEndpoint.setVisible(true);
                     inputEndpoint.setEnabled(true);
                 }
-                
+
                 if (outputEndpoint) {
                     outputEndpoint.setVisible(true);
                     outputEndpoint.setEnabled(true);
@@ -748,7 +799,7 @@
             // 支持两种数据格式：uploadedImage（新格式）和uploadedImageData（旧格式）
             let imageData = null;
             let fileName = null;
-            
+
             if (node.uploadedImage && node.uploadedImage.base64Data) {
                 // 新格式
                 imageData = node.uploadedImage.base64Data;
@@ -758,7 +809,7 @@
                 imageData = node.uploadedImageData;
                 fileName = node.uploadedFileName || '已上传图片';
             }
-            
+
             if (imageData) {
                 console.log('[CanvasManager] Restoring uploaded image for node:', node.id);
                 uploadText.textContent = fileName || '已上传图片';
@@ -766,7 +817,7 @@
                 uploadText.style.wordBreak = 'break-all';
                 previewImg.src = imageData;
                 uploadPreview.style.display = 'block';
-                
+
                 // 确保图片加载完成后重新计算连接线位置（含缓存命中的兜底）
                 const doRefresh = () => {
                     setTimeout(() => {
@@ -833,11 +884,11 @@
                 const nodeElement = this.nodes && this.nodes.get ? this.nodes.get(nodeId) : document.getElementById(nodeId);
                 if (!nodeElement) return;
                 if (nodeElement.offsetParent !== null && document.contains(nodeElement)) {
-                    try { this.jsPlumbInstance.revalidate(nodeElement); } catch (_) {}
-                    try { this.jsPlumbInstance.repaint(nodeElement); } catch (_) {}
+                    try { this.jsPlumbInstance.revalidate(nodeElement); } catch (_) { }
+                    try { this.jsPlumbInstance.repaint(nodeElement); } catch (_) { }
                     if (typeof requestAnimationFrame === 'function') {
                         requestAnimationFrame(() => {
-                            try { this.jsPlumbInstance.repaint(nodeElement); } catch (_) {}
+                            try { this.jsPlumbInstance.repaint(nodeElement); } catch (_) { }
                         });
                     }
                 }
@@ -852,7 +903,7 @@
             const maxSizeMB = (node.config && node.config.maxFileSize) || 10; // 10MB
             const maxSizeBytes = maxSizeMB * 1024 * 1024; // 转换为字节
             const fileSizeMB = file.size / (1024 * 1024);
-            
+
             if (file.size > maxSizeBytes) {
                 alert(`文件大小超过限制: ${fileSizeMB.toFixed(2)}MB > ${maxSizeMB}MB`);
                 return;
@@ -861,10 +912,10 @@
             // 检查文件格式
             const acceptedFormats = (node.config && node.config.acceptedFormats) || ['jpg', 'png', 'gif', 'webp'];
             const fileExtension = file.name.split('.').pop().toLowerCase();
-            
+
             // 处理acceptedFormats可能是数组或字符串的情况
             const formatArray = Array.isArray(acceptedFormats) ? acceptedFormats : acceptedFormats.split(',');
-            
+
             if (!formatArray.includes(fileExtension)) {
                 alert(`不支持的文件格式，支持的格式: ${formatArray.join(', ')}`);
                 return;
@@ -874,7 +925,7 @@
             const reader = new FileReader();
             reader.onload = (e) => {
                 const base64Data = e.target.result;
-                
+
                 // 更新UI显示
                 uploadText.textContent = file.name;
                 uploadText.style.fontSize = '10px';
@@ -901,12 +952,12 @@
 
                 // 更新节点状态为已准备
                 this.updateNodeStatus(node.id, 'ready');
-                
+
                 // 重新计算并更新JSPlumb连接点位置
                 setTimeout(() => {
                     this.refreshNodeConnections(node.id);
                 }, 100);
-                
+
                 console.log('[CanvasManager] Image uploaded successfully:', file.name, 'Size:', file.size);
             };
 
@@ -918,13 +969,23 @@
             reader.readAsDataURL(file);
         }
 
-        // 更新节点状态
+        // 更新节点状态（增强版：同时更新内部圆点 + 整个节点边框/阴影样式）
         updateNodeStatus(nodeId, status) {
             const nodeElement = this.nodes.get(nodeId);
             if (nodeElement) {
+                // 1. 更新内部 status 圆点（原有逻辑）
                 const statusElement = nodeElement.querySelector('.canvas-node-status');
                 if (statusElement) {
                     statusElement.className = `canvas-node-status ${status}`;
+                }
+                // 2. 更新整个节点的 class，触发 CSS 中已有的
+                //    .canvas-node.executing / .success / .error 样式
+                const statusClasses = ['idle', 'running', 'executing', 'success', 'error', 'skipped', 'ready'];
+                statusClasses.forEach(s => nodeElement.classList.remove(s));
+                // ExecutionEngine 传入 'running'，CSS 定义的是 .canvas-node.executing
+                const mappedClass = (status === 'running') ? 'executing' : status;
+                if (mappedClass && mappedClass !== 'idle') {
+                    nodeElement.classList.add(mappedClass);
                 }
             }
         }
@@ -932,26 +993,26 @@
         // 刷新节点连接点位置
         refreshNodeConnections(nodeId) {
             if (!this.jsPlumbInstance) return;
-            
+
             try {
                 const nodeElement = this.nodes.get(nodeId);
                 if (!nodeElement) {
                     console.warn('[CanvasManager] Node element not found for refresh:', nodeId);
                     return;
                 }
-                
+
                 // 更严格的DOM存在性检查
-                if (nodeElement.offsetParent !== null && 
-                    nodeElement.offsetLeft !== undefined && 
+                if (nodeElement.offsetParent !== null &&
+                    nodeElement.offsetLeft !== undefined &&
                     nodeElement.offsetTop !== undefined &&
                     document.contains(nodeElement)) {
-                    
+
                     // 重新计算节点的连接点位置
                     this.jsPlumbInstance.revalidate(nodeElement);
-                    
+
                     // 重绘所有与该节点相关的连接
                     this.jsPlumbInstance.repaint(nodeElement);
-                    
+
                     console.log('[CanvasManager] Refreshed connections for node:', nodeId);
                 } else {
                     console.warn('[CanvasManager] Cannot refresh connections - node not properly in DOM:', nodeId);
@@ -971,7 +1032,7 @@
                 // 下一帧再重绘一次，确保布局稳定后刷新
                 if (typeof requestAnimationFrame === 'function') {
                     requestAnimationFrame(() => {
-                        try { this.jsPlumbInstance.repaintEverything(); } catch (_) {}
+                        try { this.jsPlumbInstance.repaintEverything(); } catch (_) { }
                     });
                 }
                 console.log('[CanvasManager] All connections repaired');
@@ -983,26 +1044,26 @@
         // 启用所有连接的拖拽功能
         enableConnectionDragging() {
             if (!this.jsPlumbInstance) return;
-            
+
             try {
                 console.log('[CanvasManager] Enabling connection dragging for all connections...');
-                
+
                 // 获取所有连接
                 const allConnections = this.jsPlumbInstance.getAllConnections();
-                
+
                 allConnections.forEach(connection => {
                     if (connection && connection.setParameter) {
                         // 确保连接支持拖拽重连
                         connection.setParameter('connectionsDetachable', true);
                         connection.setParameter('reattachConnections', true);
-                        
+
                         // 设置连接为可拖拽
                         if (connection.connector && connection.connector.canvas) {
                             connection.connector.canvas.style.cursor = 'pointer';
                         }
                     }
                 });
-                
+
                 console.log(`[CanvasManager] Enabled dragging for ${allConnections.length} connections`);
             } catch (error) {
                 console.error('[CanvasManager] Error enabling connection dragging:', error);
@@ -1024,19 +1085,19 @@
             if (!sourceNode || !targetNode) {
                 console.warn(`[CanvasManager] Nodes not ready for connection. Source: ${sourceNode ? 'found' : 'NOT FOUND'}, Target: ${targetNode ? 'found' : 'NOT FOUND'}`);
                 console.log(`[CanvasManager] Available nodes:`, Array.from(this.nodes.keys()));
-                
+
                 // 延迟重试，增加重试次数和间隔
                 let retryCount = 0;
                 const maxRetries = 5;
                 const retryInterval = 200;
-                
+
                 const retryConnection = () => {
                     retryCount++;
                     console.log(`[CanvasManager] Retry attempt ${retryCount}/${maxRetries} for connection ${connectionData.sourceNodeId} -> ${connectionData.targetNodeId}`);
-                    
+
                     const retrySourceNode = this.nodes.get(connectionData.sourceNodeId);
                     const retryTargetNode = this.nodes.get(connectionData.targetNodeId);
-                    
+
                     if (retrySourceNode && retryTargetNode) {
                         console.log(`[CanvasManager] Retry ${retryCount} successful, creating connection`);
                         this.createConnectionInternal(connectionData, retrySourceNode, retryTargetNode);
@@ -1047,7 +1108,7 @@
                         console.error(`[CanvasManager] Missing nodes - Source: ${connectionData.sourceNodeId}, Target: ${connectionData.targetNodeId}`);
                     }
                 };
-                
+
                 setTimeout(retryConnection, retryInterval);
                 return;
             }
@@ -1067,13 +1128,13 @@
                 // 检查是否已存在相同的JSPlumb连接（基于源和目标节点）
                 const existingJSPlumbConnection = Array.from(this.connections.values()).find(conn => {
                     if (!conn || !conn.source || !conn.target) return false;
-                    
+
                     const connSourceId = conn.source.id || conn.sourceId;
                     const connTargetId = conn.target.id || conn.targetId;
-                    
+
                     return connSourceId === sourceNode.id && connTargetId === targetNode.id;
                 });
-                
+
                 if (existingJSPlumbConnection) {
                     console.log('[CanvasManager] JSPlumb connection already exists between nodes, skipping creation');
                     return;
@@ -1090,7 +1151,7 @@
                             force: true // 强制启用拖拽
                         });
                     }
-                    
+
                     if (!targetNode.classList.contains('jtk-draggable')) {
                         console.log('[CanvasManager] Making target node draggable:', targetNode.id);
                         this.jsPlumbInstance.draggable(targetNode, {
@@ -1107,17 +1168,17 @@
                 // 查找源端点和目标端点
                 let sourceEndpoint = null;
                 let targetEndpoint = null;
-                
+
                 // 查找源端点（通常是输出端点）
                 if (sourceNode._outputEndpoint) {
                     sourceEndpoint = sourceNode._outputEndpoint;
                 }
-                
+
                 // 查找目标端点
                 if (targetNode._inputEndpoint) {
                     targetEndpoint = targetNode._inputEndpoint;
                 }
-                
+
                 // 如果找到了端点，使用端点连接，否则使用节点连接
                 let connection;
                 if (sourceEndpoint && targetEndpoint) {
@@ -1195,7 +1256,7 @@
                         connection.setParameter('targetNodeId', connectionData.targetNodeId);
                         connection.setParameter('sourceParam', connectionData.sourceParam || 'output');
                         connection.setParameter('targetParam', connectionData.targetParam || 'input');
-                    } catch (_) {}
+                    } catch (_) { }
                     this.connections.set(connectionData.id, connection);
                     console.log(`[CanvasManager] Connection created successfully: ${connectionData.sourceNodeId} -> ${connectionData.targetNodeId}`);
                     console.log('[CanvasManager] Current connections size:', this.connections.size);
@@ -1207,7 +1268,7 @@
                 console.error('Connection data:', connectionData);
                 console.error('Source node:', sourceNode);
                 console.error('Target node:', targetNode);
-                
+
                 // 如果连接创建失败，尝试延迟重试一次
                 setTimeout(() => {
                     console.log('[CanvasManager] Retrying connection creation after error...');
@@ -1225,7 +1286,7 @@
                             },
                             doNotFireConnectionEvent: false
                         });
-                        
+
                         if (retryConnection) {
                             retryConnection._programmaticConnection = true;
                             retryConnection.connectionId = connectionData.id;
@@ -1247,7 +1308,7 @@
             console.log('[CanvasManager] 🎯 Target element:', info.target);
             console.log('[CanvasManager] 🎯 Source endpoint:', info.sourceEndpoint);
             console.log('[CanvasManager] 🎯 Target endpoint:', info.targetEndpoint);
-            
+
             // 检查是否是程序化创建的连接（避免重复处理）
             if (info.connection._programmaticConnection) {
                 // 如果连接已经存在于我们自己的映射中，则安全跳过
@@ -1262,7 +1323,7 @@
                 // 如果连接被标记为程序化但尚未记录到 canvas/state，则继续处理，防止误判导致丢失
                 console.log('[CanvasManager] Programmatic flag present but connection not tracked — proceeding to handle it to avoid loss');
             }
-            
+
             try {
                 // 更强健的节点ID获取逻辑
                 let sourceNodeId, targetNodeId;
@@ -1336,8 +1397,8 @@
 
                 // 检查是否已存在相同的连接
                 const existingConnections = this.stateManager.getAllConnections();
-                const isDuplicate = existingConnections.some(conn => 
-                    conn.sourceNodeId === sourceNodeId && 
+                const isDuplicate = existingConnections.some(conn =>
+                    conn.sourceNodeId === sourceNodeId &&
                     conn.targetNodeId === targetNodeId &&
                     conn.targetParam === targetParam
                 );
@@ -1359,7 +1420,7 @@
                         sourceParam = info.sourceEndpoint.paramName;
                     }
                 }
-                
+
                 if (info.targetEndpoint && info.targetEndpoint.element) {
                     const targetElement = info.targetEndpoint.element;
                     const targetParamFromDOM = targetElement.getAttribute('data-param');
@@ -1381,7 +1442,7 @@
                     sourceParam: sourceParam,
                     targetParam: targetParam
                 };
-                
+
                 console.log('[CanvasManager] Creating connection:', connectionData);
 
                 // 标记连接ID与参数到JSPlumb连接对象
@@ -1392,7 +1453,7 @@
                 info.connection.setParameter('sourceParam', sourceParam);
                 info.connection.setParameter('targetParam', targetParam);
                 this.connections.set(connectionData.id, info.connection);
-                
+
                 // 通过状态管理器添加连接前，进行更严格的去重
                 if (this.stateManager && this.stateManager.addConnection) {
                     console.log('[CanvasManager] 调用 StateManager.addConnection:', connectionData);
@@ -1403,7 +1464,7 @@
                             console.log('[CanvasManager] 去重：发现同一(source,target,targetParam)已存在，跳过重复保存，回收JSPlumb重复连接');
                             // 保留新的可视连接，但不重复保存到state；或者直接删除本次可视连接
                             // 为保持一致，这里删除新建的重复可视连接
-                            try { this.jsPlumbInstance.deleteConnection(info.connection); } catch (_) {}
+                            try { this.jsPlumbInstance.deleteConnection(info.connection); } catch (_) { }
                             return;
                         }
                     } catch (e) {
@@ -1412,7 +1473,7 @@
                     // 调用 addConnection，skipRender=true（因为连接已经在画布上了），recordHistory=true（记录历史）
                     const result = this.stateManager.addConnection(connectionData, true, true);
                     console.log('[CanvasManager] StateManager.addConnection 结果:', result);
-                    
+
                     // 验证连接是否成功添加到 StateManager
                     const savedConnection = this.stateManager.getConnection(connectionData.id);
                     if (savedConnection) {
@@ -1433,20 +1494,20 @@
         // 处理连接断开
         handleConnectionDetached(info) {
             console.log('[CanvasManager] Connection detached:', info);
-            
+
             // 检查是否是程序化删除的连接（避免重复处理）
             if (info.connection._programmaticDelete) {
                 console.log('[CanvasManager] Skipping programmatic delete event');
                 return;
             }
-            
+
             try {
                 if (info.connection.connectionId) {
                     console.log('[CanvasManager] Removing connection from state:', info.connection.connectionId);
-                    
+
                     // 从内部连接映射中移除
                     this.connections.delete(info.connection.connectionId);
-                    
+
                     // 通知状态管理器移除连接
                     if (this.stateManager && this.stateManager.removeConnection) {
                         // 调用 removeConnection，它会记录历史
@@ -1464,7 +1525,7 @@
         handleConnectionClick(connection) {
             // 选择连接线
             console.log('[CanvasManager] Connection clicked:', connection.connectionId);
-            
+
             // 选中连接线时添加视觉反馈
             this.selectConnection(connection);
         }
@@ -1473,12 +1534,12 @@
         selectConnection(connection) {
             // 清除其他连接的选择状态
             this.clearConnectionSelection();
-            
+
             // 添加选中样式
             if (connection.canvas) {
                 connection.canvas.classList.add('connection-selected');
             }
-            
+
             // 存储当前选中的连接
             this.selectedConnection = connection;
         }
@@ -1494,7 +1555,7 @@
         // 显示连接右键菜单
         showConnectionContextMenu(connection, event) {
             event.preventDefault();
-            
+
             // 创建右键菜单
             const menu = document.createElement('div');
             menu.className = 'connection-context-menu';
@@ -1508,7 +1569,7 @@
                 min-width: 120px;
                 overflow: hidden;
             `;
-            
+
             menu.innerHTML = `
                 <div class="menu-item" data-action="delete" style="padding: 8px 12px; cursor: pointer; color: #e2e8f0; font-size: 14px; border-bottom: 1px solid #334155;">
                     🗑️ 删除连接
@@ -1517,13 +1578,13 @@
                     ℹ️ 连接信息
                 </div>
             `;
-            
+
             // 定位菜单
             menu.style.left = event.clientX + 'px';
             menu.style.top = event.clientY + 'px';
-            
+
             document.body.appendChild(menu);
-            
+
             // 添加菜单项悬停效果
             const menuItems = menu.querySelectorAll('.menu-item');
             menuItems.forEach(item => {
@@ -1534,11 +1595,11 @@
                     item.style.backgroundColor = '';
                 });
             });
-            
+
             // 处理菜单点击
             const handleMenuClick = (e) => {
                 const action = e.target.getAttribute('data-action');
-                
+
                 switch (action) {
                     case 'delete':
                         this.deleteConnection(connection);
@@ -1547,19 +1608,19 @@
                         this.showConnectionInfo(connection);
                         break;
                 }
-                
+
                 // 清理菜单
                 document.body.removeChild(menu);
                 document.removeEventListener('click', hideMenu);
             };
-            
+
             const hideMenu = () => {
                 if (document.body.contains(menu)) {
                     document.body.removeChild(menu);
                 }
                 document.removeEventListener('click', hideMenu);
             };
-            
+
             // 绑定事件
             menu.addEventListener('click', handleMenuClick);
             document.addEventListener('click', hideMenu);
@@ -1568,22 +1629,22 @@
         // 删除连接
         deleteConnection(connection) {
             if (!connection) return;
-            
+
             const connectionId = connection.connectionId || connection.getParameter('connectionId');
             if (connectionId) {
                 console.log('[CanvasManager] Deleting connection:', connectionId);
-                
+
                 // 从JSPlumb中删除连接
                 this.jsPlumbInstance.deleteConnection(connection);
-                
+
                 // 从内部状态中删除
                 this.connections.delete(connectionId);
-                
+
                 // 从状态管理器中删除
                 if (this.stateManager && this.stateManager.removeConnection) {
                     this.stateManager.removeConnection(connectionId, true);
                 }
-                
+
                 console.log('[CanvasManager] Connection deleted successfully');
             }
         }
@@ -1593,42 +1654,42 @@
             const connectionId = connection.connectionId || connection.getParameter('connectionId');
             const sourceNodeId = connection.getParameter('sourceNodeId');
             const targetNodeId = connection.getParameter('targetNodeId');
-            
+
             const info = `
 连接ID: ${connectionId}
 源节点: ${sourceNodeId}
 目标节点: ${targetNodeId}
             `.trim();
-            
+
             alert(info);
         }
 
         // 处理连接移动（拖拽重连）
         handleConnectionMoved(info) {
             console.log('[CanvasManager] Connection moved event:', info);
-            
+
             try {
                 // 获取旧连接信息
                 const oldConnection = info.originalConnection;
                 const newConnection = info.connection;
-                
+
                 if (oldConnection && oldConnection.connectionId) {
                     // 移除旧连接
                     this.connections.delete(oldConnection.connectionId);
-                    
+
                     // 通知状态管理器移除旧连接
                     if (this.stateManager && this.stateManager.removeConnection) {
                         this.stateManager.removeConnection(oldConnection.connectionId, true);
                     }
                 }
-                
+
                 // 处理新连接
                 if (newConnection) {
                     // 标记为程序化创建的连接，避免重复处理
                     newConnection._programmaticConnection = true;
                     this.handleConnectionCreated({ connection: newConnection, source: newConnection.source, target: newConnection.target });
                 }
-                
+
             } catch (error) {
                 console.error('[CanvasManager] Error handling connection moved:', error);
             }
@@ -1645,17 +1706,17 @@
                         endpoint._tooltip.remove();
                     }
                 });
-                
+
                 // 移除JSPlumb管理的连接和端点
                 if (this.jsPlumbInstance) {
                     this.jsPlumbInstance.remove(nodeElement);
                 }
-                
+
                 // 从DOM中移除
                 if (nodeElement.parentNode) {
                     nodeElement.parentNode.removeChild(nodeElement);
                 }
-                
+
                 this.nodes.delete(nodeId);
             }
         }
@@ -1667,20 +1728,20 @@
                 console.warn('[CanvasManager] Node element not found for update:', nodeId);
                 return;
             }
-            
+
             if (nodeData.position) {
                 nodeElement.style.left = nodeData.position.x + 'px';
                 nodeElement.style.top = nodeData.position.y + 'px';
-                
+
                 // 如果节点正在拖拽中，跳过重新验证，避免连接线错乱
                 if (nodeElement._isDragging) {
                     return;
                 }
-                
+
                 // 更严格的DOM存在性检查
-                if (this.jsPlumbInstance && 
-                    nodeElement.offsetParent !== null && 
-                    nodeElement.offsetLeft !== undefined && 
+                if (this.jsPlumbInstance &&
+                    nodeElement.offsetParent !== null &&
+                    nodeElement.offsetLeft !== undefined &&
                     nodeElement.offsetTop !== undefined &&
                     document.contains(nodeElement)) {
                     try {
@@ -1695,7 +1756,7 @@
         // 移除连接
         removeConnection(connectionId) {
             console.log('[CanvasManager] Removing connection:', connectionId);
-            
+
             const connection = this.connections.get(connectionId);
             if (connection && this.jsPlumbInstance) {
                 try {
@@ -1710,7 +1771,7 @@
                     console.warn('[CanvasManager] Error deleting connection from JSPlumb:', error);
                     // 即使JSPlumb删除失败，也要清理内部状态
                 }
-                
+
                 this.connections.delete(connectionId);
                 console.log('[CanvasManager] Connection removed from internal state');
             } else {
@@ -1719,7 +1780,7 @@
                     connectionExists: !!connection,
                     jsPlumbExists: !!this.jsPlumbInstance
                 });
-                
+
                 // 确保从内部状态中移除，即使连接对象不存在
                 this.connections.delete(connectionId);
             }
@@ -1728,12 +1789,12 @@
         // 更新画布变换
         updateCanvasTransform() {
             if (!this.content) return;
-            
+
             const offset = this.stateManager.getCanvasOffset();
             const zoom = this.stateManager.getCanvasZoom();
-            
+
             this.content.style.transform = `translate(${offset.x}px, ${offset.y}px) scale(${zoom})`;
-            
+
             // 重绘所有连接线
             if (this.jsPlumbInstance) {
                 this.jsPlumbInstance.repaintEverything();
@@ -1779,7 +1840,7 @@
         // 更新节点输入端点
         updateNodeInputs(nodeId, dynamicInputs) {
             console.log('[CanvasManager_JSPlumb] Updating node inputs for:', nodeId, dynamicInputs);
-            
+
             const nodeElement = document.getElementById(nodeId);
             if (!nodeElement) {
                 console.warn('[CanvasManager_JSPlumb] Node element not found:', nodeId);
@@ -1794,7 +1855,7 @@
                 paramInputs.forEach(el => {
                     if (this.jsPlumbInstance) {
                         try { this.jsPlumbInstance.removeAllEndpoints(el); } catch (e) { console.warn('[CanvasManager] removeAllEndpoints failed:', e); }
-                        try { if (typeof this.jsPlumbInstance.unmanage === 'function') this.jsPlumbInstance.unmanage(el); } catch (_) {}
+                        try { if (typeof this.jsPlumbInstance.unmanage === 'function') this.jsPlumbInstance.unmanage(el); } catch (_) { }
                     }
                 });
                 existingParamsContainer.remove();
@@ -1874,13 +1935,13 @@
                             },
                             isTarget: true,
                             maxConnections: -1, // 允许无限连接，确保端点不会因连接断开而消失
-                            connectorStyle: { 
-                                stroke: '#3b82f6', 
-                                strokeWidth: 2 
+                            connectorStyle: {
+                                stroke: '#3b82f6',
+                                strokeWidth: 2
                             },
-                            connectorHoverStyle: { 
-                                stroke: '#1d4ed8', 
-                                strokeWidth: 3 
+                            connectorHoverStyle: {
+                                stroke: '#1d4ed8',
+                                strokeWidth: 3
                             },
                             // 启用连接拖拽重连
                             connectionsDetachable: true,
@@ -1895,19 +1956,19 @@
                             // 确保端点元素有正确的节点关联
                             paramInput.setAttribute('data-node-id', nodeId);
                             paramInput.setAttribute('data-param-name', input.name);
-                            
+
                             // 初始化端点映射（如果不存在）
                             if (!nodeElement._inputEndpoints) {
                                 nodeElement._inputEndpoints = {};
                             }
-                            
+
                             // 将端点添加到映射中
                             nodeElement._inputEndpoints[input.name] = endpoint;
-                            
+
                             // 确保端点支持连接拖拽重连
                             endpoint.setParameter('connectionsDetachable', true);
                             endpoint.setParameter('reattachConnections', true);
-                            
+
                             console.log(`[CanvasManager] Added dynamic input endpoint for param: ${input.name} on node: ${nodeId}`);
                         }
                     }
@@ -1942,11 +2003,11 @@
             // 延迟执行，确保JSPlumb端点已经创建
             setTimeout(() => {
                 const endpoints = nodeElement.querySelectorAll('.jtk-endpoint');
-                
+
                 endpoints.forEach(endpoint => {
                     // 添加鼠标悬停提示
                     this.addEndpointTooltip(endpoint, node);
-                    
+
                     // 添加点击反馈
                     endpoint.addEventListener('mousedown', (e) => {
                         endpoint.style.transform = 'scale(0.9)';
@@ -1954,7 +2015,7 @@
                             endpoint.style.transform = '';
                         }, 150);
                     });
-                    
+
                     // 添加键盘导航支持
                     endpoint.setAttribute('tabindex', '0');
                     endpoint.addEventListener('keydown', (e) => {
@@ -1964,12 +2025,12 @@
                         }
                     });
                 });
-                
+
                 // 为节点添加悬停时高亮连接点的效果
                 nodeElement.addEventListener('mouseenter', () => {
                     this.highlightNodeEndpoints(nodeElement, true);
                 });
-                
+
                 nodeElement.addEventListener('mouseleave', () => {
                     this.highlightNodeEndpoints(nodeElement, false);
                 });
@@ -1979,7 +2040,7 @@
         // 高亮节点连接点
         highlightNodeEndpoints(nodeElement, highlight) {
             const endpoints = nodeElement.querySelectorAll('.jtk-endpoint');
-            
+
             endpoints.forEach(endpoint => {
                 if (highlight) {
                     endpoint.style.opacity = '1';
@@ -1997,13 +2058,13 @@
         addEndpointTooltip(endpoint, node) {
             const tooltip = document.createElement('div');
             tooltip.className = 'endpoint-tooltip';
-            
+
             // 判断端点类型
-            const isInput = endpoint.classList.contains('jtk-endpoint-target') || 
-                           endpoint.getAttribute('data-endpoint-type') === 'input';
-            const isOutput = endpoint.classList.contains('jtk-endpoint-source') || 
-                            endpoint.getAttribute('data-endpoint-type') === 'output';
-            
+            const isInput = endpoint.classList.contains('jtk-endpoint-target') ||
+                endpoint.getAttribute('data-endpoint-type') === 'input';
+            const isOutput = endpoint.classList.contains('jtk-endpoint-source') ||
+                endpoint.getAttribute('data-endpoint-type') === 'output';
+
             let tooltipText = '';
             if (isInput) {
                 tooltipText = `输入连接点\n拖拽到此创建连接`;
@@ -2012,10 +2073,10 @@
             } else {
                 tooltipText = `连接点\n点击或拖拽创建连接`;
             }
-            
+
             tooltip.textContent = tooltipText;
             document.body.appendChild(tooltip);
-            
+
             // 鼠标悬停显示提示
             endpoint.addEventListener('mouseenter', (e) => {
                 const rect = endpoint.getBoundingClientRect();
@@ -2024,11 +2085,11 @@
                 tooltip.style.transform = 'translateX(-50%)';
                 tooltip.classList.add('show');
             });
-            
+
             endpoint.addEventListener('mouseleave', () => {
                 tooltip.classList.remove('show');
             });
-            
+
             // 存储工具提示引用，用于清理
             endpoint._tooltip = tooltip;
         }
@@ -2092,7 +2153,7 @@
         showConnectionGuide(info) {
             const sourceElement = info.source;
             const targetElement = info.target;
-            
+
             if (!sourceElement || !targetElement) return;
 
             const sourceNode = this.findNodeElement(sourceElement);
@@ -2101,7 +2162,7 @@
             if (sourceNode && targetNode) {
                 const sourceName = sourceNode.querySelector('.canvas-node-title')?.textContent || '源节点';
                 const targetName = targetNode.querySelector('.canvas-node-title')?.textContent || '目标节点';
-                
+
                 this.connectionGuide.innerHTML = `
                     <div style="font-weight: 600; margin-bottom: 4px;">🔗 创建连接</div>
                     <div style="font-size: 12px; color: #ccc;">
@@ -2112,7 +2173,7 @@
                         释放鼠标完成连接
                     </div>
                 `;
-                
+
                 this.connectionGuide.style.opacity = '1';
                 this.positionConnectionGuide(info);
             }
@@ -2129,7 +2190,7 @@
         positionConnectionGuide(info) {
             const mouseX = info.e?.clientX || 0;
             const mouseY = info.e?.clientY || 0;
-            
+
             this.connectionGuide.style.left = (mouseX + 20) + 'px';
             this.connectionGuide.style.top = (mouseY - 20) + 'px';
         }
@@ -2151,12 +2212,12 @@
         // 处理连接拖拽开始
         handleConnectionDragStart(info) {
             console.log('[CanvasManager] Connection drag start:', info);
-            
+
             // 为连接线添加重连样式
             if (info.connection && info.connection.canvas) {
                 info.connection.canvas.classList.add('jtk-connector-reconnecting');
             }
-            
+
             // 为拖拽的端点添加样式
             if (info.endpoint && info.endpoint.canvas) {
                 info.endpoint.canvas.classList.add('jtk-endpoint-dragging');
@@ -2166,13 +2227,13 @@
         // 处理连接拖拽结束
         handleConnectionDragStop() {
             console.log('[CanvasManager] Connection drag stop');
-            
+
             // 移除所有重连样式
             const reconnectingConnectors = document.querySelectorAll('.jtk-connector-reconnecting');
             reconnectingConnectors.forEach(connector => {
                 connector.classList.remove('jtk-connector-reconnecting');
             });
-            
+
             const draggingEndpoints = document.querySelectorAll('.jtk-endpoint-dragging');
             draggingEndpoints.forEach(endpoint => {
                 endpoint.classList.remove('jtk-endpoint-dragging');
@@ -2188,14 +2249,14 @@
         // 清空画布
         clear() {
             console.log('[CanvasManager] Clearing canvas...');
-            
+
             // 先移除所有JSPlumb管理的连接和端点
             if (this.jsPlumbInstance) {
                 try {
                     this.jsPlumbInstance.deleteEveryConnection();
                     this.jsPlumbInstance.deleteEveryEndpoint();
                     // 注意：不要调用 jsPlumbInstance.reset()，否则会清空事件绑定，导致新建后连线无法触发保存
-                    
+
                     // 清除所有拖拽元素
                     this.nodes.forEach((nodeElement) => {
                         if (nodeElement) {
@@ -2210,11 +2271,11 @@
                     console.warn('[CanvasManager] Error clearing JSPlumb elements:', error);
                 }
             }
-            
+
             // 清空内部状态
             this.nodes.clear();
             this.connections.clear();
-            
+
             // 清空DOM内容
             if (this.content) {
                 // 确保彻底清空所有子元素
@@ -2223,7 +2284,7 @@
                 }
                 this.content.innerHTML = '';
             }
-            
+
             console.log('[CanvasManager] Canvas cleared successfully');
         }
 
@@ -2337,7 +2398,7 @@
                                 targetEndpoint = targetNode._inputEndpoint;
                             }
                         }
-                        
+
                         if (!sourceEndpoint || !targetEndpoint) {
                             console.error('[CanvasManager] Missing endpoints for connection:', {
                                 sourceHasEndpoint: !!sourceEndpoint,
@@ -2391,10 +2452,10 @@
                                 connection.setParameter('targetNodeId', connectionData.targetNodeId);
                                 connection.setParameter('sourceParam', connectionData.sourceParam || 'output');
                                 connection.setParameter('targetParam', connectionData.targetParam || 'input');
-                            } catch (_) {}
+                            } catch (_) { }
                             this.connections.set(connectionData.id, connection);
                             console.log('[CanvasManager] Current connections size:', this.connections.size);
-                            
+
                             // 重要：将恢复的连接添加到状态管理器中，确保保存时不会丢失
                             if (this.stateManager && this.stateManager.addConnection) {
                                 // 使用 skipRender=true 避免重复渲染，recordHistory=false 避免记录历史
@@ -2417,7 +2478,7 @@
                                     console.log(`[CanvasManager] 🔧 Force added connection via global StateManager: ${connectionData.id}`);
                                 }
                             }
-                            
+
                             console.log(`[CanvasManager] ✅ Connection restored successfully: ${connectionData.sourceNodeId} -> ${connectionData.targetNodeId} (${connectionData.targetParam}) at ${Date.now()}`);
                         } else {
                             console.error('[CanvasManager] ❌ Failed to restore connection:', connectionData.id, '- jsPlumb.connect returned null');

--- a/VCPHumanToolBox/WorkflowEditormodules/WorkflowEditor_ExecutionEngine.js
+++ b/VCPHumanToolBox/WorkflowEditormodules/WorkflowEditor_ExecutionEngine.js
@@ -1,5 +1,5 @@
 // WorkflowEditor Execution Engine
-(function() {
+(function () {
     'use strict';
 
     class WorkflowEditor_ExecutionEngine {
@@ -7,7 +7,7 @@
             if (WorkflowEditor_ExecutionEngine.instance) {
                 return WorkflowEditor_ExecutionEngine.instance;
             }
-            
+
             this.stateManager = null;
             this.pluginManager = null;
             this.connectionManager = null; // 连接管理器
@@ -17,14 +17,14 @@
             this.nodeInputData = new Map(); // 存储节点输入数据
             this.executedNodes = new Set(); // 全局执行状态跟踪
             this.executingNodes = new Set(); // 正在执行的节点
-            
+
             // 从 settings.json 读取配置
             this.loadSettings();
-            
+
             WorkflowEditor_ExecutionEngine.instance = this;
             try {
                 console.log('[ExecutionEngine] URLRenderer router v2 loaded');
-            } catch (_) {}
+            } catch (_) { }
         }
 
         static getInstance() {
@@ -38,7 +38,7 @@
         init(stateManager, pluginManager) {
             this.stateManager = stateManager;
             this.pluginManager = pluginManager;
-            
+
             console.log('[ExecutionEngine] Initialized');
         }
 
@@ -46,7 +46,7 @@
         async loadSettings() {
             try {
                 const settings = await window.electronAPI.invoke('vcp-ht-get-settings');
-                
+
                 if (settings.vcpServerUrl) {
                     const url = new URL(settings.vcpServerUrl);
                     url.pathname = '/v1/human/tool';
@@ -54,7 +54,7 @@
                 }
                 this.VCP_API_KEY = settings.vcpApiKey || '';
                 this.USER_NAME = settings.userName || 'Human';
-                
+
                 console.log('[ExecutionEngine] Settings loaded successfully');
             } catch (error) {
                 console.error('[ExecutionEngine] Failed to load settings:', error);
@@ -77,17 +77,17 @@
             this.nodeInputData.clear();
             this.executedNodes.clear(); // 清空执行状态
             this.executingNodes.clear(); // 清空正在执行状态
-            
+
             try {
                 console.log('[ExecutionEngine] Starting workflow execution');
-                
+
                 // 获取所有节点和连接
                 const nodes = this.stateManager.getAllNodes();
-                
+
                 // 简化：直接从 StateManager 获取连接（单一数据源）
                 const connections = this.stateManager.getAllConnections();
                 console.log('[ExecutionEngine] 从 StateManager 获取连接:', connections.length);
-                
+
                 // 调试信息：输出连接详情
                 if (connections.length > 0) {
                     console.log('[ExecutionEngine] 连接详情:');
@@ -97,27 +97,59 @@
                 } else {
                     console.warn('[ExecutionEngine] ⚠️ 没有找到任何连接，请检查连接是否正确保存');
                 }
-                
+
+                // ===== 预飞行验证 =====
+                // 检查环形依赖
+                if (this.stateManager.hasCircularDependency()) {
+                    throw new Error('⚠️ 工作流存在环形依赖，请检查连线');
+                }
+
+                // 检查必需输入是否已连线
+                const preflightErrors = [];
+                nodes.forEach(node => {
+                    if (node.dynamicInputs && Array.isArray(node.dynamicInputs)) {
+                        node.dynamicInputs.forEach(input => {
+                            if (input.required) {
+                                // 检查这个必需输入是否有连线接入
+                                const hasConnection = connections.some(
+                                    conn => conn.targetNodeId === node.id && conn.targetParam === input.name
+                                );
+                                // 也检查节点配置里是否有默认值
+                                const hasDefault = node.config && node.config[input.name] !== undefined && node.config[input.name] !== '';
+                                if (!hasConnection && !hasDefault) {
+                                    preflightErrors.push(`节点"${node.name}"的必需输入"${input.name}"未连线且无默认值`);
+                                }
+                            }
+                        });
+                    }
+                });
+
+                if (preflightErrors.length > 0) {
+                    const errorMsg = '⚠️ 预飞行检查失败:\n' + preflightErrors.join('\n');
+                    console.error('[ExecutionEngine]', errorMsg);
+                    throw new Error(errorMsg);
+                }
+
+                console.log('[ExecutionEngine]✅ 预飞行验证通过');
+
                 // 构建执行图
                 const executionGraph = this.buildExecutionGraph(nodes, connections);
-                
+
                 // 找到起始节点（没有输入连接的节点）
                 const startNodes = this.findStartNodes(nodes, connections);
-                
+
                 if (startNodes.length === 0) {
                     throw new Error('未找到起始节点，请确保工作流有至少一个没有输入连接的节点');
                 }
-                
+
                 // 初始化节点输入数据
                 this.initializeNodeInputData(nodes);
-                
-                // 从起始节点开始执行
-                for (const startNode of startNodes) {
-                    await this.executeNodeChain(startNode, executionGraph);
-                }
-                
+
+                // 使用第一个起始节点触发执行（分层拓扑排序会覆盖全图）
+                await this.executeNodeChain(startNodes[0], executionGraph);
+
                 console.log('[ExecutionEngine] Workflow execution completed');
-                
+
             } catch (error) {
                 console.error('[ExecutionEngine] Workflow execution failed:', error);
                 throw error;
@@ -129,15 +161,15 @@
         // 构建执行图
         buildExecutionGraph(nodes, connections) {
             console.log(`[ExecutionEngine] 构建执行图 - 节点数: ${nodes.length}, 连接数: ${connections.length}`);
-            
+
             // 打印所有连接信息
             connections.forEach((connection, index) => {
                 console.log(`[ExecutionEngine] 连接 ${index + 1}: ${connection.sourceNodeId} -> ${connection.targetNodeId}`);
                 console.log(`[ExecutionEngine] 连接详情:`, connection);
             });
-            
+
             const graph = new Map();
-            
+
             // 初始化图节点
             nodes.forEach(node => {
                 graph.set(node.id, {
@@ -146,40 +178,40 @@
                     outputs: [] // 输出连接
                 });
             });
-            
+
             // 添加连接关系
             connections.forEach(connection => {
                 const sourceGraphNode = graph.get(connection.sourceNodeId);
                 const targetGraphNode = graph.get(connection.targetNodeId);
-                
+
                 console.log(`[ExecutionEngine] 处理连接: ${connection.sourceNodeId} -> ${connection.targetNodeId}`);
                 console.log(`[ExecutionEngine] 源节点存在: ${!!sourceGraphNode}, 目标节点存在: ${!!targetGraphNode}`);
-                
+
                 if (sourceGraphNode && targetGraphNode) {
                     sourceGraphNode.outputs.push({
                         targetNodeId: connection.targetNodeId,
                         targetPort: connection.targetPort,
                         connection: connection
                     });
-                    
+
                     targetGraphNode.inputs.push({
                         sourceNodeId: connection.sourceNodeId,
                         sourcePort: connection.sourcePort,
                         targetPort: connection.targetPort,
                         connection: connection
                     });
-                    
+
                     console.log(`[ExecutionEngine] ✓ 连接已添加到执行图`);
                 } else {
                     console.warn(`[ExecutionEngine] ✗ 连接无效，跳过: ${connection.sourceNodeId} -> ${connection.targetNodeId}`);
                 }
             });
-            
+
             // 打印最终的执行图结构
             graph.forEach((graphNode, nodeId) => {
                 console.log(`[ExecutionEngine] 节点 ${nodeId}: ${graphNode.inputs.length} 个输入, ${graphNode.outputs.length} 个输出`);
             });
-            
+
             return graph;
         }
 
@@ -189,7 +221,7 @@
             connections.forEach(conn => {
                 nodesWithInputs.add(conn.targetNodeId);
             });
-            
+
             return nodes.filter(node => !nodesWithInputs.has(node.id));
         }
 
@@ -197,151 +229,151 @@
         initializeNodeInputData(nodes) {
             nodes.forEach(node => {
                 const inputData = {};
-                
+
                 // 如果节点有动态输入参数，初始化这些参数
                 if (node.dynamicInputs && Array.isArray(node.dynamicInputs)) {
                     node.dynamicInputs.forEach(input => {
                         inputData[input.name] = null;
                     });
                 }
-                
+
                 this.nodeInputData.set(node.id, inputData);
             });
         }
 
-        // 执行节点链 - 使用拓扑排序避免循环依赖问题
+        // 执行节点链 - 使用分层拓扑排序 + 同层并行 + 错误策略
         async executeNodeChain(startNode, executionGraph) {
             console.log(`[ExecutionEngine] 开始执行节点链，起始节点: ${startNode.id}`);
-            console.log(`[ExecutionEngine] 执行图包含 ${executionGraph.size} 个节点`);
-            
-            // 打印执行图的连接信息
-            executionGraph.forEach((graphNode, nodeId) => {
-                console.log(`[ExecutionEngine] 节点 ${nodeId}: ${graphNode.inputs.length} 个输入, ${graphNode.outputs.length} 个输出`);
-                graphNode.inputs.forEach((input, i) => {
-                    console.log(`[ExecutionEngine]   输入 ${i + 1}: 来自节点 ${input.sourceNodeId}`);
-                });
-                graphNode.outputs.forEach((output, i) => {
-                    console.log(`[ExecutionEngine]   输出 ${i + 1}: 到节点 ${output.targetNodeId}`);
-                });
+
+            // 1. 获取分层拓扑排序结果
+            let layers;
+            if (this.stateManager && typeof this.stateManager.getExecutionLayers === 'function') {
+                layers = this.stateManager.getExecutionLayers();
+            }
+
+            if (!layers) {
+                // fallback: 如果分层排序不可用或有环，退回扁平拓扑排序
+                console.warn('[ExecutionEngine] 分层拓扑排序不可用，退回扁平顺序');
+                const flatOrder = this.stateManager.getExecutionOrder();
+                if (!flatOrder) {
+                    throw new Error('工作流存在循环依赖，无法执行');
+                }
+                layers = flatOrder.map(id => [id]); // 每层一个节点，串行执行
+            }
+
+            console.log(`[ExecutionEngine] 拓扑分层结果: ${layers.length} 层`);
+            layers.forEach((layer, i) => {
+                console.log(`[ExecutionEngine]   层 ${i}: [${layer.join(', ')}]`);
             });
-            
-            // 使用队列进行广度优先执行
-            const executionQueue = [startNode.id];
-            let maxIterations = executionGraph.size * 3; // 防止无限循环
-            let iterations = 0;
-            
-            while (executionQueue.length > 0 && iterations < maxIterations) {
-                iterations++;
-                const nodeId = executionQueue.shift();
-                
-                console.log(`[ExecutionEngine] 处理队列中的节点: ${nodeId} (迭代 ${iterations})`);
-                
-                // 跳过已执行的节点
-                if (this.executedNodes.has(nodeId)) {
-                    console.log(`[ExecutionEngine] 节点 ${nodeId} 已执行，跳过`);
-                    continue;
+
+            // 2. 按层逐层执行
+            const failedNodes = new Set(); // 记录失败的节点
+            const skippedNodes = new Set(); // 记录被跳过的节点
+
+            for (let layerIndex = 0; layerIndex < layers.length; layerIndex++) {
+                const layer = layers[layerIndex];
+                console.log(`[ExecutionEngine] === 执行第 ${layerIndex} 层: [${layer.join(', ')}]===`);
+
+                // 过滤掉需要跳过的节点（上游失败的）
+                const executableNodes = layer.filter(nodeId => {
+                    const graphNode = executionGraph.get(nodeId);
+                    if (!graphNode) return false;
+
+                    // 检查是否有上游节点失败
+                    const hasFailedUpstream = graphNode.inputs.some(
+                        input => failedNodes.has(input.sourceNodeId) || skippedNodes.has(input.sourceNodeId)
+                    );
+                    if (hasFailedUpstream) {
+                        const errorPolicy = graphNode.node.config?.errorPolicy || 'stop';
+                        if (errorPolicy === 'stop') {
+                            console.warn(`[ExecutionEngine] 节点 ${nodeId} 上游失败且策略为stop，跳过`);
+                            skippedNodes.add(nodeId);
+                            this.updateNodeStatus(nodeId, 'skipped');
+                            return false;
+                        }
+                        // errorPolicy === 'continue': 即使上游失败也尝试执行
+                    }
+                    return true;
+                });
+
+                if (executableNodes.length === 0) {
+                    console.log(`[ExecutionEngine] 第 ${layerIndex} 层无可执行节点，跳过`); continue;
                 }
-                
-                // 检查循环依赖
-                if (this.executingNodes.has(nodeId)) {
-                    console.warn(`[ExecutionEngine] 跳过正在执行的节点: ${nodeId}`);
-                    continue;
-                }
-                
-                const graphNode = executionGraph.get(nodeId);
-                if (!graphNode) {
-                    console.error(`[ExecutionEngine] 节点 ${nodeId} 不存在于执行图中`);
-                    continue;
-                }
-                
-                // 检查所有输入节点是否已执行（使用全局执行状态）
-                const allInputsReady = graphNode.inputs.length === 0 || 
-                    graphNode.inputs.every(input => {
-                        const ready = this.executedNodes.has(input.sourceNodeId);
-                        console.log(`[ExecutionEngine] 检查输入节点 ${input.sourceNodeId}: ${ready ? '已执行' : '未执行'}`);
-                        return ready;
-                    });
-                
-                console.log(`[ExecutionEngine] 节点 ${nodeId} 所有输入是否就绪: ${allInputsReady}`);
-                
-                if (!allInputsReady) {
-                    // 将节点重新加入队列末尾，等待输入节点执行完成
-                    console.log(`[ExecutionEngine] 节点 ${nodeId} 输入未就绪，重新加入队列`);
-                    executionQueue.push(nodeId);
-                    continue;
-                }
-                
-                // 新的统一数据传播机制下，数据已经在 propagateOutputData 中直接展开到顶层
-                // 不再需要单独的数据收集步骤
-                
-                // 检查是否所有必需参数都已准备好
-                if (this.areRequiredInputsReady(nodeId, graphNode.node)) {
-                    this.executingNodes.add(nodeId);
-                    
+
+                // 同层并行执行（Promise.allSettled 不会因单个失败中断）
+                const layerPromises = executableNodes.map(async (nodeId) => {
+                    const graphNode = executionGraph.get(nodeId);
+
+                    // 检查必需输入是否就绪
+                    if (!this.areRequiredInputsReady(nodeId, graphNode.node)) {
+                        console.log(`[ExecutionEngine] 节点 ${nodeId} 必需输入未就绪，标记跳过`);
+                        skippedNodes.add(nodeId);
+                        this.updateNodeStatus(nodeId, 'skipped');
+                        return { nodeId, status: 'skipped' };
+                    }
+
                     try {
-                        console.log(`[ExecutionEngine] 开始执行节点: ${nodeId}`);
-                        
-                        // 执行节点
+                        this.executingNodes.add(nodeId);
                         await this.executeNode(graphNode.node);
-                        
-                        console.log(`[ExecutionEngine] 节点 ${nodeId} 执行成功，开始传播数据`);
-                        
-                        // 传播输出数据到下游节点
                         this.propagateOutputData(nodeId, graphNode);
-                        
-                        // 将下游节点加入执行队列
-                        graphNode.outputs.forEach(output => {
-                            if (!this.executedNodes.has(output.targetNodeId) && !executionQueue.includes(output.targetNodeId)) {
-                                console.log(`[ExecutionEngine] 将下游节点加入队列: ${output.targetNodeId}`);
-                                executionQueue.push(output.targetNodeId);
-                            } else {
-                                console.log(`[ExecutionEngine] 下游节点 ${output.targetNodeId} 已在队列中或已执行`);
-                            }
-                        });
-                        
-                        this.executedNodes.add(nodeId);
-                        console.log(`[ExecutionEngine] 节点 ${nodeId} 执行完成`);
-                        
+                        this.executedNodes.add(nodeId); return { nodeId, status: 'success' };
                     } catch (error) {
                         console.error(`[ExecutionEngine] 节点 ${nodeId} 执行失败:`, error);
-                        throw error;
+                        failedNodes.add(nodeId);
+
+                        const errorPolicy = graphNode.node.config?.errorPolicy || 'stop';
+                        if (errorPolicy === 'stop') {
+                            throw error; // 向上抛出，中断整个工作流
+                        }
+                        // errorPolicy === 'continue': 记录错误但不中断
+                        return { nodeId, status: 'error', error: error.message };
                     } finally {
                         this.executingNodes.delete(nodeId);
                     }
-                } else {
-                    console.log(`[ExecutionEngine] 节点 ${nodeId} 必需输入未准备好，标记为已处理`);
-                    this.executedNodes.add(nodeId); // 标记为已处理，避免无限循环
+                });
+
+                // 等待本层所有节点完成
+                const layerResults = await Promise.allSettled(layerPromises);
+
+                // 检查是否有stop 策略的节点抛出了错误
+                for (const result of layerResults) {
+                    if (result.status === 'rejected') {
+                        // stop策略的错误会被reject，中断后续层
+                        throw result.reason;
+                    }
                 }
+
+                console.log(`[ExecutionEngine] 第 ${layerIndex} 层执行完成`);
             }
-            
-            if (iterations >= maxIterations) {
-                console.warn(`[ExecutionEngine] 达到最大迭代次数 ${maxIterations}，可能存在循环依赖`);
-            }
-            
-            console.log(`[ExecutionEngine] 节点链执行完成，已执行节点:`, Array.from(this.executedNodes));
+
+            // 3. 执行报告
+            console.log(`[ExecutionEngine] 节点链执行完成`);
+            console.log(`[ExecutionEngine]   成功: ${this.executedNodes.size} 个`);
+            console.log(`[ExecutionEngine]   失败: ${failedNodes.size} 个`);
+            console.log(`[ExecutionEngine]   跳过: ${skippedNodes.size} 个`);
         }
 
         // 收集输入数据
         collectInputData(nodeId, graphNode) {
             const inputData = this.nodeInputData.get(nodeId) || {};
-            
+
             console.log(`[ExecutionEngine] 开始收集节点 ${nodeId} 的输入数据`);
             console.log(`[ExecutionEngine] 节点有 ${graphNode.inputs.length} 个输入连接`);
-            
+
             graphNode.inputs.forEach(input => {
                 const sourceResult = this.nodeResults.get(input.sourceNodeId);
                 console.log(`[ExecutionEngine] 检查源节点 ${input.sourceNodeId} 的结果:`, sourceResult);
-                
+
                 if (sourceResult) {
                     // 解析JSON数据并支持字段访问
                     const processedData = this.processInputData(sourceResult);
-                    
+
                     // 确保目标参数名有效，避免undefined键
                     const targetParam = input.targetPort || input.connection?.targetParam || 'input';
-                    
+
                     console.log(`[ExecutionEngine] 收集输入数据: ${input.sourceNodeId} -> ${nodeId}, 参数: ${targetParam}`);
                     console.log(`[ExecutionEngine] 处理后的数据:`, processedData);
-                    
+
                     // 只有当目标参数名有效时才设置数据
                     if (targetParam && targetParam !== 'undefined') {
                         inputData[targetParam] = processedData;
@@ -353,7 +385,7 @@
                     console.warn(`[ExecutionEngine] 源节点 ${input.sourceNodeId} 没有结果数据`);
                 }
             });
-            
+
             console.log(`[ExecutionEngine] 收集完成，节点 ${nodeId} 的最终输入数据:`, inputData);
             this.nodeInputData.set(nodeId, inputData);
         }
@@ -362,46 +394,46 @@
         areRequiredInputsReady(nodeId, node) {
             const inputData = this.nodeInputData.get(nodeId) || {};
             const nodeConfig = node.config || {};
-            
+
             console.log(`[ExecutionEngine] 检查节点 ${nodeId} 的输入准备状态:`);
             console.log(`[ExecutionEngine] - 输入数据:`, inputData);
             console.log(`[ExecutionEngine] - 节点配置:`, nodeConfig);
             console.log(`[ExecutionEngine] - 动态输入:`, node.dynamicInputs);
-            
+
             // 如果没有动态输入参数，检查节点配置是否有必需的参数
             if (!node.dynamicInputs || !Array.isArray(node.dynamicInputs)) {
                 console.log(`[ExecutionEngine] 节点 ${nodeId} 没有动态输入，检查配置参数`);
-                
+
                 // 对于文件操作节点，检查基本配置
                 if (node.pluginId === 'FileOperator') {
                     // 如果配置中有url或从输入数据中获取到url，则认为准备就绪
                     const hasUrl = nodeConfig.url || inputData.url;
                     const hasDownloadDir = nodeConfig.downloadDir || inputData.downloadDir;
-                    
+
                     console.log(`[ExecutionEngine] FileOperator 节点检查: url=${hasUrl}, downloadDir=${hasDownloadDir}`);
-                    
+
                     if (!hasUrl && !hasDownloadDir) {
                         console.log(`[ExecutionEngine] FileOperator 节点缺少必要参数`);
                         return false;
                     }
                 }
-                
+
                 return true;
             }
-            
+
             // 检查所有必需参数是否都有数据
             for (const input of node.dynamicInputs) {
                 const hasInputData = inputData[input.name] !== null && inputData[input.name] !== undefined && inputData[input.name] !== '';
                 const hasConfigData = nodeConfig[input.name] !== null && nodeConfig[input.name] !== undefined && nodeConfig[input.name] !== '';
-                
+
                 console.log(`[ExecutionEngine] 检查参数 ${input.name}: required=${input.required}, hasInputData=${hasInputData}, hasConfigData=${hasConfigData}`);
-                
+
                 if (input.required && !hasInputData && !hasConfigData) {
                     console.log(`[ExecutionEngine] Node ${nodeId} waiting for required input: ${input.name}`);
                     return false;
                 }
             }
-            
+
             console.log(`[ExecutionEngine] 节点 ${nodeId} 所有必需输入已准备就绪`);
             return true;
         }
@@ -409,13 +441,13 @@
         // 执行单个节点
         async executeNode(node) {
             console.log(`[ExecutionEngine] Executing node: ${node.id} (${node.name})`);
-            
+
             // 更新节点状态为执行中
             this.updateNodeStatus(node.id, 'running');
-            
+
             try {
                 let result;
-                
+
                 if (node.category === 'auxiliary') {
                     // 辅助节点的处理
                     result = await this.executeAuxiliaryNode(node);
@@ -423,21 +455,21 @@
                     // 插件节点的处理
                     result = await this.executePluginNode(node);
                 }
-                
+
                 // 存储执行结果
                 this.nodeResults.set(node.id, result);
-                
+
                 // 更新节点状态为成功
                 this.updateNodeStatus(node.id, 'success');
-                
+
                 console.log(`[ExecutionEngine] Node ${node.id} executed successfully`);
-                
+
             } catch (error) {
                 console.error(`[ExecutionEngine] Node ${node.id} execution failed:`, error);
-                
+
                 // 更新节点状态为失败
                 this.updateNodeStatus(node.id, 'error');
-                
+
                 throw error;
             }
         }
@@ -445,7 +477,7 @@
         // 执行辅助节点
         async executeAuxiliaryNode(node) {
             const inputData = this.nodeInputData.get(node.id) || {};
-            
+
             switch (node.pluginId) {
                 case 'textDisplay':
                     return this.executeTextDisplayNode(node, inputData);
@@ -503,9 +535,9 @@
             const content = node.config && node.config.content !== undefined ? node.config.content : '';
             // 从节点配置中获取自定义输出参数名，如果未设置则默认为 'output'
             const outputParamName = node.config && node.config.outputParamName ? node.config.outputParamName : 'output';
-            
+
             console.log(`[ExecutionEngine] 内容输入器输出内容: ${content} (使用参数名: ${outputParamName})`);
-            
+
             // 使用自定义的参数名作为输出对象的键
             const result = {};
             result[outputParamName] = content;
@@ -515,19 +547,19 @@
         // 执行插件节点
         async executePluginNode(node) {
             const inputData = this.nodeInputData.get(node.id) || {};
-            
+
             console.log(`[ExecutionEngine] 开始执行插件节点 ${node.id} (${node.name})`);
             console.log(`[ExecutionEngine] 节点配置:`, node.config);
             console.log(`[ExecutionEngine] 输入数据:`, inputData);
-            
+
             // 合并节点配置和输入数据，支持数据引用解析
             const allParams = {};
-            
+
             // 先添加节点配置中的参数，支持模板变量解析
             if (node.config) {
                 for (const [key, value] of Object.entries(node.config)) {
                     const resolvedValue = this._resolveValue(value, inputData);
-                    
+
                     // 统一的数据传播机制下，解析结果应该是简单类型
                     if (typeof resolvedValue === 'object' && resolvedValue !== null) {
                         // 对于对象类型，JSON 字符串化
@@ -540,77 +572,77 @@
                     }
                 }
             }
-            
+
             // 数据传播的目的是为模板变量提供数据源
             // 一旦模板变量解析完成，就不需要再添加原始传播数据作为请求参数
             // 只使用节点配置中已经解析好的参数即可
-            
+
             console.log(`[ExecutionEngine] 使用节点配置参数，跳过原始传播数据的添加`);
             console.log(`[ExecutionEngine] 输入数据仅用于模板变量解析:`, Object.keys(inputData));
-            
+
             console.log(`[ExecutionEngine] 合并后的参数:`, allParams);
-            
+
             // 构建请求体，参考 renderer.js 的格式
             let requestBody = `<<<[TOOL_REQUEST]>>>\n`;
             const requestParams = [];
-            
+
             // 添加基础参数
             requestParams.push(`maid:「始」${this.USER_NAME}「末」`);
             requestParams.push(`tool_name:「始」${node.pluginId}「末」`);
-            
+
             // 智能命令匹配：根据节点配置和插件信息选择正确的命令
             let needsCommand = false;
             let commandToUse = null;
-            
+
             if (this.pluginManager) {
                 const pluginKey = `${node.category}_${node.pluginId}`;
                 const pluginInfo = this.pluginManager.getPluginInfo(pluginKey);
-                
+
                 if (pluginInfo && pluginInfo.commands && pluginInfo.commands.length > 0) {
                     console.log(`[ExecutionEngine] 插件 ${node.pluginId} 找到 ${pluginInfo.commands.length} 个命令`);
-                    
+
                     // 优先使用节点配置中的命令ID或名称
                     const nodeCommandId = node.config && node.config.command;
                     const nodeSelectedCommand = node.selectedCommand;
                     const nodeCommandIdFromNode = node.commandId;
-                    
+
                     console.log(`[ExecutionEngine] 节点命令配置: commandId=${nodeCommandId}, selectedCommand=${nodeSelectedCommand}, commandIdFromNode=${nodeCommandIdFromNode}`);
-                    
+
                     // 智能匹配命令
                     let matchedCommand = null;
-                    
+
                     // 1. 首先尝试通过命令ID精确匹配
                     if (nodeCommandId || nodeSelectedCommand || nodeCommandIdFromNode) {
                         const targetCommandId = nodeCommandId || nodeSelectedCommand || nodeCommandIdFromNode;
-                        
-                        matchedCommand = pluginInfo.commands.find(cmd => 
-                            cmd.id === targetCommandId || 
+
+                        matchedCommand = pluginInfo.commands.find(cmd =>
+                            cmd.id === targetCommandId ||
                             cmd.name === targetCommandId ||
                             cmd.command === targetCommandId
                         );
-                        
+
                         if (matchedCommand) {
                             console.log(`[ExecutionEngine] 通过命令ID匹配到命令: ${matchedCommand.name || matchedCommand.id}`);
                         }
                     }
-                    
+
                     // 2. 如果没有匹配到，尝试通过参数匹配
                     if (!matchedCommand) {
                         console.log(`[ExecutionEngine] 尝试通过参数匹配命令`);
-                        
+
                         // 分析节点配置中的参数，找到最匹配的命令
                         const nodeParams = node.config || {};
                         const paramKeys = Object.keys(nodeParams);
-                        
+
                         console.log(`[ExecutionEngine] 节点参数: ${paramKeys.join(', ')}`);
-                        
+
                         // 为每个命令计算匹配度
                         let bestMatch = null;
                         let bestScore = 0;
-                        
+
                         for (const cmd of pluginInfo.commands) {
                             let score = 0;
-                            
+
                             // 检查命令的参数是否与节点参数匹配
                             if (cmd.parameters && Array.isArray(cmd.parameters)) {
                                 for (const param of cmd.parameters) {
@@ -619,51 +651,51 @@
                                     }
                                 }
                             }
-                            
+
                             // 检查命令名称是否与插件ID相关
                             if (cmd.name && cmd.name.toLowerCase().includes(node.pluginId.toLowerCase())) {
                                 score += 0.5;
                             }
-                            
+
                             console.log(`[ExecutionEngine] 命令 ${cmd.name || cmd.id} 匹配度: ${score}`);
-                            
+
                             if (score > bestScore) {
                                 bestScore = score;
                                 bestMatch = cmd;
                             }
                         }
-                        
+
                         if (bestMatch && bestScore > 0) {
                             matchedCommand = bestMatch;
                             console.log(`[ExecutionEngine] 通过参数匹配选择命令: ${bestMatch.name || bestMatch.id} (匹配度: ${bestScore})`);
                         }
                     }
-                    
+
                     // 3. 如果还是没有匹配到，使用第一个命令作为默认
                     if (!matchedCommand) {
                         matchedCommand = pluginInfo.commands[0];
                         console.log(`[ExecutionEngine] 使用默认命令: ${matchedCommand.name || matchedCommand.id}`);
                     }
-                    
+
                     // 设置命令信息
                     needsCommand = matchedCommand.needsCommand || false;
-                    
+
                     if (needsCommand) {
                         // 优先使用匹配到的命令的command，然后使用节点配置
-                        commandToUse = matchedCommand.command || 
-                                     (node.config && node.config.command) || 
-                                     node.selectedCommand || 
-                                     node.commandId ||
-                                     matchedCommand.name ||
-                                     matchedCommand.id;
+                        commandToUse = matchedCommand.command ||
+                            (node.config && node.config.command) ||
+                            node.selectedCommand ||
+                            node.commandId ||
+                            matchedCommand.name ||
+                            matchedCommand.id;
                     }
-                    
+
                     console.log(`[ExecutionEngine] 最终选择 - 插件 ${node.pluginId} needsCommand: ${needsCommand}, command: ${commandToUse}`);
                 } else {
                     console.log(`[ExecutionEngine] 未找到插件 ${pluginKey} 的信息，跳过command参数`);
                 }
             }
-            
+
             // 只有需要command参数的插件才添加command参数
             if (needsCommand && commandToUse) {
                 requestParams.push(`command:「始」${commandToUse}「末」`);
@@ -671,11 +703,11 @@
             } else {
                 console.log(`[ExecutionEngine] 节点 ${node.id} (${node.pluginId}) 不需要command参数`);
             }
-            
+
             // 添加所有参数（配置 + 输入数据）
             for (const [key, value] of Object.entries(allParams)) {
                 // 确保值不是 null, undefined 或空字符串，除非插件明确需要空值
-                if (value !== null && value !== undefined && value !== '') { 
+                if (value !== null && value !== undefined && value !== '') {
                     const valueStr = typeof value === 'object' ? JSON.stringify(value) : String(value);
                     requestParams.push(`${key}:「始」${valueStr}「末」`);
                     console.log(`[ExecutionEngine] 添加参数 ${key}: ${valueStr}`);
@@ -683,7 +715,7 @@
                     console.log(`[ExecutionEngine] 参数 ${key} 的值为 ${value}，跳过添加`);
                 }
             }
-            
+
             // 构建最终请求体，最后一个参数不加逗号
             for (let i = 0; i < requestParams.length; i++) {
                 if (i === requestParams.length - 1) {
@@ -694,16 +726,16 @@
                     requestBody += `${requestParams[i]},\n`;
                 }
             }
-            
+
             requestBody += `<<<[END_TOOL_REQUEST]>>>`;
-            
+
             console.log(`[ExecutionEngine] 完整请求体:`, requestBody);
             console.log(`[ExecutionEngine] 请求URL: ${this.VCP_SERVER_URL}`);
-            
+
             // 发送请求
             const startTime = Date.now();
             console.log(`[ExecutionEngine] 发送请求到服务器...`);
-            
+
             const response = await fetch(this.VCP_SERVER_URL, {
                 method: 'POST',
                 headers: {
@@ -712,15 +744,15 @@
                 },
                 body: requestBody
             });
-            
+
             const endTime = Date.now();
             console.log(`[ExecutionEngine] 请求耗时: ${endTime - startTime}ms`);
             console.log(`[ExecutionEngine] 响应状态: ${response.status} ${response.statusText}`);
             console.log(`[ExecutionEngine] 响应头:`, Object.fromEntries(response.headers.entries()));
-            
+
             const responseText = await response.text();
             console.log(`[ExecutionEngine] 原始响应文本:`, responseText);
-            
+
             if (!response.ok) {
                 console.error(`[ExecutionEngine] 请求失败: HTTP ${response.status}`);
                 try {
@@ -732,7 +764,7 @@
                     throw new Error(`HTTP ${response.status}: ${responseText}`);
                 }
             }
-            
+
             let data;
             try {
                 data = JSON.parse(responseText);
@@ -742,11 +774,11 @@
                 console.log(`[ExecutionEngine] 将响应文本作为结果返回`);
                 return responseText;
             }
-            
+
             // 直接使用插件输出，不进行过滤 - 保持数据流透明
             let result = data;
             console.log(`[ExecutionEngine] 插件原始输出:`, result);
-            
+
             // 如果数据有特定的结构，尝试提取有用的信息
             if (data.result && typeof data.result.content === 'string') {
                 console.log(`[ExecutionEngine] 尝试解析 result.content:`, data.result.content);
@@ -760,7 +792,7 @@
                     result = data;
                 }
             }
-            
+
             // 添加执行元数据，但不影响原始数据
             if (result && typeof result === 'object') {
                 result._metadata = {
@@ -769,7 +801,7 @@
                     executionId: this.executionId || 'unknown'
                 };
             }
-            
+
             // 检查结果中是否包含错误信息
             if (result && typeof result === 'object') {
                 if (result.error) {
@@ -785,7 +817,7 @@
                     console.log(`[ExecutionEngine] 插件数据:`, result.data);
                 }
             }
-            
+
             console.log(`[ExecutionEngine] 节点 ${node.id} 执行完成，返回结果:`, result);
             return result;
         }
@@ -794,16 +826,16 @@
         executeRegexNode(node, inputData) {
             const config = node.config || {};
             const { pattern, flags = 'g', operation = 'match', replacement = '' } = config;
-            
+
             // 从输入数据中提取文本内容
             let text = '';
             if (inputData.input && typeof inputData.input === 'object') {
                 // 如果输入是对象，尝试提取文本内容
-                text = inputData.input.original_plugin_output || 
-                       inputData.input.text || 
-                       inputData.input.content || 
-                       inputData.input.message ||
-                       JSON.stringify(inputData.input);
+                text = inputData.input.original_plugin_output ||
+                    inputData.input.text ||
+                    inputData.input.content ||
+                    inputData.input.message ||
+                    JSON.stringify(inputData.input);
             } else if (inputData.input) {
                 text = String(inputData.input);
             } else if (inputData.text) {
@@ -812,14 +844,14 @@
                 // 如果没有找到文本，将整个输入转为字符串
                 text = JSON.stringify(inputData);
             }
-            
+
             if (!pattern) {
                 throw new Error('正则表达式节点需要 pattern 参数');
             }
-            
+
             console.log(`[ExecutionEngine] 正则处理 - 文本: ${text.substring(0, 100)}...`);
             console.log(`[ExecutionEngine] 正则处理 - 模式: ${pattern}`);
-            
+
             try {
                 const regex = new RegExp(pattern, flags);
                 let result;
@@ -839,25 +871,25 @@
                             }
                             if (!flags.includes('g')) break;
                         }
-                        
+
                         return {
                             matches: matches,
                             output: captureGroups, // 返回捕获组内容
                             text: text
                         };
-                    
+
                     case 'replace':
                         result = text.replace(regex, replacement);
                         return { output: result };
-                    
+
                     case 'test':
                         result = regex.test(text);
                         return { output: result };
-                    
+
                     case 'split':
                         result = text.split(regex);
                         return { output: result };
-                    
+
                     default:
                         result = text.match(regex);
                         return { output: result || [], matches: result || [] };
@@ -871,30 +903,30 @@
         executeDataTransformNode(node, inputData) {
             console.log('[ExecutionEngine] 数据转换 - 输入数据:', inputData);
             console.log('[ExecutionEngine] 数据转换 - 节点配置:', node.config);
-            
+
             const { transformType, customScript, outputParamName } = node.config || {};
             let result;
-            
+
             try {
                 if (transformType === 'custom' && customScript) {
                     // 自定义脚本转换 - 将所有输入数据作为变量传递给脚本
                     const scriptVars = Object.keys(inputData);
                     const scriptValues = Object.values(inputData);
-                    
+
                     console.log('[ExecutionEngine] 执行自定义脚本，可用变量:', scriptVars);
-                    
+
                     // 创建函数，将所有输入数据作为参数传递
                     const func = new Function(...scriptVars, customScript);
                     result = func(...scriptValues);
-                    
+
                     console.log('[ExecutionEngine] 自定义脚本执行结果:', result);
                 } else {
                     // 默认转换：如果有 data 参数则使用，否则使用第一个输入参数
                     const dataKey = inputData.data !== undefined ? 'data' : Object.keys(inputData)[0];
                     const data = inputData[dataKey];
-                    
+
                     console.log('[ExecutionEngine] 默认转换，使用参数:', dataKey, '值:', data);
-                    
+
                     switch (transformType) {
                         case 'json':
                             result = typeof data === 'string' ? JSON.parse(data) : data;
@@ -909,14 +941,14 @@
                             result = data;
                     }
                 }
-                
+
                 // 使用自定义输出参数名或默认的 'result'
                 const outputKey = outputParamName || 'result';
                 const output = { [outputKey]: result };
-                
+
                 console.log('[ExecutionEngine] 数据转换完成，输出:', output);
                 return output;
-                
+
             } catch (error) {
                 console.error('[ExecutionEngine] 数据转换执行失败:', error);
                 throw new Error(`数据转换失败: ${error.message}`);
@@ -928,10 +960,10 @@
             console.log('[ExecutionEngine] 执行代码编辑节点:', node.id);
             console.log('[ExecutionEngine] 输入数据:', inputData);
             console.log('[ExecutionEngine] 节点配置:', node.config);
-            
+
             const config = node.config || {};
             const { language = 'javascript', code = '', operation = 'format' } = config;
-            
+
             // 获取输入内容
             let inputContent = '';
             if (inputData.input !== undefined) {
@@ -945,26 +977,26 @@
             } else if (code) {
                 inputContent = code;
             }
-            
+
             console.log('[ExecutionEngine] 代码编辑 - 输入内容:', inputContent.substring(0, 200) + '...');
             console.log('[ExecutionEngine] 代码编辑 - 语言:', language, '操作:', operation);
-            
+
             try {
                 let result;
-                
+
                 switch (operation) {
                     case 'format':
                         result = this.formatCode(inputContent, language);
                         break;
-                    
+
                     case 'minify':
                         result = this.minifyCode(inputContent, language);
                         break;
-                    
+
                     case 'validate':
                         result = this.validateCode(inputContent, language);
                         break;
-                    
+
                     case 'execute':
                         if (language === 'javascript') {
                             try {
@@ -983,17 +1015,17 @@
                             throw new Error(`不支持执行 ${language} 代码`);
                         }
                         break;
-                    
+
                     default:
                         result = inputContent;
                 }
-                
+
                 console.log('[ExecutionEngine] 代码编辑结果:', result);
-                
+
                 // 使用自定义输出参数名
                 const outputParamName = config.outputParamName || 'output';
                 return { [outputParamName]: result };
-                
+
             } catch (error) {
                 console.error('[ExecutionEngine] 代码编辑执行失败:', error);
                 throw new Error(`代码编辑失败: ${error.message}`);
@@ -1005,21 +1037,21 @@
             console.log('[ExecutionEngine] 执行条件判断节点:', node.id);
             console.log('[ExecutionEngine] 输入数据:', inputData);
             console.log('[ExecutionEngine] 节点配置:', node.config);
-            
+
             const config = node.config || {};
             const { condition, operator = '==', value = '' } = config;
-            
+
             // 获取输入值
             let inputValue = inputData.input;
             if (inputValue === undefined && Object.keys(inputData).length > 0) {
                 inputValue = Object.values(inputData)[0]; // 使用第一个输入值
             }
-            
+
             console.log('[ExecutionEngine] 条件判断 - 输入值:', inputValue, '操作符:', operator, '比较值:', value);
-            
+
             try {
                 let result = false;
-                
+
                 switch (operator) {
                     case '==':
                         result = inputValue == value;
@@ -1055,16 +1087,16 @@
                             result = func(inputValue, value);
                         }
                 }
-                
+
                 console.log('[ExecutionEngine] 条件判断结果:', result);
-                
+
                 // 根据结果返回到不同的输出端口
                 if (result) {
                     return { true: inputValue, result: true };
                 } else {
                     return { false: inputValue, result: false };
                 }
-                
+
             } catch (error) {
                 console.error('[ExecutionEngine] 条件判断执行失败:', error);
                 throw new Error(`条件判断失败: ${error.message}`);
@@ -1076,13 +1108,13 @@
             console.log('[ExecutionEngine] 执行循环控制节点:', node.id);
             console.log('[ExecutionEngine] 输入数据:', inputData);
             console.log('[ExecutionEngine] 节点配置:', node.config);
-            
+
             const config = node.config || {};
             const { loopType = 'forEach', maxIterations = 100 } = config;
-            
+
             let items = [];
             let inputValue = inputData.input;
-            
+
             // 获取循环项目
             if (inputData.items && Array.isArray(inputData.items)) {
                 items = inputData.items;
@@ -1091,13 +1123,13 @@
             } else if (inputValue !== undefined) {
                 items = [inputValue]; // 单个值转为数组
             }
-            
+
             console.log('[ExecutionEngine] 循环控制 - 类型:', loopType, '项目数:', items.length, '最大迭代:', maxIterations);
-            
+
             try {
                 const results = [];
                 let iterations = Math.min(items.length, maxIterations);
-                
+
                 switch (loopType) {
                     case 'forEach':
                         for (let i = 0; i < iterations; i++) {
@@ -1108,7 +1140,7 @@
                             });
                         }
                         break;
-                    
+
                     case 'times':
                         const times = Math.min(Number(inputValue) || 1, maxIterations);
                         for (let i = 0; i < times; i++) {
@@ -1119,7 +1151,7 @@
                             });
                         }
                         break;
-                    
+
                     case 'while':
                         // 简单的while循环实现
                         let count = 0;
@@ -1139,15 +1171,15 @@
                         }
                         break;
                 }
-                
+
                 console.log('[ExecutionEngine] 循环控制结果:', results.length, '项');
-                
+
                 return {
                     output: results,
                     items: results.map(r => r.item),
                     count: results.length
                 };
-                
+
             } catch (error) {
                 console.error('[ExecutionEngine] 循环控制执行失败:', error);
                 throw new Error(`循环控制失败: ${error.message}`);
@@ -1159,10 +1191,10 @@
             console.log('[ExecutionEngine] 执行延时等待节点:', node.id);
             console.log('[ExecutionEngine] 输入数据:', inputData);
             console.log('[ExecutionEngine] 节点配置:', node.config);
-            
+
             const config = node.config || {};
             const { delay = 1000, unit = 'milliseconds' } = config;
-            
+
             let delayMs = delay;
             switch (unit) {
                 case 'seconds':
@@ -1172,11 +1204,11 @@
                     delayMs = delay * 60 * 1000;
                     break;
             }
-            
+
             console.log('[ExecutionEngine] 延时等待:', delayMs, 'ms');
-            
+
             await new Promise(resolve => setTimeout(resolve, delayMs));
-            
+
             // 返回输入数据
             return { output: inputData.input || inputData };
         }
@@ -1186,7 +1218,7 @@
             console.log('[ExecutionEngine] 执行URL提取器节点:', node.id);
             console.log('[ExecutionEngine] 输入数据:', inputData);
             console.log('[ExecutionEngine] 节点配置:', node.config);
-            
+
             // 调用NodeManager中的URL提取器实现
             if (window.WorkflowEditor_NodeManager && window.WorkflowEditor_NodeManager.executeUrlExtractorNode) {
                 try {
@@ -1207,7 +1239,7 @@
             console.log('[ExecutionEngine] 执行图片上传节点:', node.id);
             console.log('[ExecutionEngine] 输入数据:', inputData);
             console.log('[ExecutionEngine] 节点配置:', node.config);
-            
+
             // 调用NodeManager中的图片上传节点实现
             if (window.WorkflowEditor_NodeManager && window.WorkflowEditor_NodeManager.executeImageUploadNode) {
                 try {
@@ -1230,7 +1262,7 @@
                     case 'json':
                         const parsed = JSON.parse(code);
                         return JSON.stringify(parsed, null, 2);
-                    
+
                     case 'javascript':
                         // 简单的JavaScript格式化
                         return code
@@ -1242,13 +1274,13 @@
                             .map(line => line.trim())
                             .filter(line => line.length > 0)
                             .join('\n');
-                    
+
                     case 'html':
                         // 简单的HTML格式化
                         return code
                             .replace(/></g, '>\n<')
                             .replace(/^\s+|\s+$/g, '');
-                    
+
                     case 'css':
                         // 简单的CSS格式化
                         return code
@@ -1256,7 +1288,7 @@
                             .replace(/}/g, '\n}\n')
                             .replace(/;/g, ';\n')
                             .replace(/,/g, ',\n');
-                    
+
                     default:
                         return code;
                 }
@@ -1273,7 +1305,7 @@
                     case 'json':
                         const parsed = JSON.parse(code);
                         return JSON.stringify(parsed);
-                    
+
                     case 'javascript':
                         // 简单的JavaScript压缩
                         return code
@@ -1282,7 +1314,7 @@
                             .replace(/{\s/g, '{')
                             .replace(/\s}/g, '}')
                             .trim();
-                    
+
                     case 'css':
                         // 简单的CSS压缩
                         return code
@@ -1291,7 +1323,7 @@
                             .replace(/{\s/g, '{')
                             .replace(/\s}/g, '}')
                             .trim();
-                    
+
                     default:
                         return code.replace(/\s+/g, ' ').trim();
                 }
@@ -1308,11 +1340,11 @@
                     case 'json':
                         JSON.parse(code);
                         return { valid: true, message: 'JSON格式正确' };
-                    
+
                     case 'javascript':
                         new Function(code);
                         return { valid: true, message: 'JavaScript语法正确' };
-                    
+
                     case 'html':
                         // 简单的HTML验证
                         const parser = new DOMParser();
@@ -1322,7 +1354,7 @@
                             return { valid: false, message: 'HTML格式错误' };
                         }
                         return { valid: true, message: 'HTML格式正确' };
-                    
+
                     default:
                         return { valid: true, message: '语法检查不可用' };
                 }
@@ -1336,7 +1368,7 @@
             console.log(`[ExecutionEngine] 执行URL渲染器节点:`, node.id);
             console.log(`[ExecutionEngine] 节点配置:`, node.config);
             console.log(`[ExecutionEngine] 输入数据:`, inputData);
-            
+
             // 检查是否有批量渲染补丁可用
             if (window.WorkflowEditor_NodeManager && typeof window.WorkflowEditor_NodeManager.executeUrlRendererNode === 'function') {
                 console.log('[ExecutionEngine] 使用唯一URL渲染入口 (NodeManager.executeUrlRendererNode)');
@@ -1346,11 +1378,11 @@
                     inputData
                 );
             }
-            
+
             // 后备方案（理论上不会再走到这里）
             const config = node.config || {};
             let { urlPath = 'imageUrl', renderType = 'image' } = node.config || {};
-            
+
             // 对 urlPath 进行变量解析
             console.log(`[ExecutionEngine] URL渲染器 - 原始urlPath: ${urlPath}`);
             const resolvedUrlPath = this._resolveValue(urlPath, inputData);
@@ -1358,12 +1390,12 @@
 
             // 从输入数据或配置中获取URL
             let url = null;
-            
+
             // 检查解析后的结果类型
             if (Array.isArray(resolvedUrlPath)) {
                 // 如果解析结果是数组，说明 {{input.images}} 被解析成了数组
                 console.log(`[ExecutionEngine] 检测到数组数据，尝试提取第一个URL`);
-                
+
                 // 尝试从数组中提取URL
                 for (const item of resolvedUrlPath) {
                     if (typeof item === 'string' && (item.startsWith('http://') || item.startsWith('https://'))) {
@@ -1374,14 +1406,14 @@
                         if (url) break;
                     }
                 }
-                
+
                 console.log(`[ExecutionEngine] 从数组中提取的URL: ${url}`);
-            } 
+            }
             // 检查解析后的 urlPath 是否直接是一个URL字符串
             else if (resolvedUrlPath && (typeof resolvedUrlPath === 'string') && (resolvedUrlPath.startsWith('http://') || resolvedUrlPath.startsWith('https://'))) {
                 url = resolvedUrlPath;
                 console.log(`[ExecutionEngine] 从解析后的 urlPath 中获取URL: ${url}`);
-            } 
+            }
             // 否则，尝试从 inputData 中提取
             else if (inputData.input && typeof inputData.input === 'object') {
                 // 如果 urlPath 仍然是字符串路径，使用它来提取数据
@@ -1401,18 +1433,18 @@
                 url = this._resolveValue(node.config.url, inputData);
                 console.log(`[ExecutionEngine] 从配置url字段获取: ${url}`);
             }
-            
+
             console.log(`[ExecutionEngine] 最终提取的URL:`, url);
-            
+
             if (!url) {
                 console.warn(`[ExecutionEngine] URL渲染器未找到有效的URL`);
                 return { error: '未找到有效的URL进行渲染' };
             }
-            
+
             // 根据渲染类型生成相应的HTML内容
             let htmlContent = '';
             let actualRenderType = renderType;
-            
+
             // 处理 auto 类型：根据URL自动判断渲染方式
             if (renderType === 'auto') {
                 if (url.match(/\.(jpg|jpeg|png|gif|bmp|webp|svg)(\?.*)?$/i)) {
@@ -1424,7 +1456,7 @@
                 }
                 console.log(`[ExecutionEngine] Auto模式检测到渲染类型: ${actualRenderType}`);
             }
-            
+
             switch (actualRenderType) {
                 case 'image':
                     htmlContent = `<img src="${url}" alt="渲染图片" style="max-width: ${width}px; max-height: ${height}px;" />`;
@@ -1438,10 +1470,10 @@
                 default:
                     htmlContent = `<div>URL: <a href="${url}" target="_blank">${url}</a></div>`;
             }
-            
+
             // 更新节点的显示内容
             console.log(`[ExecutionEngine] 尝试更新节点 ${node.id} 的显示内容`);
-            
+
             // 尝试多种选择器来找到节点元素
             let nodeElement = document.querySelector(`[data-node-id="${node.id}"] .node-content`);
             if (!nodeElement) {
@@ -1453,10 +1485,10 @@
             if (!nodeElement) {
                 nodeElement = document.querySelector(`#${node.id}`);
             }
-            
+
             if (nodeElement) {
                 console.log(`[ExecutionEngine] 找到节点元素，更新内容:`, htmlContent);
-                
+
                 // 如果是 .node-content 元素，直接设置内容
                 if (nodeElement.classList.contains('node-content')) {
                     nodeElement.innerHTML = htmlContent;
@@ -1475,18 +1507,18 @@
                     }
                     contentElement.innerHTML = htmlContent;
                 }
-                
+
                 console.log(`[ExecutionEngine] 节点 ${node.id} 显示内容已更新`);
             } else {
                 console.warn(`[ExecutionEngine] 未找到节点 ${node.id} 的DOM元素`);
-                
+
                 // 尝试通过 stateManager 更新节点
                 if (this.stateManager && this.stateManager.updateNodeContent) {
                     console.log(`[ExecutionEngine] 尝试通过 stateManager 更新节点内容`);
                     this.stateManager.updateNodeContent(node.id, htmlContent);
                 }
             }
-            
+
             return {
                 success: true,
                 url: url,
@@ -1498,7 +1530,7 @@
         // 执行文本显示节点
         executeTextDisplayNode(node, inputData) {
             console.log(`[ExecutionEngine] 执行文本显示节点:`, node.id);
-            
+
             let text = '';
             if (inputData.input && typeof inputData.input === 'object') {
                 text = inputData.input.text || inputData.input.message || JSON.stringify(inputData.input);
@@ -1507,7 +1539,7 @@
             } else if (inputData.message) {
                 text = inputData.message;
             }
-            
+
             // 更新节点显示
             if (this.stateManager) {
                 const nodeElement = document.querySelector(`[data-node-id="${node.id}"] .node-content`);
@@ -1515,14 +1547,14 @@
                     nodeElement.textContent = text;
                 }
             }
-            
+
             return { success: true, text: text };
         }
 
         // 执行图片显示节点
         executeImageDisplayNode(node, inputData) {
             console.log(`[ExecutionEngine] 执行图片显示节点:`, node.id);
-            
+
             let imageUrl = '';
             if (inputData.input && typeof inputData.input === 'object') {
                 imageUrl = inputData.input.imageUrl || inputData.input.url;
@@ -1531,7 +1563,7 @@
             } else if (inputData.url) {
                 imageUrl = inputData.url;
             }
-            
+
             if (imageUrl) {
                 // 生成包含复制和下载功能的完整HTML结构
                 const imgHtml = `
@@ -1551,19 +1583,19 @@
                         </div>
                     </div>
                 `;
-                
+
                 // 更新节点显示
                 if (this.stateManager) {
                     const nodeElement = document.querySelector(`[data-node-id="${node.id}"] .node-content`);
                     if (nodeElement) {
                         nodeElement.innerHTML = imgHtml;
-                        
+
                         // 添加事件监听器
                         this.addImageControlsEventListeners(nodeElement, imageUrl);
                     }
                 }
             }
-            
+
             return { success: true, imageUrl: imageUrl };
         }
 
@@ -1571,14 +1603,14 @@
         addImageControlsEventListeners(nodeElement, imageUrl) {
             const copyBtn = nodeElement.querySelector('.copy-image-btn');
             const downloadBtn = nodeElement.querySelector('.download-image-btn');
-            
+
             if (copyBtn) {
                 copyBtn.addEventListener('click', async (e) => {
                     e.stopPropagation();
                     await this.copyImageToClipboard(imageUrl, copyBtn);
                 });
             }
-            
+
             if (downloadBtn) {
                 downloadBtn.addEventListener('click', (e) => {
                     e.stopPropagation();
@@ -1601,7 +1633,7 @@
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
-                
+
                 let blob = await response.blob();
                 let finalBlobType = blob.type || 'image/png';
 
@@ -1625,18 +1657,18 @@
                 const item = new ClipboardItem({ [finalBlobType]: blob });
                 await navigator.clipboard.write([item]);
                 console.log('ExecutionEngine: Image copied to clipboard as', finalBlobType);
-                
+
                 this.showButtonFeedback(button, `
                     <svg viewBox="0 0 24 24" style="width: 14px; height: 14px; fill: currentColor;">
                         <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
                     </svg>
                 `, 'success');
-                
+
             } catch (err) {
                 console.error('ExecutionEngine: Failed to copy image -', err);
                 this.showButtonFeedback(button, '复制失败', 'error');
             }
-            
+
             // 恢复原始按钮内容
             setTimeout(() => {
                 button.innerHTML = originalButtonHTML;
@@ -1653,24 +1685,24 @@
             try {
                 const link = document.createElement('a');
                 link.href = imageUrl;
-                
+
                 // 从URL中提取文件名
                 let filename = 'downloaded_image';
                 const urlFilename = imageUrl.substring(imageUrl.lastIndexOf('/') + 1).split('?')[0];
                 const urlExtensionMatch = urlFilename.match(/\.(jpe?g|png|gif|webp|svg)$/i);
-                
+
                 if (urlExtensionMatch) {
                     filename = urlFilename;
                 } else {
                     filename += '.png'; // 默认扩展名
                 }
-                
+
                 link.download = filename;
                 link.style.display = 'none';
                 document.body.appendChild(link);
                 link.click();
                 document.body.removeChild(link);
-                
+
                 console.log('ExecutionEngine: Image download initiated:', filename);
             } catch (err) {
                 console.error('ExecutionEngine: Failed to download image -', err);
@@ -1681,13 +1713,13 @@
         showButtonFeedback(button, content, type) {
             const originalContent = button.innerHTML;
             button.innerHTML = content;
-            
+
             if (type === 'success') {
                 button.style.background = 'rgba(0,128,0,0.8)';
             } else if (type === 'error') {
                 button.style.background = 'rgba(255,0,0,0.8)';
             }
-            
+
             setTimeout(() => {
                 button.innerHTML = originalContent;
                 button.style.background = 'rgba(0,0,0,0.7)';
@@ -1697,7 +1729,7 @@
         // 执行HTML显示节点
         executeHtmlDisplayNode(node, inputData) {
             console.log(`[ExecutionEngine] 执行HTML显示节点:`, node.id);
-            
+
             let htmlContent = '';
             if (inputData.input && typeof inputData.input === 'object') {
                 htmlContent = inputData.input.html || inputData.input.htmlContent || inputData.input.content;
@@ -1706,7 +1738,7 @@
             } else if (inputData.htmlContent) {
                 htmlContent = inputData.htmlContent;
             }
-            
+
             // 更新节点显示
             if (this.stateManager) {
                 const nodeElement = document.querySelector(`[data-node-id="${node.id}"] .node-content`);
@@ -1714,17 +1746,17 @@
                     nodeElement.innerHTML = htmlContent;
                 }
             }
-            
+
             return { success: true, htmlContent: htmlContent };
         }
 
         // 执行JSON显示节点
         executeJsonDisplayNode(node, inputData) {
             console.log(`[ExecutionEngine] 执行JSON显示节点:`, node.id);
-            
+
             let jsonData = inputData.input || inputData;
             const jsonString = JSON.stringify(jsonData, null, 2);
-            
+
             // 更新节点显示
             if (this.stateManager) {
                 const nodeElement = document.querySelector(`[data-node-id="${node.id}"] .node-content`);
@@ -1732,7 +1764,7 @@
                     nodeElement.innerHTML = `<pre>${jsonString}</pre>`;
                 }
             }
-            
+
             return { success: true, jsonData: jsonData };
         }
 
@@ -1742,18 +1774,18 @@
             const sourceNode = graphNode.node;
             console.log(`[ExecutionEngine] 传播节点 ${nodeId} 的输出数据:`, result);
             console.log(`[ExecutionEngine] 节点有 ${graphNode.outputs.length} 个输出连接`);
-            
+
             if (graphNode.outputs.length === 0) {
                 console.log(`[ExecutionEngine] 节点 ${nodeId} 没有输出连接，跳过数据传播`);
                 return;
             }
-            
+
             graphNode.outputs.forEach((output, index) => {
                 console.log(`[ExecutionEngine] 处理输出连接 ${index + 1}:`, output);
-                
+
                 const targetInputData = this.nodeInputData.get(output.targetNodeId) || {};
                 console.log(`[ExecutionEngine] 目标节点 ${output.targetNodeId} 当前输入数据:`, targetInputData);
-                
+
                 // 统一的数据传播逻辑
                 if (sourceNode.category === 'auxiliary') {
                     // 辅助节点：已经按照自定义输出名格式化了数据，直接展开到顶层
@@ -1774,10 +1806,10 @@
                         console.log(`[ExecutionEngine] 插件节点非对象结果，使用默认键名 'result':`, result);
                     }
                 }
-                
+
                 this.nodeInputData.set(output.targetNodeId, targetInputData);
                 console.log(`[ExecutionEngine] 节点 ${output.targetNodeId} 更新后的输入数据:`, targetInputData);
-                
+
                 // 检查目标节点是否现在可以执行
                 const targetNode = this.stateManager.getNode(output.targetNodeId);
                 if (targetNode && this.areRequiredInputsReady(output.targetNodeId, targetNode)) {
@@ -1828,7 +1860,7 @@
         // 处理输入数据，支持JSON解析
         processInputData(data) {
             console.log(`[ExecutionEngine] 处理输入数据:`, data);
-            
+
             // 如果数据是字符串，尝试解析为JSON
             if (typeof data === 'string') {
                 try {
@@ -1840,7 +1872,7 @@
                     return data;
                 }
             }
-            
+
             return data;
         }
 
@@ -1849,7 +1881,7 @@
         setNestedValue(obj, path, value) {
             const keys = path.split('.');
             let current = obj;
-            
+
             for (let i = 0; i < keys.length - 1; i++) {
                 const key = keys[i];
                 if (!(key in current) || typeof current[key] !== 'object') {
@@ -1857,7 +1889,7 @@
                 }
                 current = current[key];
             }
-            
+
             current[keys[keys.length - 1]] = value;
         }
 
@@ -1891,7 +1923,7 @@
             if (fullMatch) {
                 const path = fullMatch[1].trim(); // 例如: 'extractedUrls' 或 'input.extractedUrls'
                 const resolvedData = this._resolveVariablePath(path, inputData);
-                
+
                 // 特殊处理：如果解析结果是对象且包含 'output' 属性，则提取其值
                 if (typeof resolvedData === 'object' && resolvedData !== null && resolvedData.output !== undefined) {
                     return String(resolvedData.output); // 返回 'output' 属性的值并转为字符串
@@ -1905,14 +1937,14 @@
                 const path = match[1].trim(); // 例如: extractedUrls
 
                 let resolvedData = this._resolveVariablePath(path, inputData);
-                
+
                 // 特殊处理：如果解析结果是对象且包含 'output' 属性，则提取其值
                 if (typeof resolvedData === 'object' && resolvedData !== null && resolvedData.output !== undefined) {
                     resolvedData = String(resolvedData.output); // 使用 'output' 属性的值并转为字符串
                 } else if (typeof resolvedData === 'object' && resolvedData !== null) {
                     resolvedData = JSON.stringify(resolvedData); // 对于其他对象，将其 JSON 字符串化
                 }
-                
+
                 // Replace the placeholder with the string representation of the resolved data
                 resolved = resolved.replace(fullPlaceholder, resolvedData !== undefined ? String(resolvedData) : '');
             }
@@ -1923,23 +1955,23 @@
         _resolveVariablePath(path, inputData) {
             console.log(`[ExecutionEngine] 解析变量路径: ${path}`);
             console.log(`[ExecutionEngine] 可用输入数据:`, Object.keys(inputData));
-            
+
             // 兼容模式：支持 input.xxx 格式（向后兼容）
             if (path.startsWith('input.')) {
                 const actualPath = path.substring(6); // 移除 "input." 前缀
                 console.log(`[ExecutionEngine] 兼容模式 - 实际路径: ${actualPath}`);
                 return this._getNestedProperty(inputData, actualPath);
             }
-            
+
             // 统一的顶层查找：所有数据都已展开到顶层，直接查找即可
             // 支持: imageBase64, imageUrl, result, extractedUrls, extractedUrls[0], result.field 等
             const resolvedData = this._getNestedProperty(inputData, path);
-            
+
             if (resolvedData !== undefined) {
                 console.log(`[ExecutionEngine] 顶层查找成功: ${path} ->`, resolvedData);
                 return resolvedData;
             }
-            
+
             console.warn(`[ExecutionEngine] 无法解析变量路径: ${path}`);
             return undefined;
         }

--- a/VCPHumanToolBox/WorkflowEditormodules/WorkflowEditor_NodeManager.js
+++ b/VCPHumanToolBox/WorkflowEditormodules/WorkflowEditor_NodeManager.js
@@ -1,5 +1,5 @@
 // WorkflowEditor Node Manager Module
-(function() {
+(function () {
     'use strict';
 
     class WorkflowEditor_NodeManager {
@@ -7,11 +7,11 @@
             if (WorkflowEditor_NodeManager.instance) {
                 return WorkflowEditor_NodeManager.instance;
             }
-            
+
             this.stateManager = null;
             this.nodeTypes = new Map();
             this.nodeExecutors = new Map();
-            
+
             WorkflowEditor_NodeManager.instance = this;
             // 注入本地轻量右键菜单（用于未加载补丁文件时的兜底）
             try {
@@ -26,7 +26,7 @@
                         <div data-act="download"style="padding:8px 12px;cursor:pointer;">⬇️ 下载图片</div>`;
                     document.body.appendChild(menu);
 
-                    const copyText = async (text) => { try { await navigator.clipboard.writeText(text); } catch(e) { console.warn('复制链接失败', e); } };
+                    const copyText = async (text) => { try { await navigator.clipboard.writeText(text); } catch (e) { console.warn('复制链接失败', e); } };
                     const copyImage = async (url) => {
                         console.log('[LocalUrlMenu] 开始复制图片:', url);
                         try {
@@ -36,13 +36,13 @@
                             }
                             const blob = await res.blob();
                             console.log('[LocalUrlMenu] 获取到blob:', blob.type, blob.size);
-                            
+
                             // 检查浏览器支持的剪贴板类型
                             if (navigator.clipboard && window.ClipboardItem) {
                                 // 直接转换为PNG，避免格式兼容性问题
                                 console.log('[LocalUrlMenu] 转换为PNG格式以确保兼容性');
                                 const pngBlob = await convertToPng(blob);
-                                
+
                                 const item = new ClipboardItem({ 'image/png': pngBlob });
                                 await navigator.clipboard.write([item]);
                                 console.log('[LocalUrlMenu] 复制图片成功');
@@ -56,7 +56,7 @@
                             await copyText(url);
                         }
                     };
-                    
+
                     // 将图片转换为PNG格式
                     const convertToPng = async (blob) => {
                         return new Promise((resolve, reject) => {
@@ -103,7 +103,7 @@
                             console.log('[LocalUrlMenu] 显示菜单，URL:', url);
                             ev.preventDefault();
                             menu.style.left = ev.clientX + 'px';
-                            menu.style.top  = ev.clientY + 'px';
+                            menu.style.top = ev.clientY + 'px';
                             menu.style.display = 'block';
                             const onClick = async (e) => {
                                 e.stopPropagation();
@@ -129,18 +129,18 @@
                                 }
                                 hide();
                             };
-                            const hide = () => { 
+                            const hide = () => {
                                 console.log('[LocalUrlMenu] 隐藏菜单');
-                                menu.style.display='none'; 
-                                document.removeEventListener('click', hide, false); 
-                                menu.removeEventListener('click', onClick); 
+                                menu.style.display = 'none';
+                                document.removeEventListener('click', hide, false);
+                                menu.removeEventListener('click', onClick);
                             };
                             document.addEventListener('click', hide, false);
                             menu.addEventListener('click', onClick);
                         }
                     };
                 }
-            } catch (_) {}
+            } catch (_) { }
         }
 
         static getInstance() {
@@ -164,9 +164,9 @@
                     client.listModels().then(models => {
                         window.__WE_AI_MODELS__ = models;
                         console.log('[NodeManager] AI models cached:', models?.length || 0);
-                    }).catch(() => {});
+                    }).catch(() => { });
                 }
-            } catch (_) {}
+            } catch (_) { }
         }
 
         // 注册节点类型
@@ -285,37 +285,37 @@
                 inputs: ['input'],
                 outputs: ['output', 'matches'],
                 configSchema: {
-                    pattern: { 
-                        type: 'string', 
-                        required: true, 
+                    pattern: {
+                        type: 'string',
+                        required: true,
                         default: '',
                         label: '正则表达式 (Pattern)',
                         description: '用于匹配或替换的正则表达式模式，如: \\d+ 匹配数字，[a-zA-Z]+ 匹配字母',
                         placeholder: '例如: https?://[^\\s]+ 匹配URL'
                     },
-                    flags: { 
-                        type: 'string', 
+                    flags: {
+                        type: 'string',
                         default: 'g',
                         label: '正则标志 (Flags)',
                         description: '正则表达式标志：g=全局匹配，i=忽略大小写，m=多行模式，s=单行模式',
                         placeholder: '例如: gi 表示全局忽略大小写'
                     },
-                    operation: { 
-                        type: 'enum', 
+                    operation: {
+                        type: 'enum',
                         options: ['match', 'replace', 'test', 'split'],
                         default: 'match',
                         label: '操作类型 (Operation)',
                         description: '选择正则操作：match=匹配提取，replace=替换文本，test=测试匹配，split=分割字符串'
                     },
-                    replacement: { 
-                        type: 'string', 
+                    replacement: {
+                        type: 'string',
                         default: '',
                         label: '替换文本 (Replacement)',
                         description: '替换操作时的目标文本，支持 $1, $2 等捕获组引用',
                         placeholder: '例如: $1 引用第一个捕获组'
                     },
-                    outputParamName: { 
-                        type: 'string', 
+                    outputParamName: {
+                        type: 'string',
                         default: 'regexResult',
                         label: '输出参数名 (Output Param Name)',
                         description: '输出结果的参数名称，用于下游节点引用处理结果',
@@ -337,15 +337,15 @@
                         label: '转换类型 (Transform Type)',
                         description: '数据转换方式：json-parse=解析JSON，json-stringify=转为JSON字符串，to-string=转为字符串，to-number=转为数字，to-array=转为数组，custom=自定义脚本'
                     },
-                    customScript: { 
-                        type: 'string', 
+                    customScript: {
+                        type: 'string',
                         default: '',
                         label: '自定义脚本 (Custom Script)',
                         description: '自定义JavaScript代码进行数据转换，输入数据通过 input 变量访问，返回转换结果',
                         placeholder: '例如: return input.map(item => item.toUpperCase())'
                     },
-                    outputParamName: { 
-                        type: 'string', 
+                    outputParamName: {
+                        type: 'string',
                         default: 'transformedData',
                         label: '输出参数名 (Output Param Name)',
                         description: '输出结果的参数名称，用于下游节点引用转换后的数据',
@@ -367,8 +367,8 @@
                         label: '编程语言 (Language)',
                         description: '选择代码的编程语言类型，影响语法高亮和处理方式'
                     },
-                    code: { 
-                        type: 'string', 
+                    code: {
+                        type: 'string',
                         default: '',
                         label: '代码内容 (Code)',
                         description: '要处理的代码内容，支持多行输入和语法高亮显示',
@@ -390,9 +390,9 @@
                 inputs: ['input'],
                 outputs: ['true', 'false'],
                 configSchema: {
-                    condition: { 
-                        type: 'string', 
-                        required: true, 
+                    condition: {
+                        type: 'string',
+                        required: true,
                         default: '',
                         label: '条件表达式 (Condition)',
                         description: '要判断的条件表达式或字段路径，如: input.status 或 input.length',
@@ -405,8 +405,8 @@
                         label: '比较运算符 (Operator)',
                         description: '条件比较运算符：==等于，!=不等于，>大于，<小于，>=大于等于，<=小于等于，contains包含，startsWith开头匹配，endsWith结尾匹配'
                     },
-                    value: { 
-                        type: 'string', 
+                    value: {
+                        type: 'string',
                         default: '',
                         label: '比较值 (Value)',
                         description: '用于比较的目标值，支持字符串、数字等类型',
@@ -428,8 +428,8 @@
                         label: '循环类型 (Loop Type)',
                         description: '循环执行方式：forEach=遍历数组每个元素，times=指定次数循环，while=条件循环'
                     },
-                    maxIterations: { 
-                        type: 'number', 
+                    maxIterations: {
+                        type: 'number',
                         default: 100,
                         label: '最大迭代次数 (Max Iterations)',
                         description: '循环的最大执行次数，防止无限循环导致系统卡死',
@@ -445,9 +445,9 @@
                 inputs: ['input'],
                 outputs: ['output'],
                 configSchema: {
-                    delay: { 
-                        type: 'number', 
-                        default: 1000, 
+                    delay: {
+                        type: 'number',
+                        default: 1000,
                         min: 0,
                         label: '延时时长 (Delay Duration)',
                         description: '等待的时间长度，配合时间单位使用，用于控制执行节奏',
@@ -469,9 +469,9 @@
                 inputs: ['input', 'trigger'],
                 outputs: ['result'],
                 configSchema: {
-                    urlPath: { 
-                        type: 'string', 
-                        default: 'url', 
+                    urlPath: {
+                        type: 'string',
+                        default: 'url',
                         required: false,
                         label: 'URL路径 (URL Path)',
                         description: 'JSON中URL字段的路径，如: url 或 data.imageUrl 或 result.images[0]，支持数组路径如: images',
@@ -484,15 +484,15 @@
                         label: '渲染类型 (Render Type)',
                         description: '选择URL内容的渲染方式：auto=自动检测，image=图片，video=视频，iframe=网页嵌入，text=纯文本链接'
                     },
-                    allowFullscreen: { 
-                        type: 'boolean', 
+                    allowFullscreen: {
+                        type: 'boolean',
                         default: true,
                         label: '允许全屏 (Allow Fullscreen)',
                         description: '允许点击图片进入全屏查看模式，方便查看大图'
                     },
-                    outputParamName: { 
-                        type: 'string', 
-                        default: 'renderedUrl', 
+                    outputParamName: {
+                        type: 'string',
+                        default: 'renderedUrl',
                         label: '输出参数名 (Output Param Name)',
                         description: '输出结果的参数名称，用于下游节点引用渲染结果',
                         placeholder: '例如: displayedImage 或 renderedContent'
@@ -521,8 +521,8 @@
                         }
                     },
                     outputParamName: { // 移动到 configSchema 内部
-                        type: 'string', 
-                        default: 'output', 
+                        type: 'string',
+                        default: 'output',
                         required: false,
                         label: '输出参数名 (Output Param Name)',
                         description: '自定义输出参数名称，用于下游节点引用此内容',
@@ -722,34 +722,24 @@
             }
         }
 
-        // 执行VCPChat插件
+        /** @deprecated 使用 ExecutionEngine.executePluginNode() 代替 */
         async executeVCPChatPlugin(node, inputData) {
-            // TODO: 集成VCPChat插件系统
-            console.log(`Executing VCPChat plugin: ${node.pluginId}`, inputData);
-            
-            // 模拟插件执行
-            await this.delay(1000);
-            
-            return {
-                result: `VCPChat ${node.pluginId} executed successfully`,
-                data: inputData,
-                timestamp: new Date().toISOString()
-            };
+            console.warn('[NodeManager] executeVCPChatPlugin is deprecated. Use ExecutionEngine.executePluginNode()');
+            const engine = window.WorkflowEditor_ExecutionEngine;
+            if (engine && typeof engine.executePluginNode === 'function') {
+                return await engine.executePluginNode(node);
+            }
+            throw new Error('ExecutionEngine not available');
         }
 
-        // 执行VCPToolBox插件
+        /** @deprecated 使用 ExecutionEngine.executePluginNode() 代替 */
         async executeVCPToolBoxPlugin(node, inputData) {
-            // TODO: 集成VCPToolBox插件系统
-            console.log(`Executing VCPToolBox plugin: ${node.pluginId}`, inputData);
-            
-            // 模拟插件执行
-            await this.delay(1500);
-            
-            return {
-                result: `VCPToolBox ${node.pluginId} executed successfully`,
-                data: inputData,
-                timestamp: new Date().toISOString()
-            };
+            console.warn('[NodeManager] executeVCPToolBoxPlugin is deprecated. Use ExecutionEngine.executePluginNode()');
+            const engine = window.WorkflowEditor_ExecutionEngine;
+            if (engine && typeof engine.executePluginNode === 'function') {
+                return await engine.executePluginNode(node);
+            }
+            throw new Error('ExecutionEngine not available');
         }
 
         // 执行正则处理节点
@@ -769,19 +759,19 @@
                     case 'match':
                         result = input.match(regex);
                         return { output: result, matches: result };
-                    
+
                     case 'replace':
                         result = input.replace(regex, replacement || '');
                         return { output: result };
-                    
+
                     case 'test':
                         result = regex.test(input);
                         return { output: result };
-                    
+
                     case 'split':
                         result = input.split(regex);
                         return { output: result };
-                    
+
                     default:
                         throw new Error(`Unknown regex operation: ${operation}`);
                 }
@@ -802,26 +792,26 @@
                     case 'json-parse':
                         result = JSON.parse(input);
                         break;
-                    
+
                     case 'json-stringify':
                         result = JSON.stringify(input, null, 2);
                         break;
-                    
+
                     case 'to-string':
                         result = String(input);
                         break;
-                    
+
                     case 'to-number':
                         result = Number(input);
                         if (isNaN(result)) {
                             throw new Error('Cannot convert to number');
                         }
                         break;
-                    
+
                     case 'to-array':
                         result = Array.isArray(input) ? input : [input];
                         break;
-                    
+
                     default:
                         if (customScript) {
                             // 执行自定义脚本
@@ -851,17 +841,17 @@
                         // 简单的代码格式化
                         result = this.formatCode(input, language);
                         break;
-                    
+
                     case 'minify':
                         // 简单的代码压缩
                         result = this.minifyCode(input, language);
                         break;
-                    
+
                     case 'validate':
                         // 代码验证
                         result = this.validateCode(input, language);
                         break;
-                    
+
                     case 'execute':
                         // 执行代码（仅JavaScript）
                         if (language === 'javascript') {
@@ -871,7 +861,7 @@
                             throw new Error(`Cannot execute ${language} code`);
                         }
                         break;
-                    
+
                     default:
                         result = input;
                 }
@@ -949,7 +939,7 @@
                             });
                         }
                         break;
-                    
+
                     case 'times':
                         const times = Math.min(Number(input) || 1, maxIterations);
                         for (let i = 0; i < times; i++) {
@@ -960,7 +950,7 @@
                             });
                         }
                         break;
-                    
+
                     case 'while':
                         // 简单的while循环实现
                         let count = 0;
@@ -1003,7 +993,7 @@
         // 执行URL渲染节点
         async executeUrlRendererNode(node, inputData) {
             const { urlPath, renderType, allowFullscreen } = node.config;
-            
+
             // 优先使用 input 字段，如果没有则使用整个 inputData 对象
             const input = inputData.input || inputData;
 
@@ -1017,16 +1007,16 @@
                 if (cleanPath.startsWith('{{') && cleanPath.endsWith('}}')) {
                     cleanPath = cleanPath.slice(2, -2).trim();
                 }
-                
+
                 // 从输入数据中提取URL
                 console.log('[URLRenderer] 调试信息:');
                 console.log('[URLRenderer] - input:', input);
                 console.log('[URLRenderer] - urlPath:', urlPath);
                 console.log('[URLRenderer] - cleanPath:', cleanPath);
-                
+
                 const urlData = this.extractUrlFromData(input, cleanPath);
                 console.log('[URLRenderer] - extractUrlFromData 返回:', urlData);
-                
+
                 if (!urlData) {
                     throw new Error(`URL not found in input data using path: ${urlPath || 'url'}`);
                 }
@@ -1070,7 +1060,7 @@
                         let html = `
                             <div class="we-url-gallery" style="width:100%; max-width:${galleryWidth}px; display:grid; grid-template-columns: repeat(2, 1fr); gap:6px; padding:4px;">
                         `;
-                        validUrls.forEach((u)=>{
+                        validUrls.forEach((u) => {
                             html += `
                                 <div class="we-url-card" style="${cardStyle}">
                                     <img src="${u}" style="${imgStyle}" />
@@ -1081,18 +1071,18 @@
                         renderArea.innerHTML = html;
 
                         // 事件绑定（灯箱/右键 或 新标签）
-                        renderArea.querySelectorAll('img').forEach((img)=>{
+                        renderArea.querySelectorAll('img').forEach((img) => {
                             const u = img.getAttribute('src');
-                            img.addEventListener('click',(e)=>{
+                            img.addEventListener('click', (e) => {
                                 e.preventDefault(); e.stopPropagation();
                                 if (window.__UrlRenderer && window.__UrlRenderer.openLightbox) window.__UrlRenderer.openLightbox(u); else window.open(u, '_blank');
                             });
-                            img.addEventListener('contextmenu',(e)=>{
+                            img.addEventListener('contextmenu', (e) => {
                                 if (window.__UrlRenderer && window.__UrlRenderer.showContextMenu) window.__UrlRenderer.showContextMenu(e, u);
                                 else if (window.__LocalUrlMenu) window.__LocalUrlMenu.show(e, u);
                             });
                         });
-                    } catch(e) { console.warn('[URLRenderer] 内联多图渲染失败', e); }
+                    } catch (e) { console.warn('[URLRenderer] 内联多图渲染失败', e); }
                     return {
                         result: validUrls,
                         rendered: true,
@@ -1215,27 +1205,27 @@
         // 检测URL类型
         detectUrlType(url) {
             const urlLower = url.toLowerCase();
-            
+
             // 图片格式
             if (/\.(jpg|jpeg|png|gif|bmp|webp|svg)(\?.*)?$/i.test(urlLower)) {
                 return 'image';
             }
-            
+
             // 视频格式
             if (/\.(mp4|webm|ogg|avi|mov|wmv|flv|mkv)(\?.*)?$/i.test(urlLower)) {
                 return 'video';
             }
-            
+
             // 音频格式
             if (/\.(mp3|wav|ogg|aac|flac|m4a)(\?.*)?$/i.test(urlLower)) {
                 return 'audio';
             }
-            
+
             // 文档格式
             if (/\.(pdf|doc|docx|txt)(\?.*)?$/i.test(urlLower)) {
                 return 'iframe';
             }
-            
+
             // 默认使用iframe
             return 'iframe';
         }
@@ -1247,7 +1237,7 @@
             const thumbAspect = '4 / 3';
             const fitMode = 'contain';
             let renderArea = nodeElement.querySelector('.url-render-area');
-            
+
             if (!renderArea) {
                 // 创建渲染区域
                 renderArea = document.createElement('div');
@@ -1263,7 +1253,7 @@
                     width: ${galleryWidth}px;
                     max-width: ${galleryWidth}px;
                 `;
-                
+
                 // 插入到节点内容区域
                 const nodeContent = nodeElement.querySelector('.node-content') || nodeElement;
                 const nodeHeader = nodeElement.querySelector('.node-header');
@@ -1309,7 +1299,7 @@
                         renderArea.style.setProperty('width', galleryWidth + 'px', 'important');
                         renderArea.style.setProperty('max-width', galleryWidth + 'px', 'important');
                         console.log('[URLRenderer(NodeManager)] 容器宽度锁定:', renderArea.getBoundingClientRect().width);
-                    } catch (_) {}
+                    } catch (_) { }
                 } catch (error) {
                     this.showRenderError(renderArea, error.message);
                 }
@@ -1333,7 +1323,7 @@
 
             // 确保渲染增强存在（灯箱/右键）
             if (window.WorkflowEditor_NodeManager && typeof window.WorkflowEditor_NodeManager.ensureUrlRendererEnhancements === 'function') {
-                try { window.WorkflowEditor_NodeManager.ensureUrlRendererEnhancements(); } catch(e) {}
+                try { window.WorkflowEditor_NodeManager.ensureUrlRendererEnhancements(); } catch (e) { }
             }
 
             switch (type) {
@@ -1345,9 +1335,9 @@
                     img.style.cssText = `width:100%; height:100%; object-fit:${fitMode}; border-radius:4px; cursor:pointer;`;
                     img.onerror = () => this.showRenderError(container, '图片加载失败');
                     try {
-                        img.addEventListener('click', (e)=>{ if (window.__UrlRenderer) { e.preventDefault(); e.stopPropagation(); window.__UrlRenderer.openLightbox(url); }});
-                        img.addEventListener('contextmenu', (e)=>{ if (window.__UrlRenderer) { window.__UrlRenderer.showContextMenu(e, url); }});
-                    } catch(_) {}
+                        img.addEventListener('click', (e) => { if (window.__UrlRenderer) { e.preventDefault(); e.stopPropagation(); window.__UrlRenderer.openLightbox(url); } });
+                        img.addEventListener('contextmenu', (e) => { if (window.__UrlRenderer) { window.__UrlRenderer.showContextMenu(e, url); } });
+                    } catch (_) { }
                     card.appendChild(img);
                     element = card;
                     break;
@@ -1408,7 +1398,7 @@
                         font-size: 12px;
                         line-height: 1.4;
                     `;
-                    
+
                     // 异步加载文本内容
                     fetch(url)
                         .then(response => response.text())
@@ -1571,10 +1561,10 @@
         // 动态输入端点管理
         updateNodeInputsForCommand(nodeId, command, pluginKey) {
             console.log('[NodeManager] updateNodeInputsForCommand called:', { nodeId, command, pluginKey });
-            
+
             const node = this.stateManager.getNode(nodeId);
             console.log('[NodeManager] Found node:', node);
-            
+
             if (!node || (node.type !== 'VCPToolBox' && node.type !== 'vcpChat')) {
                 console.warn('[NodeManager] Invalid node or type:', node?.type);
                 return;
@@ -1606,7 +1596,7 @@
             // 获取动态输入端点
             const dynamicInputs = this.getDynamicInputsForCommand(commandInfo);
             console.log('[NodeManager] Generated dynamicInputs:', dynamicInputs);
-            
+
             // 更新节点配置
             node.command = command;
             node.dynamicInputs = dynamicInputs;
@@ -1614,7 +1604,7 @@
             // 通知画布管理器更新节点输入端点
             // 通知画布管理器更新节点输入端点
             let canvasManager = null;
-            
+
             // 尝试多种方式获取 CanvasManager
             if (window.WorkflowEditor_CanvasManager) {
                 canvasManager = window.WorkflowEditor_CanvasManager;
@@ -1623,11 +1613,11 @@
                 canvasManager = this.stateManager.canvasManager;
                 console.log('[NodeManager] Found CanvasManager via StateManager');
             }
-            
+
             if (canvasManager) {
                 console.log('[NodeManager] CanvasManager found, checking methods...');
                 console.log('[NodeManager] updateNodeInputs method type:', typeof canvasManager.updateNodeInputs);
-                
+
                 if (typeof canvasManager.updateNodeInputs === 'function') {
                     console.log('[NodeManager] Calling canvasManager.updateNodeInputs');
                     canvasManager.updateNodeInputs(nodeId, dynamicInputs);
@@ -1641,12 +1631,12 @@
                     console.log('[NodeManager] No suitable method found, updating node directly');
                     // 直接更新节点的 dynamicInputs 属性
                     this.stateManager.updateNode(nodeId, { dynamicInputs });
-                    
+
                     // 尝试触发画布重新渲染
                     if (this.stateManager.emit) {
                         this.stateManager.emit('nodeNeedsRerender', { nodeId, dynamicInputs });
                     }
-                    
+
                     // 尝试直接调用画布渲染方法
                     if (canvasManager.renderNodes) {
                         console.log('[NodeManager] Triggering full canvas rerender');
@@ -1657,26 +1647,26 @@
                 console.log('[NodeManager] CanvasManager not found, updating node directly');
                 // 直接更新节点的 dynamicInputs 属性
                 this.stateManager.updateNode(nodeId, { dynamicInputs });
-                
+
                 // 触发画布重新渲染该节点
                 if (this.stateManager.emit) {
                     this.stateManager.emit('nodeNeedsRerender', { nodeId, dynamicInputs });
                 }
             }
-            
+
             console.log('[NodeManager] Updated node inputs for command:', { nodeId, command, dynamicInputs });
         }
 
         getDynamicInputsForCommand(commandInfo) {
             const inputs = [];
-            
+
             if (commandInfo && commandInfo.parameters) {
                 Object.entries(commandInfo.parameters).forEach(([paramName, paramInfo]) => {
                     // 跳过 tool_name 和 command 参数，这些不需要输入端点
                     if (paramName.toLowerCase() === 'tool_name' || paramName.toLowerCase() === 'command') {
                         return;
                     }
-                    
+
                     inputs.push({
                         name: paramName,
                         label: paramInfo.description || paramName,
@@ -1708,7 +1698,7 @@
         // 更新辅助节点的输入端点 - 辅助节点不需要动态输入端点
         updateNodeInputsForAuxiliary(nodeId, auxiliaryType) {
             console.log('[NodeManager] updateNodeInputsForAuxiliary called - 辅助节点不需要动态输入端点:', { nodeId, auxiliaryType });
-            
+
             // 辅助节点不需要动态输入端点功能，直接返回
             // 这个功能只针对插件节点
             return;
@@ -1723,7 +1713,7 @@
         // 执行图片上传节点
         async executeImageUploadNode(node, inputData = {}) {
             console.log('[NodeManager] 执行图片上传节点:', node.id);
-            
+
             const config = node.config || {};
             const {
                 outputParamName = 'imageBase64',
@@ -1737,7 +1727,7 @@
             // 检查节点是否已经有上传的图片数据
             if (node.uploadedImageData) {
                 console.log('[NodeManager] 使用已上传的图片数据');
-                
+
                 // 简洁输出：只返回自定义输出名对应的 base64 数据
                 const result = {
                     [outputParamName]: node.uploadedImageData
@@ -1748,7 +1738,7 @@
             } else {
                 // 如果没有上传的图片，返回等待上传的状态
                 console.log('[NodeManager] 等待用户上传图片');
-                
+
                 const result = {
                     [outputParamName]: null,
                     message: '请上传图片文件',
@@ -1823,7 +1813,7 @@
         // 处理图片上传（由UI调用）
         async handleImageUpload(nodeId, file) {
             console.log('[NodeManager] 处理图片上传:', { nodeId, fileName: file.name, fileSize: file.size });
-            
+
             const node = this.stateManager.getNode(nodeId);
             if (!node) {
                 throw new Error(`节点 ${nodeId} 不存在`);
@@ -1890,10 +1880,10 @@
 
             return new Promise((resolve, reject) => {
                 const reader = new FileReader();
-                
+
                 reader.onload = (e) => {
                     const img = new Image();
-                    
+
                     img.onload = () => {
                         try {
                             // 创建canvas进行图片处理
@@ -1902,9 +1892,9 @@
 
                             // 计算新的尺寸（保持宽高比）
                             let { width, height } = this.calculateNewDimensions(
-                                img.width, 
-                                img.height, 
-                                maxWidth, 
+                                img.width,
+                                img.height,
+                                maxWidth,
                                 maxHeight
                             );
 

--- a/VCPHumanToolBox/WorkflowEditormodules/WorkflowEditor_StateManager.js
+++ b/VCPHumanToolBox/WorkflowEditormodules/WorkflowEditor_StateManager.js
@@ -1,5 +1,5 @@
 // WorkflowEditor State Manager Module
-(function() {
+(function () {
     'use strict';
 
     class WorkflowEditor_StateManager {
@@ -7,35 +7,35 @@
             if (WorkflowEditor_StateManager.instance) {
                 return WorkflowEditor_StateManager.instance;
             }
-            
+
             this.state = {
                 // 工作流基本信息
                 workflowName: '未命名工作流',
                 workflowId: null,
-                
+
                 // 画布状态
                 canvasOffset: { x: 0, y: 0 },
                 canvasZoom: 1,
-                
+
                 // 节点和连接
                 nodes: new Map(),
                 connections: new Map(),
-                
+
                 // 选择状态
                 selectedNodes: new Set(),
                 selectedConnections: new Set(),
-                
+
                 // 可用插件
                 availablePlugins: {
                     vcpChat: [],
                     vcpToolBox: [],
                     auxiliary: []
                 },
-                
+
                 // 执行状态
                 isExecuting: false,
                 executionHistory: [],
-                
+
                 // UI状态
                 isVisible: false,
                 activePropertyPanel: null,
@@ -44,11 +44,11 @@
                 undoStack: [],
                 redoStack: []
             };
-            
+
             this.listeners = new Map();
             this.nodeIdCounter = 1;
             this.connectionIdCounter = 1;
-            
+
             WorkflowEditor_StateManager.instance = this;
         }
 
@@ -148,7 +148,7 @@
                 status: 'idle', // idle, running, success, error
                 ...nodeData
             };
-            
+
             this.state.nodes.set(nodeId, node);
             this.emit('nodeAdded', node);
             return node;
@@ -185,7 +185,7 @@
                     connectionsToRemove.push(connectionId);
                 }
             });
-            
+
             connectionsToRemove.forEach(connectionId => {
                 this._removeConnection(connectionId); // 使用内部方法，不记录历史
             });
@@ -342,7 +342,7 @@
             switch (action.type) {
                 case 'addConnection':
                     // 撤销添加，即删除
-                    const connection = Array.from(this.state.connections.values()).find(c => 
+                    const connection = Array.from(this.state.connections.values()).find(c =>
                         c.sourceNodeId === action.data.connectionData.sourceNodeId &&
                         c.targetNodeId === action.data.connectionData.targetNodeId &&
                         c.targetParam === action.data.connectionData.targetParam
@@ -367,7 +367,7 @@
                     });
                     break;
             }
-            
+
             this.emit('historyChanged', {
                 undoCount: this.state.undoStack.length,
                 redoCount: this.state.redoStack.length
@@ -426,7 +426,7 @@
             console.log('[StateManager] Starting serialization...');
             console.log('[StateManager] Current nodes in state:', this.state.nodes.size);
             console.log('[StateManager] Current connections in state:', this.state.connections.size);
-            
+
             const nodes = {};
             this.state.nodes.forEach((node, id) => {
                 console.log(`[StateManager] Serializing node ${id}:`, {
@@ -434,14 +434,14 @@
                     pluginId: node.pluginId,
                     name: node.name || 'unnamed'
                 });
-                
+
                 // 复制节点数据，但排除图片上传器的base64数据
                 const nodeData = { ...node };
-                
+
                 // 如果是图片上传节点，移除base64数据以减小文件大小
-                if (node.type === 'imageUpload' || node.pluginId === 'imageUpload' || 
+                if (node.type === 'imageUpload' || node.pluginId === 'imageUpload' ||
                     (node.type === 'auxiliary' && node.pluginId === 'imageUpload')) {
-                    
+
                     // 移除base64数据，但保留文件名等元信息
                     if (nodeData.uploadedImage) {
                         nodeData.uploadedImage = {
@@ -449,15 +449,15 @@
                             base64Data: null // 清除base64数据
                         };
                     }
-                    
+
                     // 也清除旧格式的base64数据
                     if (nodeData.uploadedImageData) {
                         delete nodeData.uploadedImageData;
                     }
-                    
+
                     console.log(`[StateManager] Excluded base64 data from image upload node: ${id}`);
                 }
-                
+
                 nodes[id] = nodeData;
             });
 
@@ -484,14 +484,14 @@
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString()
             };
-            
+
             console.log('[StateManager] Serialization completed:', {
                 nodeCount: Object.keys(nodes).length,
                 connectionCount: Object.keys(connections).length,
                 workflowName: serializedData.name,
                 workflowId: serializedData.id
             });
-            
+
             return serializedData;
         }
 
@@ -499,7 +499,7 @@
         deserialize(data) {
             try {
                 console.log('[StateManager] Starting workflow deserialization:', data);
-                
+
                 // 清空当前状态
                 this.state.nodes.clear();
                 this.state.connections.clear();
@@ -520,9 +520,9 @@
                     console.log('[StateManager] Loading nodes:', Object.keys(data.nodes));
                     Object.entries(data.nodes).forEach(([id, nodeData]) => {
                         // 对图片上传节点进行特殊处理
-                        if (nodeData.type === 'imageUpload' || nodeData.pluginId === 'imageUpload' || 
+                        if (nodeData.type === 'imageUpload' || nodeData.pluginId === 'imageUpload' ||
                             (nodeData.type === 'auxiliary' && nodeData.pluginId === 'imageUpload')) {
-                            
+
                             // 如果图片上传节点没有base64数据，设置为未上传状态
                             if (nodeData.uploadedImage && !nodeData.uploadedImage.base64Data) {
                                 console.log(`[StateManager] Image upload node ${id} loaded without base64 data, setting to empty state`);
@@ -532,7 +532,7 @@
                                 delete nodeData.uploadedFileName;
                             }
                         }
-                        
+
                         this.state.nodes.set(id, nodeData);
                     });
                 }
@@ -551,7 +551,7 @@
                 // 发出工作流加载事件，延迟确保所有节点都已渲染
                 setTimeout(() => {
                     this.emit('workflowLoaded', data);
-                    
+
                     // 恢复节点的动态输入参数
                     Object.entries(data.nodes).forEach(([id, nodeData]) => {
                         if (nodeData.dynamicInputs && Array.isArray(nodeData.dynamicInputs) && nodeData.dynamicInputs.length > 0) {
@@ -563,7 +563,7 @@
                         }
                     });
                 }, 100);
-                
+
                 console.log('[StateManager] Workflow deserialization completed successfully');
                 return true;
             } catch (error) {
@@ -754,6 +754,53 @@
             }
 
             return result;
+        }
+
+        // 获取按拓扑层级分组的执行顺序（供ExecutionEngine并行执行使用）
+        getExecutionLayers() {
+            const inDegree = new Map();
+            const adjList = new Map();
+
+            // 初始化
+            this.state.nodes.forEach((node, nodeId) => {
+                inDegree.set(nodeId, 0);
+                adjList.set(nodeId, []);
+            });
+
+            // 构建图
+            this.state.connections.forEach(connection => {
+                const source = connection.sourceNodeId;
+                const target = connection.targetNodeId; if (adjList.has(source) && inDegree.has(target)) {
+                    adjList.get(source).push(target);
+                    inDegree.set(target, inDegree.get(target) + 1);
+                }
+            });
+
+            // Kahn 分层拓扑排序
+            const layers = [];
+            let currentLayer = [];
+            inDegree.forEach((deg, id) => { if (deg === 0) currentLayer.push(id); });
+
+            while (currentLayer.length > 0) {
+                layers.push([...currentLayer]);
+                const nextLayer = [];
+                currentLayer.forEach(nodeId => {
+                    (adjList.get(nodeId) || []).forEach(target => {
+                        inDegree.set(target, inDegree.get(target) - 1);
+                        if (inDegree.get(target) === 0) nextLayer.push(target);
+                    });
+                });
+                currentLayer = nextLayer;
+            }
+
+            // 如果处理的节点总数不等于全部节点数，说明有环
+            const totalProcessed = layers.reduce((sum, l) => sum + l.length, 0);
+            if (totalProcessed !== this.state.nodes.size) {
+                console.warn('[StateManager] getExecutionLayers: 存在循环依赖');
+                return null;
+            }
+
+            return layers;
         }
 
         // 重置状态

--- a/VCPHumanToolBox/WorkflowEditormodules/workflow-editor.css
+++ b/VCPHumanToolBox/WorkflowEditormodules/workflow-editor.css
@@ -1,4 +1,4 @@
-/* WorkflowEditor 样式文件 */
+﻿/* WorkflowEditor 样式文件 */
 
 /* 主容器样式 */
 .workflow-editor-container {
@@ -50,6 +50,7 @@
     gap: 20px;
     background: #0f172a;
 }
+
 /* WorkflowEditor 样式文件 */
 
 /* 主容器样式 */
@@ -115,12 +116,15 @@
     box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
-.workflow-editor-actions { /* 修改类名为更具特异性的名称 */
+.workflow-editor-actions {
+    /* 修改类名为更具特异性的名称 */
     margin-left: auto;
     display: flex;
     gap: 10px;
-    overflow: visible; /* 确保不会裁剪子元素的点击区域 */
-    /* pointer-events: auto !important; */ /* 强制响应鼠标事件 */
+    overflow: visible;
+    /* 确保不会裁剪子元素的点击区域 */
+    /* pointer-events: auto !important; */
+    /* 强制响应鼠标事件 */
 }
 
 .workflow-btn {
@@ -132,7 +136,8 @@
     cursor: pointer;
     transition: all 0.2s;
     position: relative;
-    z-index: 10001 !important; /* 设置更高的 z-index */
+    z-index: 10001 !important;
+    /* 设置更高的 z-index */
     pointer-events: auto !important;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -140,8 +145,9 @@
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
-    user-select: none; /* keep, Safari handled above */
-    
+    user-select: none;
+    /* keep, Safari handled above */
+
     /* 使用固定高度和居中对齐 */
     display: inline-flex;
     align-items: center;
@@ -149,7 +155,7 @@
     height: 36px;
     padding: 0 16px;
     min-width: 60px;
-    
+
     /* 确保按钮完全可点击 */
     box-sizing: border-box;
     vertical-align: middle;
@@ -159,28 +165,39 @@
     background: #27a532;
     color: white;
     border: none;
-    border-radius: 6px !important; /* 强制覆盖 style.css 的 border-radius */
+    border-radius: 6px !important;
+    /* 强制覆盖 style.css 的 border-radius */
     font-size: 14px;
     cursor: pointer;
     transition: all 0.2s;
     position: relative;
-    z-index: 9999 !important; /* 提高 z-index 并强制 */
-    pointer-events: auto !important; /* 强制响应鼠标事件 */
+    z-index: 9999 !important;
+    /* 提高 z-index 并强制 */
+    pointer-events: auto !important;
+    /* 强制响应鼠标事件 */
 
     /* 强制覆盖 style.css 的 flex 属性和 padding */
-    display: block; /* 从 flex 改为 block，简化布局 */
-    align-items: initial !important; /* 重置 align-items */
-    gap: 0 !important; /* 重置 gap */
-    height: 50px !important; /* 强制设置高度 */
-    line-height: 50px !important; /* 强制垂直居中 */
-    padding: 0 16px !important; /* 强制设置 padding */
-    text-align: center !important; /* 强制水平居中 */
+    display: block;
+    /* 从 flex 改为 block，简化布局 */
+    align-items: initial !important;
+    /* 重置 align-items */
+    gap: 0 !important;
+    /* 重置 gap */
+    height: 50px !important;
+    /* 强制设置高度 */
+    line-height: 50px !important;
+    /* 强制垂直居中 */
+    padding: 0 16px !important;
+    /* 强制设置 padding */
+    text-align: center !important;
+    /* 强制水平居中 */
 }
 
 
 .workflow-btn:hover {
     background: #2563eb;
-    transform: translateY(-1px); /* 恢复动画 */
+    transform: translateY(-1px);
+    /* 恢复动画 */
 }
 
 .workflow-btn.secondary {
@@ -309,7 +326,7 @@
 .workflow-canvas {
     flex: 1;
     position: relative;
-    background: 
+    background:
         radial-gradient(circle at 1px 1px, #475569 1px, transparent 0);
     background-size: 20px 20px;
     overflow: hidden;
@@ -813,17 +830,31 @@
 
 /* 动画 */
 @keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.5; }
+
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.5;
+    }
 }
 
 @keyframes dash {
-    to { stroke-dashoffset: -10; }
+    to {
+        stroke-dashoffset: -10;
+    }
 }
 
 @keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* URL渲染区域样式 */
@@ -837,7 +868,8 @@
     display: block;
     position: relative;
     overflow: hidden;
-    width: 520px; /* 固定容器宽度，避免被图片撑开 */
+    width: 520px;
+    /* 固定容器宽度，避免被图片撑开 */
 }
 
 .url-render-area img,
@@ -910,7 +942,7 @@
     .workflow-sidebar {
         width: 240px;
     }
-    
+
     .workflow-properties {
         width: 280px;
     }
@@ -949,7 +981,8 @@
 
 /* 隐藏元素 */
 .hidden {
-    display: none !important; /* 使用 !important 确保隐藏 */
+    display: none !important;
+    /* 使用 !important 确保隐藏 */
 }
 
 /* 插件对话框样式 */
@@ -1421,19 +1454,19 @@
         width: 95%;
         height: 90%;
     }
-    
+
     .plugin-list {
         grid-template-columns: 1fr;
     }
-    
+
     .stats-grid {
         grid-template-columns: repeat(2, 1fr);
     }
-    
+
     .manage-actions {
         flex-direction: column;
     }
-    
+
     .custom-plugin-item {
         flex-direction: column;
         align-items: flex-start;
@@ -1481,6 +1514,70 @@
 .canvas-node.error {
     border-color: #ef4444;
     box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.3);
+}
+
+/* ===== 执行状态增强动画 (CodeCC 2026-04-22) ===== */
+
+/* executing 状态 - 呼吸光晕 */
+.canvas-node.executing {
+    border-color: #f59e0b;
+    box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.3);
+    animation: node-executing-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes node-executing-pulse {
+
+    0%,
+    100% {
+        box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.3);
+    }
+
+    50% {
+        box-shadow: 0 0 12px 4px rgba(245, 158, 11, 0.25), 0 0 0 2px rgba(245, 158, 11, 0.4);
+    }
+}
+
+/* success 状态 - 柔和绿光 */
+.canvas-node.success {
+    border-color: #10b981;
+    box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.3);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* error 状态 - 红色警示 */
+.canvas-node.error {
+    border-color: #ef4444;
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.3), 0 0 8px rgba(239, 68, 68, 0.15);
+    animation: node-error-flash 0.6s ease-in-out 2;
+}
+
+@keyframes node-error-flash {
+
+    0%,
+    100% {
+        box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.3);
+    }
+
+    50% {
+        box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.5), 0 0 12px rgba(239, 68, 68, 0.3);
+    }
+}
+
+/* skipped 状态 - 半透明灰色 */
+.canvas-node.skipped {
+    border-color: #6b7280;
+    opacity: 0.55;
+    box-shadow: none;
+    filter: grayscale(40%);
+    transition: opacity 0.3s ease, filter 0.3s ease;
+}
+
+.canvas-node.skipped .canvas-node-header {
+    background: #1e293b;
+}
+
+.canvas-node.skipped .canvas-node-status {
+    background: #6b7280;
 }
 
 /* 图片上传节点特殊样式 */
@@ -1570,4 +1667,3 @@
     border-color: #3b82f6 !important;
     background: rgba(59, 130, 246, 0.2) !important;
 }
-


### PR DESCRIPTION
改动概述
对WorkflowEditor 的执行引擎做了一些小优化，主要集中在 VCPHumanToolBox/WorkflowEditormodules/ 目录，共5个文件，不触碰VCP核心管线。

具体改动
1. 执行引擎（ExecutionEngine.js）

executeNodeChain() 从BFS重排队改为分层拓扑排序 + 同层Promise.allSettled 并行
新增 errorPolicy 支持（stop/continue），单节点失败可不中断整条链
新增预飞行验证：执行前自动检查环形依赖和必需输入是否连线
executeWorkflow() 中循环调用改为单次调用（分层排序已覆盖全图）
2. 状态管理（StateManager.js）

新增 getExecutionLayers() 方法——基于Kahn算法的分层拓扑排序，返回按依赖层级分组的节点数组
3. 画布管理（CanvasManager_JSPlumb.js）

updateNodeStatus() 增强——除更新内部状态圆点外，同时给整个节点元素添加CSS class
nodeUpdated 事件监听器增加status 同步
新增 getNodeTypeColors() 方法——16种节点类型签名色映射，输出端点和连线跟随源节点颜色
4. 节点管理（NodeManager.js）

executeVCPChatPlugin() 和 executeVCPToolBoxPlugin() 标记 @deprecated，转调 ExecutionEngine（经DeepWiki确认两者均为死代码，实际执行路径已统一到ExecutionEngine.executePluginNode()）
5. 样式（workflow-editor.css）

新增四种执行状态动画：executing黄色呼吸脉冲 / success 绿色柔光 / error 红色闪烁 / skipped 半透明灰色
###⚠️ 说明

这些改动目前没有做前端UI层面的完整适配（比如执行结果展示面板、状态重置按钮等），只是对底层执行逻辑和视觉反馈的基础增强。如果lionsky您或其他前端大佬觉得实现思路有更好的方案，随时可以推翻重来——有错我将立正挨打

灵感来源于群友碧雨青潭对ComfyUI式工作流体验的期望。