### PR TITLE
新增聊天分条气泡渲染：真流式连发气泡（配合 OpenHerPersona 插件，零额外模型调用）

### DIFF
--- a/modules/renderer/contentPipeline.js
+++ b/modules/renderer/contentPipeline.js
@@ -22,6 +22,16 @@ function noop(value) {
     return value;
 }
 
+// OpenHerPersona 回填注释（persona_delta / persona_expression）按协议位于回复末尾。
+// 若注释体内出现 "-->"（例如模型在 reason 里写了完整分条标记），HTML 注释会被提前
+// 闭合，剩余 JSON 就会泄漏成可见文本。这里从第一个回填开标记直接剥到文末，兜底防漏。
+const PERSONA_BACKFILL_TAIL_REGEX = /<!--\s*persona_(?:delta|expression)\s*:[\s\S]*$/;
+
+function stripPersonaBackfillTail(text) {
+    if (!text || text.indexOf('persona_') === -1) return text;
+    return text.replace(PERSONA_BACKFILL_TAIL_REGEX, '').replace(/\s+$/, '');
+}
+
 function createMapPlaceholderReplacer(map) {
     if (!map || map.size === 0) {
         return noop;
@@ -202,6 +212,9 @@ function createContentPipeline(deps = {}) {
     function runFullRenderPipeline(inputText, options = {}) {
         const ctx = createContext(inputText, { ...options, mode: PIPELINE_MODES.FULL_RENDER });
 
+        if ((options.messageRole || 'assistant') === 'assistant') {
+            step(ctx, 'strip-persona-backfill-tail', (text) => stripPersonaBackfillTail(text));
+        }
         step(ctx, 'normalize-emoticon-urls', (text) => fixEmoticonUrlsInMarkdown(text));
 
         // 顺序协议：
@@ -255,6 +268,7 @@ function createContentPipeline(deps = {}) {
         const ctx = createContext(inputText, { ...options, mode: PIPELINE_MODES.STREAM_FAST });
 
         // 流式快路径只保留轻量、幂等、低风险修正
+        step(ctx, 'strip-persona-backfill-tail', (text) => stripPersonaBackfillTail(text));
         step(ctx, 'normalize-emoticon-urls', (text) => fixEmoticonUrlsInMarkdown(text));
         step(ctx, 'deindent-misinterpreted-code-blocks', (text) => deIndentMisinterpretedCodeBlocks(text));
         step(ctx, 'escape-start-end-markers', (text) => processStartEndMarkers(text));

--- a/modules/renderer/contentPipeline.js
+++ b/modules/renderer/contentPipeline.js
@@ -22,14 +22,58 @@ function noop(value) {
     return value;
 }
 
-// OpenHerPersona 回填注释（persona_delta / persona_expression）按协议位于回复末尾。
-// 若注释体内出现 "-->"（例如模型在 reason 里写了完整分条标记），HTML 注释会被提前
-// 闭合，剩余 JSON 就会泄漏成可见文本。这里从第一个回填开标记直接剥到文末，兜底防漏。
-const PERSONA_BACKFILL_TAIL_REGEX = /<!--\s*persona_(?:delta|expression)\s*:[\s\S]*$/;
+// OpenHerPersona 回填注释（persona_delta / persona_expression）需要从渲染中剥离。
+// 不能简单"从开标记删到文末"——VCP 工具循环会把工具调用等后续内容追加在同一条
+// 消息里，贪婪剥离会把回填之后的工具调用块一并吞掉。这里用与插件服务端同款的
+// 字符串感知括号配平扫描，精确删除每个回填块（即使 reason 里出现 "-->" 也不会
+// 提前截断泄漏），并保留其后的全部内容；流式半截回填则剥到文末。
+const PERSONA_BACKFILL_OPEN_REGEX = /<!--\s*persona_(?:delta|expression)\s*:/g;
+
+function findPersonaJsonEnd(text, startIndex) {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let i = startIndex; i < text.length; i++) {
+        const ch = text[i];
+        if (inString) {
+            if (escaped) escaped = false;
+            else if (ch === '\\') escaped = true;
+            else if (ch === '"') inString = false;
+            continue;
+        }
+        if (ch === '"') inString = true;
+        else if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return i + 1;
+        }
+    }
+    return -1;
+}
 
 function stripPersonaBackfillTail(text) {
     if (!text || text.indexOf('persona_') === -1) return text;
-    return text.replace(PERSONA_BACKFILL_TAIL_REGEX, '').replace(/\s+$/, '');
+    let result = '';
+    let cursor = 0;
+    PERSONA_BACKFILL_OPEN_REGEX.lastIndex = 0;
+    let match;
+    while ((match = PERSONA_BACKFILL_OPEN_REGEX.exec(text)) !== null) {
+        if (match.index < cursor) continue;
+        result += text.slice(cursor, match.index);
+        const jsonStart = text.indexOf('{', match.index + match[0].length);
+        if (jsonStart === -1) { cursor = text.length; break; }
+        const jsonEnd = findPersonaJsonEnd(text, jsonStart);
+        if (jsonEnd === -1) { cursor = text.length; break; }
+        let end = jsonEnd;
+        const closer = text.indexOf('-->', jsonEnd);
+        if (closer !== -1 && text.slice(jsonEnd, closer).trim() === '') {
+            end = closer + 3;
+        }
+        cursor = end;
+        PERSONA_BACKFILL_OPEN_REGEX.lastIndex = end;
+    }
+    result += text.slice(cursor);
+    return result.replace(/\s+$/, '');
 }
 
 function createMapPlaceholderReplacer(map) {

--- a/modules/renderer/imageHandler.js
+++ b/modules/renderer/imageHandler.js
@@ -8,6 +8,140 @@ let imageHandlerRefs = {
     chatMessagesDiv: null,
 };
 
+// --- OpenHerPersona 聊天分条（burst bubbles） ---
+// 模型在一次生成里用 <!--brk--> 注释自我分条（由 OpenHerPersona 的 hint 引导，
+// 零额外模型调用）。注释经 marked 渲染后成为 DOM 注释节点，这里把顶层内容按
+// 标记分桶成多个气泡，并对最新消息做 QQ 式逐条浮现动画。
+const BURST_MARKER_VALUE = 'brk';
+
+function isBurstMarkerNode(node) {
+    return Boolean(node) && node.nodeType === Node.COMMENT_NODE && String(node.nodeValue || '').trim() === BURST_MARKER_VALUE;
+}
+
+function nodesHaveContent(nodes) {
+    return nodes.some((node) => {
+        if (node.nodeType === Node.TEXT_NODE) return Boolean(node.textContent.trim());
+        if (node.nodeType !== Node.ELEMENT_NODE) return false;
+        return Boolean(node.textContent.trim()) || Boolean(node.querySelector('img,video,audio,canvas,iframe,svg'));
+    });
+}
+
+function applyBurstBubbles(contentDiv) {
+    if (!contentDiv) return;
+    const messageItem = contentDiv.closest ? contentDiv.closest('.message-item') : null;
+    if (messageItem && (messageItem.classList.contains('streaming') || messageItem.classList.contains('thinking'))) {
+        return;
+    }
+
+    // 流式期间已实时分条（burst-streaming），或本消息此前已播放过浮现动画
+    // （收尾阶段可能发生第二次整段重渲染），都不再重放，避免"重新弹出"。
+    const wasStreaming = contentDiv.classList.contains('burst-streaming');
+    contentDiv.classList.remove('burst-streaming');
+    const alreadyRevealed = Boolean(messageItem && messageItem.dataset.burstRevealed === 'true');
+
+    const wrappers = splitIntoBurstBubbles(contentDiv);
+    if (wrappers.length === 0) return;
+    contentDiv.classList.add('burst-mode');
+    if (messageItem) messageItem.dataset.burstRevealed = 'true';
+
+    const animate =
+        !wasStreaming &&
+        !alreadyRevealed &&
+        Boolean(messageItem && messageItem.parentElement && messageItem.parentElement.lastElementChild === messageItem);
+    if (!animate) return;
+
+    let revealDelay = 0;
+    wrappers.forEach((wrapper, index) => {
+        if (index === 0) return;
+        // 延迟按上一条的长度估算"打字时间"，模拟下一条分条到达的节奏
+        const previousLength = (wrappers[index - 1].textContent || '').length;
+        revealDelay += Math.min(1500, 360 + previousLength * 22);
+        wrapper.classList.add('burst-pending');
+        wrapper.style.animationDelay = `${revealDelay}ms`;
+    });
+}
+
+function findBurstAvatarSrc(container) {
+    const messageItem = container.closest ? container.closest('.message-item') : null;
+    // 头像行的负边距对齐只按 assistant 左侧布局设计；用户消息不套头像行
+    if (!messageItem || messageItem.classList.contains('user')) return null;
+    const avatar = messageItem.querySelector('img.chat-avatar');
+    return avatar && avatar.src ? avatar.src : null;
+}
+
+// 核心分桶：把 container 顶层内容按 brk 注释标记包装成气泡序列。
+// 第 2 条起套上"假头像行"（克隆本消息头像），冒充独立的新消息。
+// 返回包出来的外层元素数组（首条为 .burst-bubble，其余为 .burst-row）；
+// 有效段落数少于 minBubbles 时不动结构，返回空数组。
+// （最终渲染要求 ≥2 段才值得分条；流式稳定区则 1 段就包，尾部根充当下一条气泡。）
+export function splitIntoBurstBubbles(container, minBubbles = 2) {
+    if (!container) return [];
+
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_COMMENT);
+    const markers = [];
+    let current;
+    while ((current = walker.nextNode())) {
+        if (String(current.nodeValue || '').trim() === BURST_MARKER_VALUE) markers.push(current);
+    }
+    if (markers.length === 0) return [];
+
+    // 标记若在段落等一层容器内（如 <p>好<!--brk-->坏</p>），把容器在标记处剖开
+    // 并把标记提升到顶层；更深处（列表/引用/代码）的标记不拆，直接丢弃。
+    for (const marker of markers) {
+        const parent = marker.parentNode;
+        if (!parent || parent === container) continue;
+        if (parent.parentNode !== container) {
+            marker.remove();
+            continue;
+        }
+        const tail = parent.cloneNode(false);
+        while (marker.nextSibling) tail.appendChild(marker.nextSibling);
+        container.insertBefore(marker, parent.nextSibling);
+        if (tail.childNodes.length > 0) container.insertBefore(tail, marker.nextSibling);
+        if (!nodesHaveContent([parent])) parent.remove();
+    }
+
+    const groups = [[]];
+    for (const child of Array.from(container.childNodes)) {
+        if (isBurstMarkerNode(child)) {
+            child.remove();
+            if (groups[groups.length - 1].length > 0) groups.push([]);
+            continue;
+        }
+        groups[groups.length - 1].push(child);
+    }
+
+    const bubbleGroups = groups.filter(nodesHaveContent);
+    if (bubbleGroups.length < minBubbles) return [];
+    groups
+        .filter((group) => !nodesHaveContent(group))
+        .forEach((group) => group.forEach((node) => node.remove()));
+
+    const avatarSrc = findBurstAvatarSrc(container);
+
+    return bubbleGroups.map((nodes, index) => {
+        const bubble = document.createElement('div');
+        bubble.className = 'burst-bubble';
+        nodes.forEach((node) => bubble.appendChild(node));
+
+        if (index === 0 || !avatarSrc) {
+            container.appendChild(bubble);
+            return bubble;
+        }
+
+        const row = document.createElement('div');
+        row.className = 'burst-row';
+        const avatar = document.createElement('img');
+        avatar.className = 'burst-avatar';
+        avatar.src = avatarSrc;
+        avatar.alt = '';
+        row.appendChild(avatar);
+        row.appendChild(bubble);
+        container.appendChild(row);
+        return row;
+    });
+}
+
 export function initializeImageHandler(refs) {
     imageHandlerRefs.electronAPI = refs.electronAPI;
     imageHandlerRefs.uiHelper = refs.uiHelper;
@@ -25,10 +159,19 @@ export function initializeImageHandler(refs) {
 export function setContentAndProcessImages(contentDiv, rawHtml, messageId) {
     // 🟢 直接设置 HTML，不做替换
     contentDiv.innerHTML = rawHtml;
-    
+
+    // OpenHerPersona 聊天分条：按 brk 注释标记把内容拆成连发气泡
+    try {
+        applyBurstBubbles(contentDiv);
+    } catch (error) {
+        console.warn('[ImageHandler] burst bubble split failed:', error);
+    }
+
     // 🟢 然后对所有 <img> 添加事件监听
     const images = contentDiv.querySelectorAll('img');
     images.forEach((img, index) => {
+        // 分条假头像不参与图片预览/右键复制
+        if (img.classList.contains('burst-avatar')) return;
         let src = img.src;
         
         // 修复表情包 URL

--- a/modules/renderer/streamManager.js
+++ b/modules/renderer/streamManager.js
@@ -1,6 +1,7 @@
 // modules/renderer/streamManager.js
 import { formatMessageTimestamp } from './domBuilder.js';
 import { createContentPipeline, PIPELINE_MODES } from './contentPipeline.js';
+import { splitIntoBurstBubbles } from './imageHandler.js';
 
 // --- Stream State ---
 const streamingChunkQueues = new Map(); // messageId -> array of original chunk strings
@@ -32,6 +33,8 @@ const THINK_START_REGEX = /<think(?:ing)?>/ig;
 const THINK_END_REGEX = /<\/think(?:ing)?>/ig;
 const DAILY_NOTE_START = '<<<DailyNoteStart>>>';
 const DAILY_NOTE_END = '<<<DailyNoteEnd>>>';
+// OpenHerPersona 聊天分条标记：完整出现即成为稳定切点，流式过程中实时分出气泡
+const BURST_MARKER_TOKEN = '<!--brk-->';
 const STREAM_PARAGRAPH_SAFETY_BLOCKS = 1;
 const HTML_ISLAND_MAX_STACK_DEPTH = 128;
 const HTML_ISLAND_MAX_CHARS = 256 * 1024;
@@ -405,11 +408,30 @@ function getOrCreateStreamSegmentState(messageId) {
             stableCutoff: 0,
             stableHtml: '',
             lastTailText: '',
-            lastParagraphBoundary: 0
+            lastParagraphBoundary: 0,
+            burstBubbleCount: 0
         };
         streamSegmentStates.set(messageId, state);
     }
     return state;
+}
+
+// 分条流式时给尾部根（"正在打字"的下一条）套上头像行，看起来像新消息正在到来。
+// 收尾阶段会整体重渲染 contentDiv，包装行随之消失。
+function ensureBurstTailRow(contentDiv, tailRoot, messageItem) {
+    if (contentDiv.querySelector('.burst-tail-row')) return;
+    const avatar = messageItem ? messageItem.querySelector('img.chat-avatar') : null;
+    const tailRow = document.createElement('div');
+    tailRow.className = 'burst-row burst-tail-row';
+    if (avatar && avatar.src) {
+        const tailAvatar = document.createElement('img');
+        tailAvatar.className = 'burst-avatar';
+        tailAvatar.src = avatar.src;
+        tailAvatar.alt = '';
+        tailRow.appendChild(tailAvatar);
+    }
+    contentDiv.appendChild(tailRow);
+    tailRow.appendChild(tailRoot);
 }
 
 function startsWithAt(text, index, token) {
@@ -841,6 +863,13 @@ function findExplicitStablePrefix(text, startOffset = 0) {
             continue;
         }
 
+        if (startsWithAt(text, index, BURST_MARKER_TOKEN)) {
+            stableCutoff = index + BURST_MARKER_TOKEN.length;
+            paragraphFloor = stableCutoff;
+            index = stableCutoff;
+            continue;
+        }
+
         const thinkStart = findConventionalThinkStart(text, index);
         if (thinkStart === index) {
             const thinkEnd = findConventionalThinkEnd(text, index);
@@ -977,8 +1006,8 @@ function renderStreamFrame(messageId) {
     // 🟢 使用缓存的 DOM 引用
     const cachedDom = getCachedMessageDom(messageId);
     if (!cachedDom) return;
-    
-    const { contentDiv } = cachedDom;
+
+    const { contentDiv, messageItem } = cachedDom;
     const { stableRoot, tailRoot } = ensureStreamingRoots(contentDiv);
     const segmentState = getOrCreateStreamSegmentState(messageId);
 
@@ -1008,6 +1037,26 @@ function renderStreamFrame(messageId) {
             }
         } else {
             stableRoot.innerHTML = stableHtml;
+        }
+
+        // OpenHerPersona 聊天分条：稳定区里完成的段落实时包成封口气泡，
+        // 尾部根继续作为"正在打字"的活动气泡（样式见 .burst-streaming）。
+        try {
+            const bubbles = splitIntoBurstBubbles(stableRoot, 1);
+            if (bubbles.length > 0) {
+                contentDiv.classList.add('burst-streaming');
+                if (messageItem) messageItem.dataset.burstRevealed = 'true';
+                ensureBurstTailRow(contentDiv, tailRoot, messageItem);
+                bubbles.forEach((bubble, index) => {
+                    if (index >= segmentState.burstBubbleCount) {
+                        bubble.classList.add('burst-pending');
+                        bubble.style.animationDelay = '0ms';
+                    }
+                });
+                segmentState.burstBubbleCount = bubbles.length;
+            }
+        } catch (error) {
+            console.warn('[StreamManager] burst bubble split failed:', error);
         }
     }
 

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1340,3 +1340,138 @@ body.light-theme .message-item .md-content pre .hljs-meta {
    outline-offset: 2px;
 }
 
+
+/* --- OpenHerPersona 聊天分条（burst bubbles） --- */
+/* 外层 .md-content 退化为透明容器，每个 .burst-bubble 才是真正的气泡 */
+.message-item .md-content.burst-mode {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 7px;
+}
+
+.message-item .md-content.burst-mode .burst-bubble {
+    width: fit-content;
+    max-width: 100%;
+    padding: 9px 14px;
+    border-radius: 12px;
+    border-bottom-left-radius: 5px;
+    background-color: var(--assistant-bubble-bg);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+body.light-theme .message-item .md-content.burst-mode .burst-bubble {
+    border: 1px solid color-mix(in srgb, var(--border-color) 34%, rgba(255, 255, 255, 0.58));
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.14)),
+        color-mix(in srgb, var(--assistant-bubble-bg) 58%, rgba(255, 255, 255, 0.92));
+}
+
+.message-item .md-content.burst-mode .burst-bubble > :first-child { margin-top: 0; }
+.message-item .md-content.burst-mode .burst-bubble > :last-child { margin-bottom: 0; }
+
+/* 假头像行：第 2 条起的分条带上与首条同款同尺寸的头像，
+   负外边距把头像拉回真实头像列，气泡与第一条左对齐（不重复名字/时间） */
+.burst-row {
+    --burst-avatar-outdent: 49px; /* 40px头像 + 2x2px边框 + 10px列间距 - 5px wrapper负边距 */
+    display: flex;
+    align-items: flex-start;
+    gap: 5px;
+    margin-left: calc(-1 * var(--burst-avatar-outdent));
+    width: calc(100% + var(--burst-avatar-outdent));
+    min-width: 0;
+}
+
+.burst-row .burst-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex: none;
+    border: 2px solid var(--dynamic-avatar-color, var(--border-color));
+    margin-top: 0;
+    cursor: default !important;
+}
+
+.burst-row .burst-bubble,
+.burst-row .vcp-stream-tail-root {
+    min-width: 0;
+    max-width: calc(100% - var(--burst-avatar-outdent));
+}
+
+/* 分条浮现动画（气泡与假头像行通用），延迟按上一条长度估算打字时间 */
+.burst-pending {
+    opacity: 0;
+    animation: burstBubbleIn 0.24s ease-out forwards;
+}
+
+@keyframes burstBubbleIn {
+    from { opacity: 0; transform: translateY(6px) scale(0.985); }
+    to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .burst-pending { animation: none; opacity: 1; }
+}
+
+/* --- 真流式分条：stableRoot 里是封口气泡，tailRoot 是"正在打字"的活动气泡 --- */
+.message-item .md-content.burst-streaming {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 7px;
+}
+
+.message-item .md-content.burst-streaming .vcp-stream-stable-root {
+    display: contents;
+}
+
+.message-item .md-content.burst-streaming .burst-bubble,
+.message-item .md-content.burst-streaming .vcp-stream-tail-root {
+    width: fit-content;
+    max-width: 100%;
+    padding: 9px 14px;
+    border-radius: 12px;
+    border-bottom-left-radius: 5px;
+    background-color: var(--assistant-bubble-bg);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+body.light-theme .message-item .md-content.burst-streaming .burst-bubble,
+body.light-theme .message-item .md-content.burst-streaming .vcp-stream-tail-root {
+    border: 1px solid color-mix(in srgb, var(--border-color) 34%, rgba(255, 255, 255, 0.58));
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.14)),
+        color-mix(in srgb, var(--assistant-bubble-bg) 58%, rgba(255, 255, 255, 0.92));
+}
+
+.message-item .md-content.burst-streaming .vcp-stream-tail-root:empty {
+    display: none;
+}
+
+/* 尾部假头像行：正在打字的下一条；尾部内容为空时整行隐藏 */
+.message-item .md-content.burst-streaming .burst-tail-row:has(.vcp-stream-tail-root:empty) {
+    display: none;
+}
+
+.message-item .md-content.burst-streaming .burst-bubble > :first-child,
+.message-item .md-content.burst-streaming .vcp-stream-tail-root > :first-child { margin-top: 0; }
+.message-item .md-content.burst-streaming .burst-bubble > :last-child,
+.message-item .md-content.burst-streaming .vcp-stream-tail-root > :last-child { margin-bottom: 0; }
+


### PR DESCRIPTION
## 简介

配套 VCPToolBox 的 OpenHerPersona 情绪插件（lioensky/VCPToolBox#359）：插件在情绪适合时引导模型**在单次生成内**用 `brk` HTML 注释标记自我分条（零额外模型调用），本 PR 让 VCPChat 把这样的回复渲染成 IM 式连发气泡——流式过程中气泡一条条实时"长"出来，节奏就是模型真实的生成节奏。

**完全可降级**：标记是 HTML 注释，天然不可见。没装插件、或后端没下发分条指令时，渲染行为与现状完全一致；旧版前端遇到带标记的消息也只是显示为一条普通消息。

## 实现

- **imageHandler**：`setContentAndProcessImages` 末尾按 `brk` 注释节点把顶层内容分桶为 `.burst-bubble`。段落内一层深的标记会把段落剖开；列表/引用/代码块内的标记被忽略并丢弃（永不切坏结构）。第 2 条起套上与消息头像同尺寸（40px+2px 动态色边框）的头像行，负外边距对齐到真实头像列——视觉上即同一人连发多条独立消息（不重复名字/时间）。最新消息按"上一条长度估算打字时间"的节奏逐条浮现，带 `burstRevealed` 防重放标记，尊重 `prefers-reduced-motion`；假头像不参与图片预览/右键菜单
- **streamManager**：完整 `brk` 标记成为 `findExplicitStablePrefix` 的稳定切点——流式过程中说完的段落实时封口成气泡进稳定区，尾部根作为带头像的"正在打字"气泡持续增长；分条还顺带把 morphdom 每帧 diff 的活动尾部切小
- **contentPipeline**：full-render 与 stream-fast 两条路径在最前剥离 `persona_delta`/`persona_expression` 回填尾部——若模型在回填注释体内写了含 `-->` 的内容导致注释提前闭合，不会再把 JSON 泄漏为可见文本
- **chat.css**：`burst-mode`（最终态）/`burst-streaming`（流式态）下外层 `.md-content` 退化为透明纵向栈，每个气泡独立着色（深浅主题各一套），头像行对齐参数集中在 `--burst-avatar-outdent` 一个变量

## 测试

- 三个 JS 模块通过 `node --check` 语法校验；改动基于当前 upstream main 手工移植并适配了新版稳定切点架构（`blockedByUnclosedExplicitBlock`/`paragraphFloor` 语义保持）
- 插件侧协议（标记生成、客户端门控、回填剥离的源头约束）由 VCPToolBox PR 中的 20 项测试覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)
