### PR TITLE
fix(memo): split maid and folder into separate input fields for diary creation

### DIFF
--- a/Memomodules/memo.html
+++ b/Memomodules/memo.html
@@ -146,12 +146,16 @@
                 <input type="date" id="new-memo-date" class="glass-input" style="width: 100%;">
             </div>
             <div style="margin-bottom: 15px;">
-                <label style="display: block; margin-bottom: 5px; font-size: 0.9rem; color: var(--text-secondary);">署名 / 目标文件夹 <span style="opacity: 0.5; font-size: 0.8rem;">(maid)</span></label>
-                <input type="text" id="new-memo-maid" class="glass-input" style="width: 100%;" placeholder="如：Nova 或 [Nova的知识]Nova">
+                <label style="display: block; margin-bottom: 5px; font-size: 0.9rem; color: var(--text-secondary);">署名 <span style="opacity: 0.5; font-size: 0.8rem;">(maid)</span></label>
+                <input type="text" id="new-memo-maid" class="glass-input" style="width: 100%;" placeholder="如：Nova">
+            </div>
+            <div style="margin-bottom: 15px;">
+                <label style="display: block; margin-bottom: 5px; font-size: 0.9rem; color: var(--text-secondary);">目标文件夹 <span style="opacity: 0.5; font-size: 0.8rem;">(folder, 可选，留空写入默认日记本)</span></label>
+                <input type="text" id="new-memo-folder" class="glass-input" style="width: 100%;" placeholder="如：Nova的知识">
             </div>
             <div style="margin-bottom: 15px;">
                 <label style="display: block; margin-bottom: 5px; font-size: 0.9rem; color: var(--text-secondary);">文件名 <span style="opacity: 0.5; font-size: 0.8rem;">(可选，留空自动生成)</span></label>
-                <input type="text" id="new-memo-filename" class="glass-input" style="width: 100%;" placeholder="自定义文件名，如：莱恩日记提示词哲学">
+                <input type="text" id="new-memo-filename" class="glass-input" style="width: 100%;" placeholder="自定义文件名，如：日记提示词哲学">
             </div>
             <div style="margin-bottom: 15px;">
                 <label style="display: block; margin-bottom: 5px; font-size: 0.9rem; color: var(--text-secondary);">标签 <span style="opacity: 0.5; font-size: 0.8rem;">(必选，逗号分隔)</span></label>

--- a/Memomodules/memo.js
+++ b/Memomodules/memo.js
@@ -1019,6 +1019,7 @@ async function handleDeleteMemo() {
 async function handleCreateMemo() {
     const date = newMemoDateInput.value;
     const maid = newMemoMaidInput.value.trim();
+    const folder = document.getElementById('new-memo-folder')?.value.trim() || '';
     const fileName = newMemoFilenameInput.value.trim();
     const tags = newMemoTagsInput.value.trim();
     const content = newMemoContentInput.value.trim();
@@ -1042,6 +1043,9 @@ tool_name:「始」DailyNote「末」,
 command:「始」create「末」,
 Date:「始」${date}「末」,`;
 
+        if (folder) {
+            toolFields += `\nfolder:「始」${folder}「末」,`;
+        }
         if (fileName) {
             toolFields += `\nfileName:「始」${fileName}「末」,`;
         }


### PR DESCRIPTION
## 问题
新建日记弹窗中，"署名/目标文件夹 (maid)" 合并在一个输入框中，要求用户填写 [文件夹]伙伴名 这种旧格式。
但后端 DailyNote 插件早已支持 maid 和 folder 作为独立字段分别传递。

## 修复
将原来的单一输入框拆分为两个独立字段：
- 署名 (maid)：填写伙伴昵称，如"赵枫"
- 目标文件夹 (folder)：可选，填写目标日记本名称，如"程宸Cod的知识"，留空则写入默认日记本

## 改动文件
- Memomodules/memo.html：新建日记弹窗 UI 拆分
- Memomodules/memo.js：handleCreateMemo() 中新增 folder 变量和 TOOL_REQUEST 构造逻辑

## 测试
1. 填写 maid + folder → 日记写入指定文件夹 ✅
2. 填写 maid 但 folder 留空 → 日记写入默认日记本 ✅
3. 工作台创建日记不受影响（已是新格式）✅