### PR TITLE
修复 PTYShellExecutor 会话生命周期竞态

### DIFF
--- a/VCPDistributedServer/Plugin/PTYShellExecutor/PTYShellExecutor.impl.js
+++ b/VCPDistributedServer/Plugin/PTYShellExecutor/PTYShellExecutor.impl.js
@@ -637,14 +637,14 @@ setupThemeWatcher();
 
 // --- IPC 事件监听 ---
 if (ipcMain) {
-    ipcMain.on('shell-gui-ready', (event) => {
+    ipcMain.on('shell-gui-ready', async (event) => {
         sendThemeUpdate(event.sender, true);
         
         // 如果 PTY 尚未启动，则主动启动一个默认会话
         if (!ptyProcess) {
             console.log('[PTYShellExecutor] GUI ready but no PTY session. Starting default session...');
             try {
-                createNewShellSession();
+                await createNewShellSession();
             } catch (e) {
                 console.error('[PTYShellExecutor] Failed to start shell session on GUI ready:', e);
             }
@@ -924,6 +924,8 @@ let activeSessionMode = null; // 'pty' | 'pipe' | null
 let executionQueue = Promise.resolve();
 let executionQueueLength = 0;
 const MAX_EXECUTION_QUEUE_LENGTH = 50;
+let sessionGeneration = 0;
+let sessionCreationPromise = null;
 
 // --- 配置加载 ---
 const defaultConfig = {
@@ -1039,7 +1041,7 @@ function createNewPtySession(preferredShell) {
 
     console.log(`[PTYShellExecutor] Starting shell: ${shell} with args: ${args.join(' ')}`);
 
-    ptyProcess = pty.spawn(shell, args, {
+    const session = pty.spawn(shell, args, {
         name: 'xterm-256color',
         cwd: process.env.HOME || '/home',
         env: withPagerDisabledEnv({
@@ -1049,24 +1051,30 @@ function createNewPtySession(preferredShell) {
             LC_ALL: 'en_US.UTF-8'
         })
     });
-    childProcesses.add(ptyProcess);
+    ptyProcess = session;
+    const currentGeneration = ++sessionGeneration;
+    childProcesses.add(session);
     activeSessionMode = 'pty';
 
     // 数据监听 - 转发到 GUI
-    ptyProcess.onData((data) => {
+    session.onData((data) => {
         if (isExecutingCommand) return;
         if (guiWindow && !guiWindow.isDestroyed()) {
             guiWindow.webContents.send('shell-data', data);
         }
     });
 
-    ptyProcess.onExit(() => {
-        childProcesses.delete(ptyProcess);
-        ptyProcess = null;
-        isExecutingCommand = false;
-        activeSessionMode = null;
-        if (guiWindow && !guiWindow.isDestroyed()) {
-            guiWindow.webContents.send('pty-status', { connected: false });
+    session.onExit(() => {
+        childProcesses.delete(session);
+        if (ptyProcess === session && sessionGeneration === currentGeneration) {
+            ptyProcess = null;
+            isExecutingCommand = false;
+            activeSessionMode = null;
+            if (guiWindow && !guiWindow.isDestroyed()) {
+                guiWindow.webContents.send('pty-status', { connected: false });
+            }
+        } else {
+            console.log('[PTYShellExecutor] Ignoring stale PTY exit for replaced session.');
         }
     });
 
@@ -1155,6 +1163,7 @@ function createNewPipeSession(preferredShell) {
     });
 
     ptyProcess = session;
+    sessionGeneration++;
     childProcesses.add(session);
     activeSessionMode = 'pipe';
 
@@ -1182,6 +1191,22 @@ function createNewPipeSession(preferredShell) {
 }
 
 function createNewShellSession(preferredShell) {
+    if (sessionCreationPromise) {
+        return sessionCreationPromise;
+    }
+
+    sessionCreationPromise = Promise.resolve().then(() => createNewShellSessionImmediate(preferredShell));
+
+    sessionCreationPromise.then(() => {
+        sessionCreationPromise = null;
+    }, () => {
+        sessionCreationPromise = null;
+    });
+
+    return sessionCreationPromise;
+}
+
+function createNewShellSessionImmediate(preferredShell) {
     const mode = getEffectivePtyMode();
     if (mode === 'pipe') {
         return { shellName: createNewPipeSession(preferredShell), mode: 'pipe' };
@@ -1427,7 +1452,7 @@ async function handleSyncExecute(args) {
 
         // 创建或复用会话
         if (newSession || !ptyProcess) {
-            const created = createNewShellSession(preferredShell);
+            const created = await createNewShellSession(preferredShell);
             await new Promise(resolve => setTimeout(resolve, 800)); // 等待 shell 初始化
             console.log(`[PTYShellExecutor] Session started with ${created.shellName} (mode=${created.mode})`);
         }

--- a/VCPDistributedServer/Plugin/PTYShellExecutor/PTYShellExecutor.impl.js
+++ b/VCPDistributedServer/Plugin/PTYShellExecutor/PTYShellExecutor.impl.js
@@ -1163,7 +1163,7 @@ function createNewPipeSession(preferredShell) {
     });
 
     ptyProcess = session;
-    sessionGeneration++;
+    const currentGeneration = ++sessionGeneration;
     childProcesses.add(session);
     activeSessionMode = 'pipe';
 
@@ -1177,13 +1177,15 @@ function createNewPipeSession(preferredShell) {
 
     session.onExit(() => {
         childProcesses.delete(session);
-        if (ptyProcess === session) {
+        if (ptyProcess === session && sessionGeneration === currentGeneration) {
             ptyProcess = null;
-        }
-        activeSessionMode = null;
-        isExecutingCommand = false;
-        if (guiWindow && !guiWindow.isDestroyed()) {
-            guiWindow.webContents.send('pty-status', { connected: false });
+            activeSessionMode = null;
+            isExecutingCommand = false;
+            if (guiWindow && !guiWindow.isDestroyed()) {
+                guiWindow.webContents.send('pty-status', { connected: false });
+            }
+        } else {
+            console.log('[PTYShellExecutor] Ignoring stale pipe exit for replaced session.');
         }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@3d-dice/dice-box": "^1.1.4",
         "@chenglou/pretext": "^0.0.7",
+        "@xterm/headless": "^6.0.0",
         "animejs": "^4.0.2",
         "axios": "^1.10.0",
         "better-sqlite3": "^12.10.0",
@@ -1929,6 +1930,15 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@3d-dice/dice-box": "^1.1.4",
     "@chenglou/pretext": "^0.0.7",
+    "@xterm/headless": "^6.0.0",
     "animejs": "^4.0.2",
     "axios": "^1.10.0",
     "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
## 变更说明
- 修复 PTYShellExecutor 在 newSession:true 场景下旧 PTY 会话退出回调误清全局 ptyProcess 的竞态问题。
- 增加轻量 sessionCreationPromise 创建锁，避免 GUI ready 和工具调用同时创建会话时互相踩状态。
- 将 pipe fallback 会话的退出清理也改为同样的 sessionGeneration 身份检查。
- 补充 @xterm/headless 到 package.json/package-lock.json，保证干净安装环境能解析当前实现中 require('@xterm/headless') 的依赖。

## 验证
- node --check VCPDistributedServer/Plugin/PTYShellExecutor/PTYShellExecutor.impl.js
- 生命周期回归脚本：复现旧 PTY stale exit 后通过
- 真实 node-pty smoke：连续 newSession:true 和复用调用通过
- pipe fallback 生命周期回归脚本通过
- package.json / package-lock.json JSON 解析通过
- git diff --check 通过