### PR TITLE
feat(HumanToolBox): 新增插件管理面板 & 参数自动解析引擎 v0.3

### DIFF
--- a/VCPHumanToolBox/README.md
+++ b/VCPHumanToolBox/README.md
@@ -1,0 +1,439 @@
+# VCPHumanToolBox · 人类工具箱
+
+> VCP 生态的可视化工具调用面板——将 AI 工具能力以表单界面的形式开放给人类用户，无需手写VCP 指令即可调用任意工具。
+
+---
+
+## 目录
+
+1. [项目概述](#1-项目概述)
+2. [快速启动](#2-快速启动)
+3. [整体架构](#3-整体架构)
+4. [目录结构](#4-目录结构)
+5. [工具定义格式](#5-工具定义格式)
+6. [新增工具的两条路径](#6-新增工具的两条路径)
+7. [插件管理面板](#7-插件管理面板-v03)
+8. [工作流编辑器](#8-工作流编辑器现状)
+9. [ComfyUI 集成](#9-comfyui-集成)
+10. [IPC 通道白名单](#10-ipc-通道白名单)
+11. [开发指南](#11-开发指南)
+
+---
+
+## 1. 项目概述
+
+VCPHumanToolBox 是一个**独立的 Electron 应用**，运行于 `VCPChat/VCPHumanToolBox/` 目录下。它不是 VCPChat 的内嵌模块，而是通过 IPC 桥接（`vcp-ht-execute-tool-proxy`）与 VCPChat 主进程通信，最终将工具调用请求代理到 VCPDistributedServer 的 `/v1/human/tool` 端点。
+
+**核心能力**：
+- 🧰 **工具网格**：以卡片形式展示所有可用工具，支持搜索、分类筛选、收藏
+- 📝 **动态表单**：根据工具参数定义自动生成输入界面，支持 7 种参数类型
+-🎨 **多模态结果**：结果区支持 Markdown、图片、视频渲染
+- 📦 **插件管理**（v0.3 新增）：从后端动态导入插件定义，支持可视化编辑参数
+- 🔀 **工作流编辑器**（部分实现）：基于 jsPlumb 的节点编排界面
+
+**不是什么**：
+- 不是 AI 对话界面（那是 VCPChat 主窗口）
+- 不是插件的执行后端（执行由 VCPDistributedServer 负责）
+- 不是工具的权限管理系统
+
+---
+
+## 2. 快速启动
+
+### 前提条件
+- VCPChat 主进程已运行（提供 IPC 桥接）
+- VCPDistributedServer 已启动（执行工具调用）
+- `AppData/settings.json` 中已配置 `vcpServerUrl` 和 `vcpApiKey`
+
+### 启动方式
+双击 `VCPHumanToolBox/VCHB.lnk` 快捷方式，或执行：
+```bat
+cd VCPHumanToolBox
+start.bat
+```
+
+更常用的方式是，通过 VCPChat 主窗口的「工具箱」按钮唤起子窗口。
+
+---
+
+## 3. 整体架构
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      VCPHumanToolBox (Electron)                 │
+│                                                                 │
+│  ┌────────────────┐    IPC (contextIsolation)    ┌───────────┐  │
+│  │  renderer.js   │◄────────────────────────── │  preload  │  │
+│  │  (65KB, UI核心) │                             │   .js     │  │
+│  └───────┬────────┘                             └─────┬─────┘  │
+│          │ import│ expose  │
+│  ┌───────▼────────┐                             ┌─────▼─────┐  │
+│  │  config.js     │                             │  main.js  │  │
+│  │  (72KB, 工具定义)│                             │(IPC注册器)│  │
+│  └────────────────┘                             └─────┬─────┘  │
+│  ┌────────────────┐                                │        │
+│  │ tool-manager.js│                                   │ fetch│
+│  │ (48KB, 插件管理)│                                   ▼        │
+└──┴────────────────┴───────────────────────────────────┬────────┘
+                                                        │ vcp-ht-execute-tool-proxy
+                                         ┌──────────────▼─────────────────┐
+                                         │      VCPChat主进程 (desktopHandlers.js)      │
+                                         └──────────────┬─────────────────┘
+                                                        │ POST /v1/human/tool┌──────────────▼─────────────────┐
+                                         │      VCPDistributedServer       │
+                                         └────────────────────────────────┘
+```
+
+### 数据流（工具执行）
+
+```
+用户点击工具卡片→ showToolDetail()#渲染工具详情页
+    → buildToolForm()           # 根据 params schema 生成表单
+    →用户填写参数 + 点击执行
+    → executeTool()             # 收集FormData
+    → electronAPI.invoke('vcp-ht-execute-tool-proxy', toolName, args)
+    → main.js 拼装<<<[TOOL_REQUEST]>>> 格式请求体→ POST https://{vcpServerUrl}/v1/human/tool (Bearer Token)
+    → renderResult()            # 多模态结果渲染
+```
+
+### 安全三层
+
+| 层级 | 机制 |
+|------|------|
+| 进程隔离 | `contextIsolation: true` + `nodeIntegration: false` |
+| 通信白名单 | preload.js 只暴露 12 个 IPC 通道 |
+| 认证 | Bearer Token（来自 settings.json 的 vcpApiKey）|
+
+---
+
+## 4. 目录结构
+
+```
+VCPHumanToolBox/
+├── main.js                    # Electron 主进程：窗口管理 + IPC 注册（13.5KB）
+├── preload.js                 # 上下文桥：暴露安全 API到 renderer（3.8KB）
+├── renderer.js                # UI 核心：工具网格 + 表单 + 结果渲染（67KB）
+├── index.html                 # 窗口 HTML骨架（含 Tab 切换：工具/管理）
+├── style.css                  # 全部样式（31KB，含 Tool Manager 样式）
+├── package.json               # Electron 入口配置
+├── start.bat                  # Windows 启动脚本
+├── run_silent.vbs             # 无命令行窗口启动（供快捷方式使用）
+├── VCHB.lnk                # 桌面快捷方式
+│
+├── renderer_modules/
+│   ├── config.js# 工具定义库（72KB，46个出厂工具）
+│   ├── tool-manager.js        # 插件管理模块（48KB，v0.3 新增）
+│   └── ui/                    # UI 组件（拖拽排序等辅助组件）
+│
+├── WorkflowEditormodules/     # 工作流编辑器（部分实现）
+│   ├── WorkflowEditor_UIManager.js
+│   ├── WorkflowEditor_ExecutionEngine.js
+│   ├── WorkflowEditor_NodeManager.js
+│   └── WorkflowEditor_StateManager.js
+│
+└── ComfyUImodules/            # ComfyUI 本地生图集成
+```
+
+---
+
+## 5. 工具定义格式
+
+所有工具定义在 `renderer_modules/config.js` 中，`export const tools = { ... }` 对象。
+
+### 格式 A：多命令工具
+
+```javascript
+'ZImageTurboGen': {
+    displayName: 'Z-Image-Turbo 图片生成/编辑/合成',
+    description: '使用 Z-Image-Turbo 生成、编辑或合成图片。',
+    commands: {
+        'generate': {
+            description: '生成图片',
+            params: [
+                { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+                { name: 'prompt', type: 'textarea', required: true, placeholder: '详细描述' },
+                { name: 'size', type: 'select', required: false, options: ['1024x1024', '1280x720'], default: '1024x1024' }
+            ]
+        },
+        'edit': {
+            description: '编辑图片',
+            params: [ /* ... */ ]
+        }
+    }
+}
+```
+
+### 格式 B：单命令工具（直接 params）
+
+```javascript
+'GoogleSearch': {
+    displayName: 'Google 搜索',
+    description: '进行标准谷歌网页搜索。',
+    params: [
+        { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+        { name: 'query', type: 'text', required: true, placeholder: '搜索关键词' }
+    ]
+}
+```
+
+### 7 种参数类型（widget）
+
+| type | 渲染结果 | 适用场景 |
+|------|----------|----------|
+| `text` | 单行文本框 | 短字符串、名称、ID |
+| `textarea` | 多行文本框 | 长描述、提示词、代码 |
+| `number` | 数字输入框 | 整数、浮点数 |
+| `select` | 下拉菜单 | 枚举值，需配合 `options: []` |
+| `radio` | 单选按钮组 | 少量枚举值，需配合 `options: []` |
+| `checkbox` | 复选框 | 布尔值，可配合 `default: false` |
+| `dragdrop_image` | 拖拽图片上传框 | 图片 URL / base64 / 本地文件 |
+
+### 参数字段完整说明
+
+```javascript
+{
+    name: 'size',           // 必需：参数名（与 VCP 工具调用字段名一致）
+    type: 'select',         // 必需：见上表
+    required: true,         // 可选：是否必填，默认 false
+    placeholder: '描述',    // 可选：输入框占位文字
+    default: '1024x1024',   // 可选：默认值
+    options: ['a', 'b'],    // select/radio必需
+    min: 1, max: 100,       // number 可用
+    step: 0.1,              // number 可用
+    description: '说明',    // 可选：额外说明文字
+    dependsOn: {// 可选：条件显示
+        field: 'mode',
+        value: 'i2v'        // 仅当 mode=i2v 时显示此参数
+    }
+}
+```
+
+---
+
+## 6. 新增工具的两条路径
+
+### 路径 A：直接修改 config.js（推荐，适合开发者）
+
+在 `renderer_modules/config.js` 的 `tools` 对象中按格式添加新条目。
+**无需重启**（热重载）—— 但推荐重启 HumanToolBox 子窗口生效。
+**优先级**：会被用户通过插件管理面板导入的同名工具覆盖（Config Overlay 机制）。
+
+```javascript
+// 在 config.js 末尾的 tools 对象中添加：
+'MyNewTool': {
+    displayName: '我的新工具',
+    description: '描述这个工具做什么。[后端插件: MyNewTool]',
+    params: [
+        { name: 'maid', type: 'text', required: true, placeholder: '你的名字' },
+        { name: 'input', type: 'textarea', required: true, placeholder: '输入内容' }
+    ]
+}
+```
+
+### 路径 B：通过插件管理面板导入（推荐，适合用户）
+
+1. 点击顶部 **「管理」Tab**
+2. 点击 **「导入插件」**，首次使用需配置后端连接（主机/端口/用户名/密码）
+3. 从插件列表中勾选需要导入的插件，支持模糊搜索
+4. 点击 **「导入选中」**——工具会立即出现在工具网格中
+5. 如需调整参数定义，点击管理列表中的卡片进入**编辑对话框**
+
+**Config Overlay 规则**：用户导入的工具定义优先于config.js 中的同名工具。
+
+---
+
+## 7. 插件管理面板（v0.3）
+
+> 本节描述 2026-06-25 合并的新功能，核心模块为 `renderer_modules/tool-manager.js`。
+
+### 功能概览
+
+| 功能 | 说明 |
+|------|------|
+| 从后端导入 | 调用 `/admin_api/plugins`，将后端插件定义转换为本地工具定义 |
+| 参数自动解析 | 从manifest description 文本自动提取参数 schema（无需 AI） |
+| CRUD | 管理面板中对已导入工具进行编辑、批量删除 |
+| 表单编辑器 | 可视化编辑参数名/类型/必填/占位符/选项，支持新增/删除参数 |
+| Raw JSON编辑 | 直接编辑工具定义的 JSON，与表单编辑器双向同步 |
+| 全局搜索 | 在管理面板和导入列表中模糊匹配工具名/描述 |
+
+### 参数自动解析引擎（parseDescription）
+
+当插件 manifest 的 `parameters` 字段为空时，自动从 `description` 文本提取参数。支持四种格式：
+
+```
+# 格式 A（VCPClawMail、VCPAlarm风格）
+- 参数名 (类型, 必填): 描述
+- mailbox/alias: 可选，子邮箱槽位 mail1/mail2/mail3/mail4
+
+# 格式 B（TopicSponsor 风格）
+1. `topic_name`: 「始」xxx「末」 (必需)
+
+# 格式 D（AgentAssistant 风格）
+参数名:「始」(必需/可选)描述内容「末」
+
+# 格式 F（AgnesGen / DoubaoGen 风格——嵌入在<<<[TOOL_REQUEST]>>> 示例中）
+<<<[TOOL_REQUEST]>>>
+tool_name:「始」AgnesGen「末」,
+prompt:「始」(必需) 提示词描述「末」,
+size:「始」(可选) 图片尺寸「末」,
+<<<[END_TOOL_REQUEST]>>>
+```
+
+**三层Fallback 策略**：
+1. `parameters` 对象存在且非空 → 用`parseParams`（最可靠）
+2. `parameters` 为空 → 用 `parseDescription` 从文本解析
+3. 解析失败 → 只保留`maid` 参数（保证工具可用）
+
+### 用户数据存储
+
+导入的工具定义存储在 `settings.vcpht_userTools` 字段（随`AppData/settings.json` 持久化）。
+
+**不新增任何 IPC 通道**，复用已有的 `vcp-ht-get-settings` / `vcp-ht-save-settings`。
+
+### 管理模式说明
+
+- **默认**：点击工具卡片直接打开编辑对话框
+- **删除模式**：点击「删除模式」按钮进入，点击卡片选中/取消，再次点击按钮确认批量删除
+
+### 后端连接配置
+
+管理面板需要连接 VCPToolBox 后端的 Admin API：
+
+| 字段 | 说明 | 默认值 |
+|------|------|--------|
+|主机 | VCPToolBox 所在主机 | `localhost` |
+| 端口 | VCPToolBox 监听端口 | `6005` |
+| 用户名 | Admin API 用户名 | 见 VCPToolBox 配置 |
+| 密码 | Admin API 密码 | 见 VCPToolBox 配置 |
+
+配置存储于 `localStorage`（`vcpht_adminConfig`），与 contextIsolation 隔离保护。
+
+---
+
+## 8. 工作流编辑器（现状）
+
+>⚠️ **部分实现**：UI 框架和节点管理已完成，工具执行管线为空壳，不建议在生产中依赖。
+
+### 已实现
+
+-基于 jsPlumb 的可视化节点画布
+- 节点类型：VCPChat插件、VCPToolBox 插件、辅助节点
+- 节点状态管理（位置、配置、连接）
+- 侧边栏插件面板（搜索、分类、拖拽到画布）
+- 工作流保存/加载
+
+### 空壳（或许未实现）
+
+- `executeVCPChatPlugin()`：调用 VCPChat Agent 的逻辑为空壳
+- `executeVCPToolBoxPlugin()`：调用 VCPToolBox工具的逻辑为空壳
+- 节点间数据传递（输出变量注入下一节点的输入）
+
+### 后续计划
+
+完成执行引擎需要对接：
+1. `vcp-ht-execute-tool-proxy` IPC（工具执行已有，需接入工作流上下文）
+2. 变量替换引擎（`{{node_1.output}}` →实际值）
+3. 错误处理与节点状态回显
+
+---
+
+## 9. ComfyUI 集成
+
+HumanToolBox 对 `ComfyUIGen` 工具有专属支持：
+
+- 点击工具卡片右上角的⚙️ 设置按钮打开 **ComfyUI 配置抽屉**
+- 支持：查看/保存 ComfyUI 配置、管理工作流模板、导入/转换 ComfyUI 原生工作流
+
+IPC 通道（见 preload.js）：
+```
+comfyui:get-config
+comfyui:save-config
+comfyui:get-workflows
+comfyui:read-workflow
+comfyui:save-workflow
+comfyui:delete-workflow
+comfyui:get-plugin-path
+comfyui:import-and-convert-workflow
+comfyui:validate-workflow-template
+```
+
+---
+
+## 10. IPC 通道白名单
+
+`preload.js` 中 `allowedChannels` 严格限制可用通道（共12 个）：
+
+| 通道 | 用途 |
+|------|------|
+| `vcp-ht-execute-tool-proxy` | 核心：工具调用代理 |
+| `vcp-ht-get-settings` | 读取 settings.json |
+| `vcp-ht-save-settings` | 写入 settings.json（含 vcpht_userTools）|
+| `vcp-ht-process-wallpaper` | 壁纸处理 |
+| `comfyui:*`（7个）| ComfyUI 相关操作 |
+| `window-control`（send） | 窗口最小化/关闭 |
+
+**新增 IPC 原则**：在 `main.js` 中注册，在 `preload.js` 的 `allowedChannels` 中添加白名单，缺一不可。
+
+---
+
+## 11. 开发指南
+
+### 新增工具卡片（最低成本）
+
+只改`config.js`，零改动其他文件。
+
+### 修改 UI 或执行逻辑
+
+改 `renderer.js`，注意：
+- `allTools = { ...tools, ...userTools }` ——工具网格从 `allTools` 读取，不要直接访问 `tools`
+- `window.refreshToolGrid`——插件管理面板保存后调用此函数触发网格刷新
+- `buildToolForm()` 支持 `dependsOn` 条件显示，修改时保持兼容
+
+### 新增 IPC 通道
+
+1. `main.js`：`ipcMain.handle('channel-name', handler)`
+2. `preload.js`：`allowedChannels` 数组中添加 `'channel-name'`
+
+### 本地测试
+
+```bash
+cd VCPHumanToolBox
+# 确保 VCPChat 主进程已运行
+start.bat
+```
+
+### 常见问题
+
+**Q：导入插件后工具卡片没有更新？**  
+A：检查 `renderer.js` 中 `window.refreshToolGrid` 是否已在`initializeUI` 中正确赋值。
+
+**Q：工具执行返回 401/403？**  
+A：检查 `AppData/settings.json` 中的 `vcpApiKey` 是否有效，以及 VCPDistributedServer 是否正在运行。
+
+**Q：插件管理面板导入后参数都是空的？**  
+A：该插件的 manifest description 格式不在已支持的四种格式（A/B/D/F）中。通过「编辑」→「表单编辑」手动补充参数，或联系插件作者在 manifest 中补充结构化`parameters` 字段。
+
+**Q：搜索框无法输入？**  
+A：是事件监听器重复绑定导致的已知 Bug，重启 HumanToolBox 子窗口可临时解决。根本修复见 `attachEventListeners()` 开头的 `cloneNode` 方案。
+
+---
+
+## 变更日志
+
+### v0.3（2026-06-25）
+- 新增：插件管理面板（`tool-manager.js`）
+- 新增：`parseDescription` 四格式参数自动解析引擎
+- 新增：可视化表单编辑器（参数类型/必填/占位符/选项均可编辑）
+- 新增：批量删除模式、全局搜索框
+- 修复：invocationCommands 数组/对象格式兼容
+- 修复：导入/删除后实时刷新工具网格（无需重启）
+
+### v0.2（2026-06-25）
+- 新增：插件管理 Tab（index.html + renderer.js）
+- 新增：Config Overlay 机制（user-tools优先于 config.js）
+- 新增：`allTools` 动态合并，renderer.js 全面迁移
+
+### v0.1（初始版本）
+- 工具网格、动态表单、多模态结果渲染
+- ComfyUI 集成、工作流编辑器框架

--- a/VCPHumanToolBox/index.html
+++ b/VCPHumanToolBox/index.html
@@ -23,6 +23,8 @@
             <h1>工具箱</h1>
             <p>一个为人类设计的直观工具调用界面。</p>
             <div class="header-actions">
+                <button id="tool-tab-btn" class="tab-btn tab-btn-active">工具</button>
+                <button id="manage-tab-btn" class="tab-btn">管理</button>
                 <button id="workflow-btn" class="workflow-btn">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
@@ -34,6 +36,7 @@
 
         <main id="main-content">
             <div id="tool-grid" class="tool-grid"></div>
+            <div id="manage-panel" class="manage-panel" style="display: none;"></div>
 
             <div id="tool-detail-view" class="tool-detail-view" style="display: none;">
                 <button id="back-to-grid-btn" class="back-btn">&larr; 返回工具列表</button>

--- a/VCPHumanToolBox/renderer.js
+++ b/VCPHumanToolBox/renderer.js
@@ -4,8 +4,12 @@
 import { tools } from './renderer_modules/config.js';
 import * as canvasHandler from './renderer_modules/ui/canvas-handler.js';
 import * as dynamicImageHandler from './renderer_modules/ui/dynamic-image-handler.js';
+import { ToolManager, ToolManagerUI } from './renderer_modules/tool-manager.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
+    // --- 全局工具集合（合并 config.js + user tools）---
+    let allTools = { ...tools }; // 初始为config.js的工具
+
     // --- 元素获取 ---
     const toolGrid = document.getElementById('tool-grid');
     const toolDetailView = document.getElementById('tool-detail-view');
@@ -101,6 +105,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
+        // 加载用户工具并合并到allTools
+        const userTools = settings.vcpht_userTools || {};
+        allTools = { ...tools, ...userTools }; // user优先覆盖config
+
         initializeUI();
     }
 
@@ -167,7 +175,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             background: rgba(255,152,0,0.15); color: var(--highlight-text);
             white-space: nowrap; font-weight: 600;
         `;
-        const totalTools = Object.keys(tools).length;
+        const totalTools = Object.keys(allTools).length;
         countBadge.textContent = `共${totalTools} 个`;
 
         searchBar.appendChild(searchInput);
@@ -176,8 +184,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         toolGrid.appendChild(searchBar);
 
         // 生成工具卡片
-        for (const toolName in tools) {
-            const tool = tools[toolName];
+        for (const toolName in allTools) {
+            const tool = allTools[toolName];
             const category = getCategoryForTool(toolName);
             const isFav = favorites.includes(toolName);
 
@@ -291,7 +299,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
         currentToolName = toolName;
 
-        const tool = tools[toolName];
+        const tool = allTools[toolName];
         toolTitle.textContent = tool.displayName;
         toolDescription.textContent = tool.description;
         
@@ -341,7 +349,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function buildToolForm(toolName) {
-        const tool = tools[toolName];
+        const tool = allTools[toolName];
         toolForm.innerHTML = '';
         const paramsContainer = document.createElement('div');
         paramsContainer.id = 'params-container';
@@ -1421,6 +1429,48 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (workflowBtn) {
             workflowBtn.addEventListener('click', openWorkflowEditor);
         }
+
+        // Tab切换逻辑
+        const toolTabBtn = document.getElementById('tool-tab-btn');
+        const manageTabBtn = document.getElementById('manage-tab-btn');
+        const toolGridEl = document.getElementById('tool-grid');
+        const managePanelEl = document.getElementById('manage-panel');
+
+        if (toolTabBtn && manageTabBtn && toolGridEl && managePanelEl) {
+            toolTabBtn.addEventListener('click', () => {
+                toolTabBtn.classList.add('tab-btn-active');
+                manageTabBtn.classList.remove('tab-btn-active');
+                toolGridEl.style.display = 'grid';
+                managePanelEl.style.display = 'none';
+                toolDetailView.style.display = 'none'; // 隐藏工具详情
+            });
+
+            manageTabBtn.addEventListener('click', async () => {
+                manageTabBtn.classList.add('tab-btn-active');
+                toolTabBtn.classList.remove('tab-btn-active');
+                toolGridEl.style.display = 'none';
+                managePanelEl.style.display = 'block';
+                toolDetailView.style.display = 'none';
+
+                // 初始化管理面板（首次点击时）
+                if (!window.toolManagerUIInitialized) {
+                    await window.toolManagerUI.init('manage-panel');
+                    window.toolManagerUIInitialized = true;
+                }
+            });
+        }
+
+        // 初始化工具管理器（但不立即渲染UI）
+        window.toolManager = new ToolManager();
+        window.toolManagerUI = new ToolManagerUI(window.toolManager);
+        window.toolManagerUIInitialized = false;
+
+        // 暴露刷新工具网格的函数供tool-manager调用
+        window.refreshToolGrid = async () => {
+            await initializeApp(); // 重新加载settings并合并allTools
+            renderToolGrid(); // 重新渲染工具网格
+        };
+
         renderToolGrid();
         loadAndProcessWallpaper();
         setupImageViewer();

--- a/VCPHumanToolBox/renderer_modules/config.js
+++ b/VCPHumanToolBox/renderer_modules/config.js
@@ -1,8 +1,6 @@
 ﻿// renderer_modules/config.js
 // VCPHumanToolBox工具定义
-// 最后更新: 2026-04-21by CodeCC &赵枫
-// 备份: config.js.bak.20260421
-// 工具总数: 46 (原39+ 新增7)
+// author:lionsky & infinite-vector
 
 // --- 工具定义 ---
 export const tools = {

--- a/VCPHumanToolBox/renderer_modules/tool-manager.js
+++ b/VCPHumanToolBox/renderer_modules/tool-manager.js
@@ -1,0 +1,1117 @@
+// renderer_modules/tool-manager.js
+// VCPHumanToolBox 插件管理模块
+// 负责从后端导入插件、保存为用户工具定义、CRUD用户工具
+// 最后更新: 2026-06-25 by 程宸Cod v0.3-final
+
+/**
+ * 工具管理器 - 核心模块
+ * 功能：
+ * 1. 从后端 /admin_api/plugins 获取插件列表
+ * 2. 解析 manifest.invocationCommands 转换为 config.js 兼容格式
+ * 3. 从description文本自动解析参数（三层fallback）
+ * 4. 保存/读取用户自定义工具到 settings.vcpht_userTools
+ * 5. 提供管理面板UI：导入、编辑、删除、Raw JSON编辑
+ */
+
+export class ToolManager {
+    constructor() {
+        this.adminConfig = this.loadAdminConfig();
+        this.userTools = {}; // 从settings.vcpht_userTools加载
+    }
+
+    // ========================================
+    // 配置管理
+    // ========================================
+
+    loadAdminConfig() {
+        const stored = localStorage.getItem('vcpht_adminConfig');
+        if (stored) {
+            try {
+                return JSON.parse(stored);
+            } catch (e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    saveAdminConfig(config) {
+        localStorage.setItem('vcpht_adminConfig', JSON.stringify(config));
+        this.adminConfig = config;
+    }
+
+    // ========================================
+    // 用户工具的持久化（settings.vcpht_userTools）
+    // ========================================
+
+    async loadUserTools() {
+        try {
+            const settings = await window.electronAPI.invoke('vcp-ht-get-settings');
+            this.userTools = settings.vcpht_userTools || {};
+            return this.userTools;
+        } catch (error) {
+            console.error('[ToolManager] 加载用户工具失败:', error);
+            this.userTools = {};
+            return {};
+        }
+    }
+
+    async saveUserTools() {
+        try {
+            const settings = await window.electronAPI.invoke('vcp-ht-get-settings');
+            settings.vcpht_userTools = this.userTools;
+            const result = await window.electronAPI.invoke('vcp-ht-save-settings', settings);
+            if (!result.success) {
+                throw new Error(result.error || '保存失败');
+            }
+            console.log('[ToolManager] 用户工具已保存');
+            return true;
+        } catch (error) {
+            console.error('[ToolManager] 保存用户工具失败:', error);
+            throw error;
+        }
+    }
+
+    // ========================================
+    // 后端插件获取
+    // ========================================
+
+    async fetchPlugins() {
+        if (!this.adminConfig) {
+            throw new Error('请先配置后端连接信息');
+        }
+
+        const { host, port, username, password } = this.adminConfig;
+        const url = `http://${host}:${port}/admin_api/plugins`;
+        const auth = 'Basic ' + btoa(`${username}:${password}`);
+
+        try {
+            const response = await fetch(url, {
+                method: 'GET',
+                headers: {
+                    'Authorization': auth,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(`HTTP ${response.status}: ${errorText}`);
+            }
+
+            const plugins = await response.json();
+            return plugins; // Array<{name, manifest, isDistributed, enabled, ...}>
+        } catch (error) {
+            console.error('[ToolManager] 获取插件列表失败:', error);
+            throw error;
+        }
+    }
+
+    // ========================================
+    // Description文本解析（三格式兼容）
+    // ========================================
+
+    parseDescription(description, commandName = '') {
+        const params = [];
+        if (!description) return params;
+
+        // 找参数区域起始位置
+        const paramSection = description.match(/(?:参数[说明]*[:：]|Parameters[:：]|参数\s*\(|参数说明\s*\()([\s\S]+?)(?=调用格式|示例|Example|$)/i);
+        if (!paramSection) return params;
+
+        const text = paramSection[1];
+
+        // 格式A/C：- 参数名 (类型, 必填): 描述  或  - 参数名/别名: 描述
+        const lineRegex = /^[-*]\s*`?([^`:\n(]+(?:\/[^`:\n(]+)*)`?\s*(?:\(([^)]+)\))?\s*[:：]\s*(.+)/gm;
+        let match;
+        const foundParams = [];
+
+        while ((match = lineRegex.exec(text)) !== null) {
+            const [, nameRaw, typeHint, desc] = match;
+            const names = nameRaw.trim().split('/').map(n => n.trim()).filter(Boolean);
+            const primaryName = names[0];
+
+            // 跳过固定参数
+            if (['tool_name', 'command', 'maid'].includes(primaryName)) continue;
+
+            const required = /必需|required|必填/i.test(desc + (typeHint || ''));
+            const type = this.inferTypeFromHint(typeHint || '', desc);
+            const options = this.extractOptions(desc);
+
+            foundParams.push({
+                name: primaryName,
+                type: options.length > 0 ? 'select' : type,
+                required,
+                placeholder: desc.replace(/必需|可选|必填|字符串|整数|数字|可选值[:：]/gi, '').trim().slice(0, 60),
+                description: desc.trim().slice(0, 100),
+                options: options.length > 0 ? options : undefined
+            });
+        }
+
+        // 格式B：数字列表 N. `param`: 描述
+        if (foundParams.length === 0) {
+            const numberedRegex = /^\d+\.\s+`?([^`:\n(]+)`?\s*[:：]\s*[「「]?始[」」]?[^」」]*[「「]?末[」」]?\s*(?:\(([^)]+)\))?\s*(.+)/gm;
+            while ((match = numberedRegex.exec(text)) !== null) {
+                const [, nameRaw, typeHint, desc] = match;
+                if (['tool_name', 'command', 'maid'].includes(nameRaw.trim())) continue;
+
+                const required = /必需|required|必填/i.test((typeHint || '') + desc);
+                foundParams.push({
+                    name: nameRaw.trim(),
+                    type: this.inferTypeFromHint(typeHint || '', desc),
+                    required,
+                    placeholder: desc.replace(/必需|可选|字符串|必填/gi, '').trim().slice(0, 60),
+                    description: desc.trim().slice(0, 100)
+                });
+            }
+        }
+
+        // 格式D：VCP调用格式 参数名:「始」(必需/可选) 描述「末」
+        if (foundParams.length === 0) {
+            const vcpFormatRegex = /(\w+)[:：]\s*[「「]始[」」]\s*\(([^)]+)\)\s*([^「」]+)[「「]末[」」]/g;
+            while ((match = vcpFormatRegex.exec(description)) !== null) {
+                const [, nameRaw, hint, desc] = match;
+                if (['tool_name', 'command', 'maid'].includes(nameRaw.trim())) continue;
+
+                const required = /必需|required|必填/i.test(hint);
+                const type = this.inferTypeFromHint(hint, desc);
+                const options = this.extractOptions(desc);
+
+                foundParams.push({
+                    name: nameRaw.trim(),
+                    type: options.length > 0 ? 'select' : type,
+                    required,
+                    placeholder: desc.replace(/必需|可选|必填|字符串/gi, '').trim().slice(0, 60),
+                    description: desc.trim().slice(0, 100),
+                    options: options.length > 0 ? options : undefined
+                });
+            }
+        }
+
+        // 🔧 新增：格式F - VCP TOOL_REQUEST 嵌入式示例格式
+        // 适配 AgnesGen/DoubaoGen 等插件：参数在 <<<[TOOL_REQUEST]>>> 示例中定义
+        // 格式：参数名:__VCP_STYLE_PROTECT_5__,
+        if (foundParams.length === 0 && /<<<\[TOOL_REQUEST\]>>>/i.test(description)) {
+            const toolRequestBlock = description.match(/<<<\[TOOL_REQUEST\]>>>([\s\S]+?)<<<\[END_TOOL_REQUEST\]>>>/i);
+            if (toolRequestBlock) {
+                const blockText = toolRequestBlock[1];
+                // 正则：参数名:__VCP_STYLE_PROTECT_6__
+                const embeddedParamRegex = /(\w+)\s*[:：]\s*[「「]始[」」]\s*\(([^)]+)\)\s*([^「」]+?)[「「]末[」」]/g;
+                let embedMatch;
+                while ((embedMatch = embeddedParamRegex.exec(blockText)) !== null) {
+                    const [, nameRaw, hint, desc] = embedMatch;
+                    if (['tool_name', 'command', 'maid'].includes(nameRaw.trim())) continue;
+
+                    const required = /必需|required|必填/i.test(hint);
+                    const type = this.inferTypeFromHint(hint, desc);
+                    const options = this.extractOptions(desc);
+
+                    foundParams.push({
+                        name: nameRaw.trim(),
+                        type: options.length > 0 ? 'select' : type,
+                        required,
+                        placeholder: desc.replace(/必需|可选|必填|字符串|也兼容|统一尺寸字段/gi, '').trim().slice(0, 60),
+                        description: desc.trim().slice(0, 100),
+                        options: options.length > 0 ? options : undefined
+                    });
+                }
+            }
+        }
+
+        // 始终注入maid参数到第一位
+        if (!foundParams.find(p => p.name === 'maid')) {
+            foundParams.unshift({ name: 'maid', type: 'text', required: true, placeholder: '你的名字' });
+        }
+
+        return foundParams;
+    }
+
+    inferTypeFromHint(hint, desc) {
+        const combined = (hint + ' ' + desc).toLowerCase();
+        if (/bool|true.*false|false.*true|true\/false|是\/否/i.test(combined)) return 'checkbox';
+        if (/int|integer|number|数字|整数|数量/i.test(combined)) return 'number';
+        if (/text|长文本|详细|内容|正文|textarea/i.test(combined)) return 'textarea';
+        if (/url|路径|链接|file:|http/i.test(combined)) return 'text';
+        return 'text';
+    }
+
+    extractOptions(desc) {
+        // 提取 mail1/mail2/mail3/mail4 这类斜杠分隔枚举
+        const slashMatch = desc.match(/\b(\w+(?:\/\w+){2,})\b/);
+        if (slashMatch) {
+            const opts = slashMatch[1].split('/').filter(s => s.length > 0 && s.length < 30);
+            if (opts.length >= 2) return opts;
+        }
+
+        // 提取 'value1', 'value2' 引号枚举
+        const quoteMatches = desc.match(/'([^']+)'/g);
+        if (quoteMatches && quoteMatches.length >= 2) {
+            return quoteMatches.map(s => s.replace(/'/g, ''));
+        }
+
+        // 提取可选值：xxx、xxx、xxx
+        const colonMatch = desc.match(/可选值?[:：]\s*([^\n。]+)/i);
+        if (colonMatch) {
+            const opts = colonMatch[1].split(/[,、，|]/).map(s => s.trim()).filter(Boolean);
+            if (opts.length >= 2) return opts;
+        }
+
+        return [];
+    }
+
+    // ========================================
+    // 插件适配：manifest → config.js格式
+    // ========================================
+
+    adaptPlugin(apiPlugin) {
+        const { name, manifest } = apiPlugin;
+        if (!manifest || !manifest.capabilities || !manifest.capabilities.invocationCommands) {
+            return null;
+        }
+
+        let invocationCommands = manifest.capabilities.invocationCommands;
+
+        // 兼容数组格式（分布式插件）和对象格式（后端插件）
+        if (Array.isArray(invocationCommands)) {
+            const commandsObj = {};
+            invocationCommands.forEach(cmd => {
+                const cmdName = cmd.command || cmd.commandIdentifier || 'default';
+                commandsObj[cmdName] = cmd;
+            });
+            invocationCommands = commandsObj;
+        }
+
+        const commandNames = Object.keys(invocationCommands);
+
+        // 单命令工具
+        if (commandNames.length === 1) {
+            const cmdName = commandNames[0];
+            const singleCmd = invocationCommands[cmdName];
+            let params = this.parseParams(singleCmd.parameters || {});
+
+            // 三层fallback：parameters为空时尝试parseDescription
+            if (params.length === 0 && singleCmd.description) {
+                params = this.parseDescription(singleCmd.description, cmdName);
+            }
+
+            // 仍为空，只放maid
+            if (params.length === 0) {
+                params = [{ name: 'maid', type: 'text', required: true, placeholder: '你的名字' }];
+            }
+
+            return {
+                displayName: manifest.displayName || name,
+                description: manifest.description || '',
+                params
+            };
+        }
+
+        // 多命令工具
+        const adapted = {
+            displayName: manifest.displayName || name,
+            description: manifest.description || '',
+            commands: {}
+        };
+
+        for (const cmdName in invocationCommands) {
+            const cmd = invocationCommands[cmdName];
+            let params = this.parseParams(cmd.parameters || {});
+
+            // 三层fallback
+            if (params.length === 0 && cmd.description) {
+                params = this.parseDescription(cmd.description, cmdName);
+            }
+
+            if (params.length === 0) {
+                params = [{ name: 'maid', type: 'text', required: true, placeholder: '你的名字' }];
+            }
+
+            adapted.commands[cmdName] = {
+                description: cmd.description || '',
+                params
+            };
+        }
+
+        return adapted;
+    }
+
+    parseParams(parameters) {
+        const params = [];
+        for (const paramName in parameters) {
+            const param = parameters[paramName];
+            const parsed = {
+                name: paramName,
+                type: this.inferType(param),
+                required: param.required || false,
+                placeholder: param.description || '',
+                description: param.description || ''
+            };
+
+            // 提取默认值
+            if (param.default !== undefined) {
+                parsed.default = param.default;
+            }
+
+            // 提取枚举选项
+            if (param.enum && Array.isArray(param.enum)) {
+                parsed.options = param.enum;
+                parsed.type = 'select';
+            }
+
+            params.push(parsed);
+        }
+        return params;
+    }
+
+    inferType(param) {
+        if (param.type === 'number' || param.type === 'integer') return 'number';
+        if (param.type === 'boolean') return 'checkbox';
+        if (param.enum && Array.isArray(param.enum)) return 'select';
+        if (param.type === 'array') return 'textarea';
+
+        const desc = (param.description || '').toLowerCase();
+        if (desc.includes('url') || desc.includes('路径') || desc.includes('长文本') || desc.includes('详细')) {
+            return 'textarea';
+        }
+
+        return 'text';
+    }
+
+    // ========================================
+    // 用户工具CRUD
+    // ========================================
+
+    addUserTool(toolName, toolDefinition) {
+        this.userTools[toolName] = toolDefinition;
+    }
+
+    updateUserTool(toolName, toolDefinition) {
+        if (!this.userTools[toolName]) {
+            throw new Error(`工具 ${toolName} 不存在`);
+        }
+        this.userTools[toolName] = toolDefinition;
+    }
+
+    deleteUserTool(toolName) {
+        if (!this.userTools[toolName]) {
+            throw new Error(`工具 ${toolName} 不存在`);
+        }
+        delete this.userTools[toolName];
+    }
+
+    getUserTool(toolName) {
+        return this.userTools[toolName];
+    }
+
+    listUserTools() {
+        return Object.keys(this.userTools).map(name => ({
+            name,
+            ...this.userTools[name]
+        }));
+    }
+}
+
+// ========================================
+// UI 渲染模块
+// ========================================
+
+export class ToolManagerUI {
+    constructor(toolManager) {
+        this.manager = toolManager;
+        this.container = null;
+        this.deleteMode = false; // 删除模式开关
+        this.selectedForDelete = new Set(); // 删除模式选中项
+    }
+
+    async init(containerId) {
+        this.container = document.getElementById(containerId);
+        if (!this.container) {
+            throw new Error(`容器 ${containerId} 不存在`);
+        }
+
+        await this.manager.loadUserTools();
+        this.render();
+    }
+
+    render() {
+        this.container.innerHTML = `
+            <div class="tool-manager-panel">
+                <div class="tm-header">
+                    <h3>插件管理</h3>
+                    <div class="tm-actions">
+                        <input type="text" id="tm-global-search" placeholder="🔍 搜索工具..." style="width:200px;padding:8px 12px;background:var(--input-bg);border:1px solid var(--border-color);border-radius:6px;color:var(--primary-text);font-size:14px;margin-right:10px;">
+                        <button class="tm-btn tm-btn-danger" id="tm-delete-mode-btn" style="margin-right:10px">删除模式</button>
+                        <button class="tm-btn tm-btn-primary" id="tm-import-btn" style="border:2px solid rgba(59,130,246,0.5)">导入插件</button>
+                    </div>
+                </div>
+                <div class="tm-content">
+                    <div class="tm-user-tools-list" id="tm-user-tools-list">
+                        <!-- 用户工具列表 -->
+                    </div>
+                </div>
+            </div>
+        `;
+
+        this.renderUserToolsList();
+        this.attachEventListeners();
+    }
+
+    renderUserToolsList() {
+        const listContainer = document.getElementById('tm-user-tools-list');
+        const tools = this.manager.listUserTools();
+
+        if (tools.length === 0) {
+            listContainer.innerHTML = `
+                <div class="tm-empty-state">
+                    <p>还没有导入任何工具</p>
+                    <p style="font-size: 12px; color: var(--secondary-text);">点击"导入插件"开始</p>
+                </div>
+            `;
+            return;
+        }
+
+        const searchQuery = document.getElementById('tm-global-search')?.value.toLowerCase() || '';
+        const filtered = tools.filter(tool => {
+            if (!searchQuery) return true;
+            const searchable = (tool.displayName + ' ' + tool.description + ' ' + tool.name).toLowerCase();
+            return searchable.includes(searchQuery);
+        });
+
+        if (filtered.length === 0) {
+            listContainer.innerHTML = `<p style="color:var(--secondary-text);text-align:center;padding:30px">没有匹配的工具</p>`;
+            return;
+        }
+
+        listContainer.innerHTML = filtered.map(tool => {
+            const isSelected = this.selectedForDelete.has(tool.name);
+            const cardClass = this.deleteMode ? 'tm-tool-card tm-tool-card-delete-mode' : 'tm-tool-card tm-tool-card-clickable';
+            const selectedClass = isSelected ? 'tm-tool-card-selected' : '';
+
+            return `
+        <div class="${cardClass} ${selectedClass}" data-tool-name="${tool.name}" data-clickable="${!this.deleteMode}">
+            <div class="tm-tool-info">
+                <h4>${tool.displayName}</h4>
+                <p>${tool.description}</p>
+                <span class="tm-tool-badge">${Object.keys(tool.commands || {}).length || 1} 个命令</span>
+            </div>
+        </div>
+    `;
+        }).join('');
+    }
+
+    attachEventListeners() {
+        // 🔧 修复：移除旧监听器，防止重复绑定
+        const oldSearchInput = document.getElementById('tm-global-search');
+        if (oldSearchInput) {
+            oldSearchInput.replaceWith(oldSearchInput.cloneNode(true)); // 克隆新元素，清除所有旧事件
+        }
+        
+        // 全局搜索
+        const searchInput = document.getElementById('tm-global-search');
+        if (searchInput) {
+            searchInput.addEventListener('input', () => this.renderUserToolsList());
+        }
+
+        // 导入按钮
+        const importBtn = document.getElementById('tm-import-btn');
+        if (importBtn) {
+            importBtn.addEventListener('click', () => this.showImportDialog());
+        }
+
+        // 删除模式按钮
+        const deleteModeBtn = document.getElementById('tm-delete-mode-btn');
+        if (deleteModeBtn) {
+            deleteModeBtn.addEventListener('click', () => {
+                this.deleteMode = !this.deleteMode;
+                deleteModeBtn.textContent = this.deleteMode ? '确认删除' : '删除模式';
+                deleteModeBtn.className = this.deleteMode ? 'tm-btn tm-btn-primary' : 'tm-btn tm-btn-danger';
+                if (this.deleteMode) {
+                    this.renderUserToolsList();
+                } else {
+                    this.confirmBatchDelete();
+                }
+            });
+        }
+
+        // 卡片点击事件（编辑或删除）——必须在listContainer获取之后
+        const listContainer = document.getElementById('tm-user-tools-list');
+        if (listContainer) {
+            listContainer.addEventListener('click', (e) => {
+                const card = e.target.closest('.tm-tool-card');
+                if (!card) return;
+
+                const toolName = card.dataset.toolName;
+
+                if (this.deleteMode) {
+                    // 删除模式：切换选中状态
+                    if (this.selectedForDelete.has(toolName)) {
+                        this.selectedForDelete.delete(toolName);
+                    } else {
+                        this.selectedForDelete.add(toolName);
+                    }
+                    this.renderUserToolsList();
+                } else {
+                    // 默认编辑模式：直接打开编辑
+                    this.showEditDialog(toolName);
+                }
+            });
+        }
+    }
+
+    async confirmBatchDelete() {
+        if (this.selectedForDelete.size === 0) {
+            this.renderUserToolsList();
+            return;
+        }
+
+        const names = Array.from(this.selectedForDelete);
+        if (!confirm(`确定删除 ${names.length} 个工具吗？\n${names.join(', ')}\n\n此操作不可恢复。`)) {
+            this.selectedForDelete.clear();
+            this.renderUserToolsList();
+            return;
+        }
+
+        try {
+            for (const name of names) {
+                this.manager.deleteUserTool(name);
+            }
+            await this.manager.saveUserTools();
+            if (window.refreshToolGrid) await window.refreshToolGrid();
+            this.showToast(`已删除 ${names.length} 个工具`);
+            this.selectedForDelete.clear();
+            this.deleteMode = false; // 删除完成后退出删除模式
+            this.render();
+        } catch (error) {
+            alert(`批量删除失败: ${error.message}`);
+        }
+    }
+
+    // ========================================
+    // 对话框：导入
+    // ========================================
+
+    async showImportDialog() {
+        if (!this.manager.adminConfig) {
+            this.showCredentialDialog();
+            return;
+        }
+
+        const overlay = this.createOverlay();
+        const dialog = document.createElement('div');
+        dialog.className = 'tm-dialog tm-dialog-large';
+        dialog.innerHTML = `
+            <div class="tm-dialog-header">
+                <h3>导入插件</h3>
+                <button class="tm-dialog-close">&times;</button>
+            </div>
+            <div class="tm-dialog-body">
+                <p style="text-align: center; color: var(--secondary-text);">正在加载插件列表...</p>
+            </div>
+        `;
+
+        overlay.appendChild(dialog);
+        document.body.appendChild(overlay);
+
+        const closeBtn = dialog.querySelector('.tm-dialog-close');
+        closeBtn.addEventListener('click', () => document.body.removeChild(overlay));
+
+        try {
+            const plugins = await this.manager.fetchPlugins();
+            const adapted = plugins
+                .map(p => ({ raw: p, adapted: this.manager.adaptPlugin(p) }))
+                .filter(p => p.adapted !== null);
+
+            if (adapted.length === 0) {
+                dialog.querySelector('.tm-dialog-body').innerHTML = `
+                    <p style="color: var(--warning-color);">后端没有可用的插件（无invocationCommands）</p>
+                `;
+                return;
+            }
+
+            this.renderImportList(dialog.querySelector('.tm-dialog-body'), adapted);
+        } catch (error) {
+            dialog.querySelector('.tm-dialog-body').innerHTML = `
+                <p style="color: var(--danger-color);">加载失败: ${error.message}</p>
+                <button class="tm-btn tm-btn-secondary" id="tm-reconfig-btn">重新配置</button>
+            `;
+            const reconfigBtn = dialog.querySelector('#tm-reconfig-btn');
+            if (reconfigBtn) {
+                reconfigBtn.addEventListener('click', () => {
+                    document.body.removeChild(overlay);
+                    this.showCredentialDialog();
+                });
+            }
+        }
+    }
+    renderImportList(container, adapted) {
+        const selectedTools = new Set();
+
+        container.innerHTML = `
+        <div style="margin-bottom: 12px;">
+            <input type="text" id="tm-plugin-search" placeholder="🔍 搜索插件..." style="
+                width: 100%; padding: 8px 12px; background: var(--input-bg);
+                border: 1px solid var(--border-color); border-radius: 6px;
+                color: var(--primary-text); font-size: 14px; box-sizing: border-box;">
+        </div>
+        <div class="tm-import-list" id="tm-plugin-list" style="max-height:50vh;overflow-y:auto;">
+            ${adapted.map((p, idx) => {
+            const shortDesc = p.adapted.description.slice(0, 120);
+            const needsExpand = p.adapted.description.length > 120;
+            return `
+                    <div class="tm-import-item" data-idx="${idx}" data-search="${(p.adapted.displayName + ' ' + p.adapted.description + ' ' + p.raw.name).toLowerCase()}" style="padding:12px;margin-bottom:8px;border:1px solid var(--border-color);border-radius:6px;background:rgba(255,255,255,0.02);">
+                        <label class="tm-import-checkbox" style="display:flex;align-items:start;cursor:pointer;">
+                            <input type="checkbox" data-idx="${idx}" style="margin-right:12px;margin-top:4px;">
+                            <div style="flex:1;">
+                                <div style="display:flex;align-items:center;gap:6px;margin-bottom:6px;">
+                                    <strong style="font-size:14px;">${p.adapted.displayName}</strong>
+                                    <span style="font-size:11px;padding:2px 6px;border-radius:3px;background:${p.raw.isDistributed ? 'rgba(59,130,246,0.2)' : 'rgba(16,185,129,0.2)'};color:${p.raw.isDistributed ? '#60a5fa' : '#34d399'}">${p.raw.isDistributed ? '[分布式]' : '[后端]'}</span>
+                                </div>
+                                <div style="font-size:12px;color:var(--secondary-text);line-height:1.5;">
+                                    <span class="tm-desc-short">${shortDesc}${needsExpand ? '...' : ''}</span>
+                                    ${needsExpand ? `<span class="tm-desc-full" style="display:none;">${p.adapted.description}</span>` : ''}
+                                    ${needsExpand ? `<button class="tm-btn tm-btn-sm" onclick="this.previousElementSibling.style.display='inline';this.previousElementSibling.previousElementSibling.style.display='none';this.style.display='none'" style="margin-left:6px;font-size:11px;padding:2px 6px">展开</button>` : ''}
+                                </div>
+                            </div>
+                        </label>
+                    </div>
+                `;
+        }).join('')}
+        </div>
+        <div class="tm-dialog-footer">
+            <button class="tm-btn tm-btn-secondary" id="tm-import-cancel">取消</button>
+            <button class="tm-btn tm-btn-primary" id="tm-import-confirm" disabled>导入选中(0)</button>
+        </div>
+    `;
+
+        const searchInput = container.querySelector('#tm-plugin-search');
+        const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+        const confirmBtn = container.querySelector('#tm-import-confirm');
+        const cancelBtn = container.querySelector('#tm-import-cancel');
+
+        // 搜索过滤
+        searchInput.addEventListener('input', () => {
+            const query = searchInput.value.toLowerCase().trim();
+            container.querySelectorAll('.tm-import-item').forEach(item => {
+                item.style.display = (!query || item.dataset.search.includes(query)) ? '' : 'none';
+            });
+        });
+
+        checkboxes.forEach(cb => {
+            cb.addEventListener('change', () => {
+                const idx = parseInt(cb.dataset.idx, 10);
+                cb.checked ? selectedTools.add(idx) : selectedTools.delete(idx);
+                confirmBtn.disabled = selectedTools.size === 0;
+                confirmBtn.textContent = `导入选中 (${selectedTools.size})`;
+            });
+        });
+
+        cancelBtn.addEventListener('click', () => {
+            const overlay = container.closest('.tm-overlay');
+            document.body.removeChild(overlay);
+        });
+
+        confirmBtn.addEventListener('click', async () => {
+            const toImport = Array.from(selectedTools).map(idx => adapted[idx]);
+            await this.importTools(toImport);
+            const overlay = container.closest('.tm-overlay');
+            document.body.removeChild(overlay);
+            this.render();
+        });
+    }
+
+    async importTools(tools) {
+        const distributedCount = tools.filter(t => t.raw.isDistributed).length;
+
+        for (const { raw, adapted } of tools) {
+            const toolName = raw.name;
+            this.manager.addUserTool(toolName, adapted);
+        }
+        await this.manager.saveUserTools();
+
+        let message = `成功导入 ${tools.length} 个工具`;
+        if (distributedCount > 0) {
+            message += `\n\n⚠️ 其中 ${distributedCount} 个为分布式插件，参数已从description自动解析。建议导入后检查参数是否正确。`;
+        }
+
+        this.showToast(message);
+
+        // 触发工具网格刷新
+        if (window.refreshToolGrid) {
+            await window.refreshToolGrid();
+        }
+    }
+
+    // ========================================
+    // 对话框：凭据配置
+    // ========================================
+
+    showCredentialDialog() {
+        const overlay = this.createOverlay();
+        const dialog = document.createElement('div');
+        dialog.className = 'tm-dialog';
+
+        const existing = this.manager.adminConfig || {};
+        dialog.innerHTML = `
+            <div class="tm-dialog-header">
+                <h3>配置后端连接</h3>
+                <button class="tm-dialog-close">&times;</button>
+            </div>
+            <div class="tm-dialog-body">
+                <div class="tm-form-group">
+                    <label>主机地址</label>
+                    <input type="text" id="tm-host" value="${existing.host || 'localhost'}" placeholder="localhost">
+                </div>
+                <div class="tm-form-group">
+                    <label>端口</label>
+                    <input type="number" id="tm-port" value="${existing.port || '6005'}" placeholder="6005">
+                </div>
+                <div class="tm-form-group">
+                    <label>用户名</label>
+                    <input type="text" id="tm-username" value="${existing.username || ''}" placeholder="admin">
+                </div>
+                <div class="tm-form-group">
+                    <label>密码</label>
+                    <input type="password" id="tm-password" value="${existing.password || ''}" placeholder="密码">
+                </div>
+            </div>
+            <div class="tm-dialog-footer">
+                <button class="tm-btn tm-btn-secondary" id="tm-cred-cancel">取消</button>
+                <button class="tm-btn tm-btn-primary" id="tm-cred-save">保存</button>
+            </div>
+        `;
+
+        overlay.appendChild(dialog);
+        document.body.appendChild(overlay);
+
+        const closeBtn = dialog.querySelector('.tm-dialog-close');
+        const cancelBtn = dialog.querySelector('#tm-cred-cancel');
+        const saveBtn = dialog.querySelector('#tm-cred-save');
+
+        const close = () => document.body.removeChild(overlay);
+
+        closeBtn.addEventListener('click', close);
+        cancelBtn.addEventListener('click', close);
+
+        saveBtn.addEventListener('click', () => {
+            const config = {
+                host: document.getElementById('tm-host').value.trim(),
+                port: document.getElementById('tm-port').value.trim(),
+                username: document.getElementById('tm-username').value.trim(),
+                password: document.getElementById('tm-password').value.trim()
+            };
+
+            if (!config.host || !config.port || !config.username || !config.password) {
+                alert('请填写完整信息');
+                return;
+            }
+
+            this.manager.saveAdminConfig(config);
+            this.showToast('连接配置已保存');
+            close();
+        });
+    }
+
+    // ========================================
+    // 对话框：编辑
+    // ========================================
+
+    showEditDialog(toolName) {
+        const tool = this.manager.getUserTool(toolName);
+        if (!tool) return;
+
+        const overlay = this.createOverlay();
+        const dialog = document.createElement('div');
+        dialog.className = 'tm-dialog tm-dialog-large';
+        dialog.innerHTML = `
+        <div class="tm-dialog-header">
+            <h3>编辑工具: ${tool.displayName}</h3>
+            <button class="tm-dialog-close">&times;</button>
+        </div>
+        <div class="tm-dialog-body">
+            <div class="tm-tabs" style="padding: 15px 20px 0; border-bottom: 1px solid var(--border-color);">
+                <button class="tm-tab tm-tab-active" data-tab="form">表单编辑</button>
+                <button class="tm-tab" data-tab="json">Raw JSON</button>
+            </div>
+            <div id="tm-tab-form" style="padding: 20px; max-height: 60vh; overflow-y: auto;"></div>
+            <div id="tm-tab-json" style="padding: 20px; max-height: 60vh; overflow-y: auto; display: none;">
+                <textarea id="tm-json-editor" style="width: 100%; min-height: 400px; font-family: 'Cascadia Code', monospace; font-size: 12px; background: var(--input-bg); color: var(--primary-text); border: 1px solid var(--border-color); border-radius: 4px; padding: 10px; box-sizing: border-box; resize: vertical;">${JSON.stringify(tool, null, 2)}</textarea>
+            </div>
+        </div>
+        <div class="tm-dialog-footer">
+            <button class="tm-btn tm-btn-secondary" id="tm-edit-cancel">取消</button>
+            <button class="tm-btn tm-btn-primary" id="tm-edit-save">保存</button>
+        </div>
+    `;
+
+        overlay.appendChild(dialog);
+        document.body.appendChild(overlay);
+
+        // 构建工作副本
+        let workingCopy = JSON.parse(JSON.stringify(tool));
+        const formTab = dialog.querySelector('#tm-tab-form');
+        const jsonEditor = dialog.querySelector('#tm-json-editor');
+
+        // 收集所有现有参数名作为候选
+        const allParamNames = new Set();
+        const collectNames = (params) => {
+            if (Array.isArray(params)) params.forEach(p => allParamNames.add(p.name));
+        };
+        if (workingCopy.params) collectNames(workingCopy.params);
+        if (workingCopy.commands) {
+            Object.values(workingCopy.commands).forEach(cmd => collectNames(cmd.params || []));
+        }
+
+        // 渲染表单编辑器
+        const renderFormEditor = () => {
+            formTab.innerHTML = '';
+
+            // 基本信息
+            formTab.innerHTML = `
+            <div class="tm-form-group">
+                <label>显示名称</label>
+                <input type="text" id="tm-edit-displayName" value="${workingCopy.displayName || ''}" style="width:100%;padding:8px 12px;background:var(--input-bg);border:1px solid var(--border-color);border-radius:6px;color:var(--primary-text);font-size:14px;box-sizing:border-box;">
+            </div>
+            <div class="tm-form-group">
+                <label>描述</label>
+                <input type="text" id="tm-edit-description" value="${workingCopy.description || ''}" style="width:100%;padding:8px 12px;background:var(--input-bg);border:1px solid var(--border-color);border-radius:6px;color:var(--primary-text);font-size:14px;box-sizing:border-box;">
+            </div>
+        `;
+
+            // 基本信息变动同步
+            formTab.querySelector('#tm-edit-displayName').addEventListener('input', e => { workingCopy.displayName = e.target.value; });
+            formTab.querySelector('#tm-edit-description').addEventListener('input', e => { workingCopy.description = e.target.value; });
+
+            // 参数编辑器
+            const renderParamsEditor = (params, onUpdate) => {
+                const wrap = document.createElement('div');
+                wrap.className = 'tm-params-editor';
+
+                const header = document.createElement('div');
+                header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;';
+                header.innerHTML = `<span style="font-size:13px;color:var(--secondary-text);">参数列表 (${params.length})</span>`;
+                const addBtn = document.createElement('button');
+                addBtn.className = 'tm-btn tm-btn-sm tm-btn-secondary';
+                addBtn.textContent = '+ 新增参数';
+                addBtn.addEventListener('click', () => {
+                    params.push({ name: 'new_param', type: 'text', required: false, placeholder: '' });
+                    onUpdate(params);
+                    refreshTable();
+                });
+                header.appendChild(addBtn);
+                wrap.appendChild(header);
+
+                const table = document.createElement('div');
+                table.className = 'tm-params-table';
+
+                const refreshTable = () => {
+                    table.innerHTML = `
+                    <div style="display:grid;grid-template-columns:1fr 100px 60px 1fr 80px 40px;gap:6px;margin-bottom:6px;padding:0 4px;">
+                        <span style="font-size:11px;color:var(--secondary-text);">参数名</span>
+                        <span style="font-size:11px;color:var(--secondary-text);">类型</span>
+                        <span style="font-size:11px;color:var(--secondary-text);">必填</span>
+                        <span style="font-size:11px;color:var(--secondary-text);">占位符/默认值</span>
+                        <span style="font-size:11px;color:var(--secondary-text);">选项</span>
+                        <span></span>
+                    </div>
+                `;
+
+                    params.forEach((param, i) => {
+                        const row = document.createElement('div');
+                        row.style.cssText = 'display:grid;grid-template-columns:1fr 100px 60px 1fr 80px 40px;gap:6px;margin-bottom:6px;align-items:center;';
+
+                        const inputStyle = 'width:100%;padding:6px 8px;background:var(--input-bg);border:1px solid var(--border-color);border-radius:4px;color:var(--primary-text);font-size:12px;box-sizing:border-box;';
+
+                        // datalist for param names
+                        const datalistId = `tm-param-names-${i}`;
+                        const optionsHtml = [...allParamNames].map(n => `<option value="${n}">`).join('');
+
+                        row.innerHTML = `
+                            <div style="position:relative;min-width:0;">
+                                <input type="text" value="${param.name || ''}" placeholder="参数名" list="${datalistId}" style="${inputStyle}">
+                            </div>
+                            <select style="${inputStyle}">
+                                ${['text', 'textarea', 'number', 'select', 'checkbox', 'radio', 'dragdrop_image'].map(t =>
+                            `<option value="${t}" ${param.type === t ? 'selected' : ''}>${t}</option>`
+                        ).join('')}
+                            </select>
+                            <div style="text-align:center;"><input type="checkbox" ${param.required ? 'checked' : ''}></div>
+                            <input type="text" value="${param.placeholder || param.default || ''}" placeholder="占位符/默认值" style="${inputStyle}">
+                            ${(param.type === 'select' || param.type === 'radio') ? `<button style="background:rgba(59,130,246,0.2);color:#93c5fd;border:none;border-radius:4px;cursor:pointer;padding:4px 6px;font-size:11px;">编辑</button>` : '<div></div>'}
+                            <button style="background:var(--danger-color);color:white;border:none;border-radius:4px;cursor:pointer;padding:4px 8px;font-size:12px;">✕</button>
+                            <datalist id="${datalistId}">${optionsHtml}</datalist>
+                        `;
+
+                        const nameInput = row.children[0].querySelector('input'); // 从wrapper取input
+                        const [, typeSelect, , placeholderInput, optionsBtn, deleteBtn] = row.children;
+                        const reqCb = row.querySelector('input[type="checkbox"]');
+
+                        nameInput.addEventListener('input', e => { params[i].name = e.target.value; onUpdate(params); });
+                        typeSelect.addEventListener('change', e => {
+                            params[i].type = e.target.value;
+                            onUpdate(params);
+                            refreshTable();
+                        });
+                        reqCb.addEventListener('change', e => { params[i].required = e.target.checked; onUpdate(params); });
+                        placeholderInput.addEventListener('input', e => { params[i].placeholder = e.target.value; params[i].default = e.target.value; onUpdate(params); });
+                        if (param.type === 'select' || param.type === 'radio') {
+                            optionsBtn.addEventListener('click', () => {
+                                const current = param.options ? param.options.join(', ') : '';
+                                const input = prompt('编辑选项（逗号分隔）:', current);
+                                if (input !== null) {
+                                    params[i].options = input.split(',').map(s => s.trim()).filter(Boolean);
+                                    onUpdate(params);
+                                }
+                            });
+                        }
+                        deleteBtn.addEventListener('click', () => {
+                            params.splice(i, 1);
+                            onUpdate(params);
+                            refreshTable();
+                        });
+
+                        table.appendChild(row);
+                    });
+                };
+
+                refreshTable();
+                wrap.appendChild(table);
+                return wrap;
+            };
+
+            // 单命令工具（有params）
+            if (workingCopy.params) {
+                const section = document.createElement('div');
+                section.style.marginTop = '15px';
+                const label = document.createElement('div');
+                label.style.cssText = 'font-size:13px;font-weight:600;color:var(--primary-text);margin-bottom:8px;';
+                label.textContent = '参数编辑';
+                section.appendChild(label);
+                section.appendChild(renderParamsEditor(workingCopy.params, params => { workingCopy.params = params; }));
+                formTab.appendChild(section);
+            }
+
+            // 多命令工具（有commands）
+            if (workingCopy.commands) {
+                const section = document.createElement('div');
+                section.style.marginTop = '15px';
+
+                const cmdNames = Object.keys(workingCopy.commands);
+                if (cmdNames.length > 1) {
+                    // 多命令：用accordion
+                    cmdNames.forEach(cmdName => {
+                        const cmdBlock = document.createElement('details');
+                        cmdBlock.style.cssText = 'border:1px solid var(--border-color);border-radius:6px;margin-bottom:8px;overflow:hidden;';
+                        const summary = document.createElement('summary');
+                        summary.style.cssText = 'padding:10px 14px;cursor:pointer;background:rgba(255,255,255,0.03);font-weight:500;';
+                        summary.textContent = `${cmdName} — ${workingCopy.commands[cmdName].description || ''}`;
+                        cmdBlock.appendChild(summary);
+                        const inner = document.createElement('div');
+                        inner.style.padding = '12px';
+                        inner.appendChild(renderParamsEditor(workingCopy.commands[cmdName].params || [], params => { workingCopy.commands[cmdName].params = params; }));
+                        cmdBlock.appendChild(inner);
+                        section.appendChild(cmdBlock);
+                    });
+                } else {
+                    // 单命令的commands格式
+                    const [cmdName] = cmdNames;
+                    const label = document.createElement('div');
+                    label.style.cssText = 'font-size:13px;font-weight:600;color:var(--primary-text);margin-bottom:8px;';
+                    label.textContent = `参数编辑 (${cmdName})`;
+                    section.appendChild(label);
+                    section.appendChild(renderParamsEditor(workingCopy.commands[cmdName].params || [], params => { workingCopy.commands[cmdName].params = params; }));
+                }
+
+                formTab.appendChild(section);
+            }
+        };
+
+        renderFormEditor();
+
+        // Tab切换（表单 ↔ JSON双向同步）
+        const tabs = dialog.querySelectorAll('.tm-tab');
+        tabs.forEach(tab => {
+            tab.addEventListener('click', () => {
+                tabs.forEach(t => t.classList.remove('tm-tab-active'));
+                tab.classList.add('tm-tab-active');
+
+                if (tab.dataset.tab === 'form') {
+                    dialog.querySelector('#tm-tab-json').style.display = 'none';
+                    dialog.querySelector('#tm-tab-form').style.display = 'block';
+                    // 从JSON同步回来
+                    try {
+                        workingCopy = JSON.parse(jsonEditor.value);
+                        renderFormEditor();
+                    } catch (e) { /* JSON有误时不同步 */ }
+                } else {
+                    dialog.querySelector('#tm-tab-form').style.display = 'none';
+                    dialog.querySelector('#tm-tab-json').style.display = 'block';
+                    jsonEditor.value = JSON.stringify(workingCopy, null, 2);
+                }
+            });
+        });
+
+        const closeBtn = dialog.querySelector('.tm-dialog-close');
+        const cancelBtn = dialog.querySelector('#tm-edit-cancel');
+        const saveBtn = dialog.querySelector('#tm-edit-save');
+
+        const close = () => document.body.removeChild(overlay);
+        closeBtn.addEventListener('click', close);
+        cancelBtn.addEventListener('click', close);
+
+        saveBtn.addEventListener('click', async () => {
+            // 如果当前在JSON tab，从JSON读取
+            if (dialog.querySelector('#tm-tab-json').style.display !== 'none') {
+                try {
+                    workingCopy = JSON.parse(jsonEditor.value);
+                } catch (error) {
+                    alert(`JSON格式错误: ${error.message}`);
+                    return;
+                }
+            }
+            try {
+                this.manager.updateUserTool(toolName, workingCopy);
+                await this.manager.saveUserTools();
+                if (window.refreshToolGrid) await window.refreshToolGrid();
+                this.showToast('保存成功');
+                close();
+                this.render();
+            } catch (error) {
+                alert(`保存失败: ${error.message}`);
+            }
+        });
+    }
+
+    // ========================================
+    // 工具函数
+    // ========================================
+
+    createOverlay() {
+        const overlay = document.createElement('div');
+        overlay.className = 'tm-overlay';
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) {
+                document.body.removeChild(overlay);
+            }
+        });
+        return overlay;
+    }
+
+    showToast(message) {
+        const toast = document.createElement('div');
+        toast.className = 'tm-toast';
+        toast.style.cssText = `
+            position: fixed; top: 20px; right: 20px;
+            background: var(--success-color); color: white;
+            padding: 12px 20px; border-radius: 6px;
+            z-index: 10001; font-size: 14px; font-weight: 500;
+            box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+            max-width: 400px; white-space: pre-wrap;
+        `;
+        toast.textContent = message;
+        document.body.appendChild(toast);
+
+        setTimeout(() => {
+            if (toast.parentNode) toast.parentNode.removeChild(toast);
+        }, 4000);
+    }
+}

--- a/VCPHumanToolBox/style.css
+++ b/VCPHumanToolBox/style.css
@@ -1065,3 +1065,434 @@ header p {
     background: rgba(255, 152, 0, 0.1);
     color: var(--highlight-text);
 }
+
+/* ========================================
+   Tool Manager Styles
+   ======================================== */
+
+.tab-btn {
+    padding: 8px 16px;
+    border: none;
+    background: rgba(255,255,255,0.05);
+    color: var(--secondary-text);
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    margin-right: 8px;
+    transition: all 0.2s;
+}
+
+.tab-btn-active {
+    background: var(--primary-color);
+    color: white;
+}
+
+.tab-btn:hover:not(.tab-btn-active) {
+    background: rgba(255,255,255,0.1);
+}
+
+.manage-panel {
+    padding: 20px;
+}
+
+.tool-manager-panel {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.tm-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.tm-header h3 {
+    margin: 0;
+    color: var(--primary-text);
+}
+
+.tm-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.tm-btn {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.2s;
+}
+
+.tm-btn-primary {
+    background: var(--primary-color);
+    color: white;
+}
+
+.tm-btn-primary:hover {
+    opacity: 0.9;
+}
+
+.tm-btn-secondary {
+    background: rgba(255,255,255,0.1);
+    color: var(--secondary-text);
+}
+
+.tm-btn-secondary:hover {
+    background: rgba(255,255,255,0.15);
+}
+
+.tm-btn-danger {
+    background: var(--danger-color);
+    color: white;
+}
+
+.tm-btn-danger:hover {
+    opacity: 0.9;
+}
+
+.tm-btn-sm {
+    padding: 6px 12px;
+    font-size: 12px;
+}
+
+.tm-empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: var(--secondary-text);
+}
+
+.tm-user-tools-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 15px;
+}
+
+.tm-tool-card {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 15px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    transition: all 0.2s;
+}
+
+.tm-tool-card:hover {
+    background: rgba(255,255,255,0.05);
+    border-color: var(--primary-color);
+}
+
+.tm-tool-info h4 {
+    margin: 0 0 8px;
+    color: var(--primary-text);
+}
+
+.tm-tool-info p {
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: var(--secondary-text);
+}
+
+.tm-tool-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    background: rgba(255,152,0,0.1);
+    color: var(--highlight-text);
+}
+
+.tm-tool-actions {
+    display: flex;
+    gap: 6px;
+}
+
+/* 对话框样式 */
+.tm-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.7);
+    z-index: 9999;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.tm-dialog {
+    background: var(--card-bg);
+    border-radius: 12px;
+    width: 90%;
+    max-width: 600px;
+    max-height: 80vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.5);
+}
+
+.tm-dialog-large {
+    max-width: 900px;
+}
+
+.tm-dialog-header {
+    padding: 20px;
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.tm-dialog-header h3 {
+    margin: 0;
+    color: var(--primary-text);
+}
+
+.tm-dialog-close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    color: var(--secondary-text);
+    cursor: pointer;
+    padding: 0;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.tm-dialog-close:hover {
+    color: var(--danger-color);
+}
+
+.tm-dialog-body {
+    padding: 20px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.tm-dialog-footer {
+    padding: 15px 20px;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.tm-form-group {
+    margin-bottom: 15px;
+}
+
+.tm-form-group label {
+    display: block;
+    margin-bottom: 6px;
+    color: var(--secondary-text);
+    font-size: 13px;
+}
+
+.tm-form-group input,
+.tm-form-group textarea {
+    width: 100%;
+    padding: 8px 12px;
+    background: var(--input-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--primary-text);
+    font-size: 14px;
+    font-family: inherit;
+}
+
+.tm-form-group input:focus,
+.tm-form-group textarea:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+.tm-import-list {
+    max-height: 400px;
+    overflow-y: auto;
+    margin-bottom: 15px;
+}
+
+.tm-import-item {
+    padding: 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    margin-bottom: 10px;
+}
+
+.tm-import-checkbox {
+    display: flex;
+    align-items: flex-start;
+    cursor: pointer;
+}
+
+.tm-import-checkbox input[type="checkbox"] {
+    margin-right: 12px;
+    margin-top: 4px;
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+}
+
+.tm-import-info strong {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--primary-text);
+}
+
+.tm-import-info p {
+    margin: 0;
+    font-size: 12px;
+    color: var(--secondary-text);
+}
+
+/* Tab样式 */
+.tm-tabs {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 10px;
+}
+
+.tm-tab {
+    padding: 8px 16px;
+    border: none;
+    background: none;
+    color: var(--secondary-text);
+    cursor: pointer;
+    font-size: 14px;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s;
+}
+
+.tm-tab-active {
+    color: var(--primary-color);
+    border-bottom-color: var(--primary-color);
+}
+
+.tm-tab:hover:not(.tm-tab-active) {
+    color: var(--primary-text);
+}
+
+.tm-tab-content {
+    padding: 10px 0;
+}
+
+/* Toast通知 */
+.tm-toast {
+    animation: tm-toast-in 0.3s ease;
+}
+
+@keyframes tm-toast-in {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* 卡片点击态样式 */
+.tm-tool-card-clickable {
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.tm-tool-card-clickable:hover {
+    background: rgba(255,255,255,0.06) !important;
+    border-color: rgba(59,130,246,0.4) !important;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(59,130,246,0.2);
+}
+
+.tm-tool-card-delete-mode {
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.tm-tool-card-delete-mode:hover {
+    background: rgba(239,68,68,0.08) !important;
+    border-color: rgba(239,68,68,0.4) !important;
+}
+
+.tm-tool-card-selected {
+    background: rgba(59,130,246,0.15) !important;
+    border-color: rgba(59,130,246,0.6) !important;
+}
+
+.tm-delete-indicator {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    width: 28px;
+    height: 28px;
+    border: 2px solid var(--border-color);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    color: #3b82f6;
+    background: rgba(59,130,246,0.1);
+    transition: all 0.2s ease;
+}
+
+.tm-tool-card-selected .tm-delete-indicator {
+    background: #3b82f6;
+    border-color: #3b82f6;
+    color: white;
+    transform: scale(1.1);
+}
+
+/* 编辑对话框滚动条修复 */
+.tm-dialog-large .tm-dialog-body {
+    overflow: hidden !important;
+    padding: 0 !important;
+}
+
+.tm-dialog-large #tm-tab-form {
+    overflow-y: auto !important;
+}
+
+.tm-dialog-large #tm-tab-json {
+    overflow-y: auto !important;
+}
+
+/* 编辑对话框 flex 布局修复 */
+.tm-dialog-large {
+    display: flex !important;
+    flex-direction: column;
+    max-height: 85vh;
+    overflow: hidden;
+}
+.tm-dialog-large .tm-dialog-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 0;
+}
+.tm-dialog-large .tm-dialog-footer {
+    flex-shrink: 0;
+}
+.tm-dialog-large #tm-tab-form,
+.tm-dialog-large #tm-tab-json {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}


### PR DESCRIPTION
## 改动概述

为VCPHumanToolBox 新增「插件管理」Tab，允许用户从 VCPToolBox 后端动态导入插件定义，
并通过可视化表单直接编辑工具参数，无需手动修改 config.js。
尚未完善完全。

## 新增文件

- `VCPHumanToolBox/renderer_modules/tool-manager.js`（48KB）
  - ToolManager 类：fetchPlugins、adaptPlugin、parseDescription、CRUD用户工具
  - ToolManagerUI 类：导入对话框、编辑对话框、批量删除模式、全局搜索
- `VCPHumanToolBox/README.md`：项目完整文档

## 修改文件

- `renderer.js`：新增 Tab 切换逻辑、allTools 动态合并（Config Overlay）、window.refreshToolGrid
- `index.html`：新增「管理」Tab 按钮 + manage-panel容器
- `style.css`：新增 Tool Manager 样式块（~300行）

## 核心特性

### Config Overlay 机制
`allTools = { ...config.js, ...userTools }`——用户导入的工具定义优先于出厂定义，向后完全兼容。

### 参数自动解析（parseDescription）
当插件 manifest 没有结构化`parameters` 对象时，自动从 description 文本提取参数 schema。
支持四种 VCP 常见格式（A/B/D/F），纯确定性规则引擎，不依赖 AI：
- 格式 A：`- 参数名 (类型): 描述`（VCPClawMail风格）
- 格式 B：`N. \`param\`: (必需)` （TopicSponsor 风格）
- 格式 D：`参数名:「始」(必需/可选) 描述「末」`（AgentAssistant 风格）
- 格式 F：嵌入在 `<<<[TOOL_REQUEST]>>>` 示例中（AgnesGen/DoubaoGen 风格）

三层Fallback：parameters 对象 → parseDescription → 只保留 maid

由于插件plugin-manifest.json的格式不是很统一，已经尽力写了些正则，不能说效果拔群吧，也能说收效甚微。

### 零新增 IPC 通道
用户工具数据存储在 `settings.vcpht_userTools`，复用已有的 `vcp-ht-get-settings`/`vcp-ht-save-settings`，
main.js 和 preload.js 零改动。

## 测试要点

- [ ] 导入一个后端插件（如 DailyNote）：params 应从 parameters 对象解析
- [ ] 导入一个分布式插件（如 MusicController）：params 应从 description 文本解析
- [ ] 导入后工具卡片立即出现在工具网格，无需重启
- [ ] 重启后已导入工具持久化保留
- [ ] 不点管理 Tab 时与原版行为完全一致（向后兼容）
- [ ] 表单编辑器：修改参数类型/必填/占位符后保存，Raw JSON 同步更新
- [ ] 批量删除：勾选多个工具，确认删除后立即从工具网格消失

总之各种一波改动，等有空再来微调完善吧。只要已有的功能没啥影响，就先放那吧……