### PR TITLE
chore(.gitignore): 添加 rust_audio_engine 运行时缓存文件忽略规则

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ vendor/LibreHardwareMonitor/*
 
 # 忽略 WebIndexTTS2 生成输出目录
 /WebIndexTTS2/tmp-output/
+
+# rust_audio_engine 运行时缓存（响度分析等）
+loudness_cache.db
+loudness_cache.db-journal
+loudness_cache.db-wal
+loudness_cache.db-shm


### PR DESCRIPTION
1. 背景/目的：防止 rust_audio_engine 模块运行时产生的缓存文件（如响度分析数据）被意外提交到版本库，保持仓库整洁。

2. 变更要点：
   - 新增对 loudness_cache.db 及关联日志文件的忽略规则
   - 避免缓存文件干扰版本控制，减少不必要的文件变更