### PR TITLE
feat(sync): standardize Wire 1.2 errors

### DIFF
--- a/.github/workflows/mobile_sync.yml
+++ b/.github/workflows/mobile_sync.yml
@@ -1,4 +1,4 @@
-name: VCPMobileSync 1.1
+name: VCPMobileSync 1.2
 
 on:
   workflow_dispatch:

--- a/VCPDistributedServer/Plugin/VCPMobileSync/README.md
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/README.md
@@ -1,15 +1,15 @@
 # VCPMobileSync (VCP 移动端双向增量同步服务插件)
 
-[![Version](https://img.shields.io/badge/Version-1.1.0-blue.svg?style=flat-square)](./plugin-manifest.json)
+[![Version](https://img.shields.io/badge/Version-1.2.0-blue.svg?style=flat-square)](./plugin-manifest.json)
 [![Platform](https://img.shields.io/badge/Platform-Node.js%20%7C%20Electron-brightgreen.svg?style=flat-square)](https://nodejs.org)
-[![Sync Protocol](https://img.shields.io/badge/Wire%20Protocol-1.1-orange.svg?style=flat-square)](#协议-11-硬切与兼容边界)
+[![Sync Protocol](https://img.shields.io/badge/Wire%20Protocol-1.2-orange.svg?style=flat-square)](#协议-12-硬切与兼容边界)
 
 **让 VCPChat 桌面端和 VCPMobile 手机端的数据进行可诊断、失败即停的双向增量同步。**
 
 VCPMobileSync 是 VCPChat 桌面端的专属分布式服务插件，采用 **Double-Track 3-Tier（双轨三层）** 同步架构。它不仅为普通用户提供直观的一键双向数据合并能力，其底层更设计了严苛的多层级 Merkle 聚合指纹算法与 NDJSON 流式吞吐防线，保障海量聊天数据与大文件附件在局域网内以极低延迟、强事务安全性进行无损传输。
 
 > [!IMPORTANT]
-> 本版本只修改 MobileSync 插件、VCP-CDS 同步接口及其启动/打包接线，不修改模型调用、提示词、消息渲染或普通聊天保存逻辑。中央模式的 Mobile→Desktop 消息同步本来就会投影并写入 `history.json`；1.1 对这条既有同步写入增加严格解析、来源 hash 校验、原子替换和失败传播，但不会回写桌面旧消息的附件结构。
+> 本版本只修改 MobileSync 插件、VCP-CDS 同步接口及其启动/打包接线，不修改模型调用、提示词、消息渲染或普通聊天保存逻辑。中央模式的 Mobile→Desktop 消息同步本来就会投影并写入 `history.json`；1.2 延续严格解析、来源 hash 校验、原子替换和失败传播，并把全部跨端错误统一为结构化对象，但不会回写桌面旧消息的附件结构。
 
 ---
 
@@ -99,29 +99,55 @@ pnpm exec electron-rebuild --only better-sqlite3
 
 ---
 
-## 协议 1.1 硬切与兼容边界
+## 协议 1.2 硬切与兼容边界
 
 公开握手固定为：
 
 ```text
-VERSION_CHECK { mobileVersion, protocolVersion: "1.1" }
-VERSION_ACK   { pluginVersion: "1.1.0", protocolVersion: "1.1" }
+VERSION_CHECK { mobileVersion, protocolVersion: "1.2" }
+VERSION_ACK   { pluginVersion: "1.2.0", protocolVersion: "1.2" }
 ```
 
 Phase 3 每个 Topic 的 decision 必须是以下判别联合之一；缺字段、错类型、重复 Topic、`ok:false` 或未知帧都会终止当前 attempt，不能进入完成态：
 
 ```text
 { ok: true, toPull: string[], toPush: boolean }
-{ ok: false, error: { code: string, message: string } }
+{ ok: false, error: SyncError }
 ```
 
-Wire 1.1 与 1.0 不支持混跑。插件 1.1.0、VCP-CDS internal protocol 2 和 VCPMobile 1.1.4 必须作为同一兼容批次发布或回滚。
+Wire 1.2 与 1.1 不支持混跑。插件 1.2.0、VCP-CDS internal protocol 2 和 VCPMobile 1.1.4 必须作为同一兼容批次发布或回滚。
 
-本次桌面批次配对的 Mobile 本地提交为 `b52d887aeb589a515a3c34ab5969919a6889ca07`；发布时必须以该提交或其无语义差异后继提交构建 APK。
+本次桌面批次配对的 Mobile 本地提交为 `226b79f546abc93d7878b33dc202f1c176bd8c4e`；发布时必须以该提交或其无语义差异后继提交构建 APK。
+
+错误在 WebSocket、HTTP、NDJSON 和逐 Topic 结果中复用同一个对象：
+
+```json
+{
+  "code": "SYNC_OWNER_CONFLICT",
+  "origin": "desktop_cds",
+  "stage": "messages",
+  "kind": "data",
+  "retry": "manual",
+  "message": "owner identity conflict",
+  "failedTopicIds": ["topic-a"]
+}
+```
+
+固定外壳分别是 `SYNC_ERROR.error`、HTTP `{error}`、NDJSON `_error` / `_stream_error` 以及 `success:false.error`。对象必须包含全部七个字段，未知字段与字符串错误均拒绝。捕获边界保留已有稳定根因码和类别，只能补充更准确的 `origin`、`stage` 与失败 Topic；`ENOENT`、`EAI_*`、`ERR_*`、`SQLITE_*` 等平台码不会提升为 wire code。`message` 是脱敏诊断信息，最终用户中文原因与唯一下一步由 Mobile 按 code 固定映射。
+
+VCP-CDS internal protocol 2 仍可返回 `{code,message,retryable}`、Phase 3 `{code,message}`、流式 Pull Topic 的字符串 `_error`，以及逐 Topic Push 的字符串 `error`；`sync/central.js` 在唯一适配边界保留已有 code，并补齐 `desktop_cds` 来源、实际阶段、分类、重试策略和失败 Topic。Pull/Push 字符串错误不按文案猜类型，分别固定映射为 `SYNC_MESSAGE_READ_FAILED` / `SYNC_MESSAGE_WRITE_FAILED` 与 `desktop_cds / messages / storage / manual`。未知但合法的 CDS code 不会被外层 `SYNC_ATTEMPT_FAILED` 覆盖，无法识别的分类以 `internal/manual` 安全兜底。
+
+中央适配器还会校验 CDS Manifest、消息 Manifest、Topic hash 与 Phase 3 的响应形状及请求集合覆盖。畸形“成功”响应在桌面边界直接转换为 `SYNC_PROTOCOL_INVALID / desktop_cds`，不会延迟到 Mobile 后误归为手机端协议错误。
+
+CDS internal protocol 返回的 `PROTOCOL_MISMATCH` 会在适配边界重命名为 `CDS_PROTOCOL_MISMATCH`，避免与 Mobile wire 版本不兼容混为同一用户故障。
+
+`SERVICE_BUSY` 会先在插件内部做有界退避；若最终仍需跨端上报，`retry=manual`，因为此时内部自动重试已经耗尽。
+
+双端通过字节一致的 `fixtures/error_contract_1_2_golden.json` 和 `fixtures/protocol_1_2_golden.json` 验证契约；对应 SHA-256 分别为 `434279b33a86a2206c1e4f47caccb4e72f05b2f9d48e093af95d5ebae6947adb` 与 `7226118ea55766f952575032efc8cfff883a19c9d196f637ac267cb8795fcef8`。错误 fixture 的 `registeredSemantics` 还会逐项锁定跨端 code 的 `kind/retry`，避免两端注册表静默漂移。
 
 消息在唯一 canonicalizer 边界转换为 wire DTO：附件 hash 只接受顶层或 `_fileManagerData.hash` 中一致的 64 位十六进制值，并转为小写；缺失、非法或冲突附件只产生有界 warning，消息本身保留。桌面路径及 `_fileManagerData` 不会穿过 wire，最终 `contentHash` 仅按规范化消息计算。
 
-Topic manifest 与消息流都使用 `ownerType + ownerId + topicId` 复合身份。协议 1.1 不再通过 `LIKE`、目录前缀或同名 Topic 猜 Owner；缺失身份、Owner 冲突或重复 Topic 会直接终止 attempt。
+Topic manifest 与消息流都使用 `ownerType + ownerId + topicId` 复合身份。协议 1.2 不通过 `LIKE`、目录前缀或同名 Topic 猜 Owner；缺失身份、Owner 冲突或重复 Topic 会直接终止 attempt。
 
 ## 🛡️ 三阶段增量同步协议
 
@@ -289,9 +315,9 @@ VCP 设计了精密的 **“墓碑拦截 (Tombstone Interceptor)”** 防线：
 
 ## 🚀 版本信息
 
-* **适配标准**：VCPChat 桌面插件 1.1.0 / wire protocol 1.1 / VCP-CDS internal protocol 2 / VCPMobile 1.1.4
-* **当前版本**：`1.1.0`
+* **适配标准**：VCPChat 桌面插件 1.2.0 / wire protocol 1.2 / VCP-CDS internal protocol 2 / VCPMobile 1.1.4
+* **当前版本**：`1.2.0`
 * **最终确认**：`PHASE_COMPLETED` 的 `PHASE_ACK` 原样回显 `phase`、`sessionId`、`attemptId` 与 `nonce`，避免迟到或重放 ACK 完成错误会话
-* **升级要求**：协议版本采用精确匹配，不支持 1.0/1.1 混跑；桌面和 Mobile 必须成对升级、成对回滚
+* **升级要求**：协议版本采用精确匹配，不支持 1.1/1.2 混跑；桌面和 Mobile 必须成对升级、成对回滚
 * **架构师 / 作者**：Nova
 * **开源许可**：VCP 闭环生态核心插件

--- a/VCPDistributedServer/Plugin/VCPMobileSync/error-contract.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/error-contract.js
@@ -1,0 +1,420 @@
+"use strict";
+
+const ERROR_CODE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
+const NON_WIRE_ERROR_CODE_PREFIXES = ["ERR_", "SQLITE_"];
+const PLATFORM_ERROR_CODES = new Set([
+  "E2BIG",
+  "EACCES",
+  "EADDRINUSE",
+  "EADDRNOTAVAIL",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EEXIST",
+  "EFAULT",
+  "EHOSTUNREACH",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMSGSIZE",
+  "ENAMETOOLONG",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENFILE",
+  "ENOBUFS",
+  "ENODEV",
+  "ENOENT",
+  "ENOMEM",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTFOUND",
+  "ENOTSUP",
+  "EPERM",
+  "EPIPE",
+  "EROFS",
+  "ETIMEDOUT",
+]);
+const MAX_ERROR_MESSAGE_LENGTH = 1024;
+const MAX_FAILED_TOPIC_IDS = 8;
+const ERROR_FIELDS = new Set([
+  "code",
+  "origin",
+  "stage",
+  "kind",
+  "retry",
+  "message",
+  "failedTopicIds",
+]);
+
+const ERROR_ORIGINS = new Set([
+  "mobile_ui",
+  "mobile_native",
+  "mobile_sync",
+  "desktop_plugin",
+  "desktop_cds",
+]);
+
+const ERROR_STAGES = new Set([
+  "preflight",
+  "startup",
+  "connect",
+  "handshake",
+  "owner_metadata",
+  "topic_metadata",
+  "topic_validation",
+  "messages",
+  "finalize",
+  "shutdown",
+  "history",
+]);
+
+const ERROR_KINDS = new Set([
+  "device",
+  "configuration",
+  "connection",
+  "compatibility",
+  "protocol",
+  "data",
+  "storage",
+  "internal",
+]);
+
+const ERROR_RETRIES = new Set([
+  "automatic",
+  "after_user_action",
+  "manual",
+  "never",
+]);
+
+const definition = (stage, kind, retry, origin = "desktop_plugin") =>
+  Object.freeze({ origin, stage, kind, retry });
+
+// Exact-code registry. A code describes the cause; stage/origin may still be
+// narrowed by the boundary that catches it. No substring classification is used.
+const ERROR_DEFINITIONS = Object.freeze({
+  POWER_SAVE_MODE: definition("preflight", "device", "after_user_action", "mobile_native"),
+  BATTERY_TOO_LOW: definition("preflight", "device", "after_user_action", "mobile_native"),
+  SYNC_ATTEMPT_FAILED: definition("startup", "internal", "manual"),
+  CDS_ERROR: definition("startup", "internal", "manual", "desktop_cds"),
+  CDS_PROTOCOL_MISMATCH: definition("startup", "compatibility", "after_user_action", "desktop_cds"),
+  INVALID_CONFIGURATION: definition("startup", "configuration", "after_user_action", "desktop_cds"),
+  INVALID_RESPONSE: definition("startup", "protocol", "after_user_action", "desktop_cds"),
+  RESPONSE_TOO_LARGE: definition("messages", "data", "after_user_action", "desktop_cds"),
+  CANCELLED: definition("shutdown", "internal", "never", "desktop_cds"),
+  TIMEOUT: definition("connect", "connection", "manual", "desktop_cds"),
+  UNAVAILABLE: definition("connect", "connection", "manual", "desktop_cds"),
+  HTTP_ERROR: definition("connect", "connection", "manual", "desktop_cds"),
+  HEALTH_CHECK_FAILED: definition("startup", "connection", "manual", "desktop_cds"),
+  SYNC_PHASE_STALLED: definition("topic_metadata", "internal", "manual", "mobile_sync"),
+  SYNC_PREVIOUS_SESSION_EXIT_FAILED: definition("shutdown", "internal", "manual", "mobile_sync"),
+  SYNC_DB_DRAIN_FAILED: definition("finalize", "storage", "manual", "mobile_sync"),
+  PROTOCOL_INVALID: definition("handshake", "protocol", "after_user_action"),
+  PROTOCOL_DUPLICATE_KEY: definition("handshake", "protocol", "after_user_action"),
+  VERSION_CHECK_REQUIRED: definition("handshake", "protocol", "after_user_action"),
+  VERSION_CHECK_DUPLICATE: definition("handshake", "protocol", "after_user_action"),
+  VERSION_CHECK_INVALID: definition("handshake", "protocol", "after_user_action"),
+  VERSION_ACK_INVALID: definition("handshake", "protocol", "after_user_action", "mobile_sync"),
+  SYNC_VERSION_INCOMPATIBLE: definition("handshake", "compatibility", "after_user_action"),
+  VERSION_CHECK_TIMEOUT: definition("handshake", "connection", "manual", "mobile_sync"),
+  MANIFEST_RESPONSE_TIMEOUT: definition("owner_metadata", "connection", "manual", "mobile_sync"),
+  TOPIC_HASH_RESPONSE_TIMEOUT: definition("topic_validation", "connection", "manual", "mobile_sync"),
+  PHASE3_RESPONSE_TIMEOUT: definition("messages", "connection", "manual", "mobile_sync"),
+  FINAL_ACK_TIMEOUT: definition("finalize", "connection", "manual", "mobile_sync"),
+  PROTOCOL_MISMATCH: definition("handshake", "compatibility", "after_user_action"),
+  PLUGIN_VERSION_MISMATCH: definition("handshake", "compatibility", "after_user_action"),
+  MOBILE_SYNC_ERROR: definition("shutdown", "internal", "manual", "mobile_sync"),
+  SYNC_PROTOCOL_INVALID: definition("owner_metadata", "protocol", "after_user_action"),
+  SYNC_BUDGET_EXCEEDED: definition("messages", "data", "after_user_action"),
+  SYNC_INDEX_INVALID: definition("topic_metadata", "storage", "manual"),
+  SYNC_DB_UNAVAILABLE: definition("startup", "storage", "manual"),
+  SYNC_DB_QUERY_FAILED: definition("topic_validation", "storage", "manual"),
+  TOPIC_HASH_FAILED: definition("messages", "storage", "manual", "desktop_cds"),
+  MESSAGE_MANIFEST_FAILED: definition("messages", "storage", "manual", "desktop_cds"),
+  SYNC_OWNER_CONFLICT: definition("topic_metadata", "data", "manual"),
+  SYNC_ENTITY_NOT_FOUND: definition("owner_metadata", "data", "manual"),
+  SYNC_DELETE_INVALID: definition("messages", "protocol", "after_user_action"),
+  SYNC_DELETE_FAILED: definition("messages", "storage", "manual"),
+  HISTORY_SOURCE_INVALID: definition("messages", "data", "after_user_action"),
+  MESSAGE_DIFF_FAILED: definition("messages", "storage", "manual"),
+  TOPIC_NOT_FOUND: definition("messages", "data", "manual"),
+  ATTACHMENT_PATH_INVALID: definition("messages", "storage", "after_user_action"),
+  MOBILE_ATTACHMENT_INVALID: definition("messages", "data", "after_user_action"),
+  CDS_UNAVAILABLE: definition("startup", "internal", "manual", "desktop_cds"),
+  INVALID_REQUEST: definition("startup", "protocol", "after_user_action", "desktop_cds"),
+  UNAUTHORIZED: definition("connect", "configuration", "after_user_action", "desktop_cds"),
+  NOT_FOUND: definition("startup", "data", "manual", "desktop_cds"),
+  AMBIGUOUS_IDENTITY: definition("startup", "data", "manual", "desktop_cds"),
+  SEARCH_UNAVAILABLE: definition("startup", "storage", "manual", "desktop_cds"),
+  INTERNAL_ERROR: definition("startup", "internal", "manual", "desktop_cds"),
+  SERVICE_BUSY: definition("startup", "connection", "manual", "desktop_cds"),
+  SYNC_AUTH_FAILED: definition("connect", "configuration", "after_user_action"),
+  SYNC_REQUEST_INVALID: definition("connect", "protocol", "after_user_action"),
+  SYNC_ENTITY_READ_FAILED: definition("owner_metadata", "storage", "manual"),
+  SYNC_ENTITY_WRITE_FAILED: definition("owner_metadata", "storage", "manual"),
+  SYNC_ENTITY_BATCH_FAILED: definition("topic_metadata", "storage", "manual"),
+  SYNC_MESSAGE_READ_FAILED: definition("messages", "storage", "manual"),
+  SYNC_MESSAGE_WRITE_FAILED: definition("messages", "storage", "manual"),
+  SYNC_STREAM_FAILED: definition("messages", "connection", "manual"),
+  SYNC_ATTACHMENT_NOT_FOUND: definition("messages", "data", "manual"),
+  SYNC_ATTACHMENT_READ_FAILED: definition("messages", "storage", "manual"),
+  SYNC_ATTACHMENT_WRITE_FAILED: definition("messages", "storage", "manual"),
+  SYNC_AVATAR_NOT_FOUND: definition("owner_metadata", "data", "manual"),
+  SYNC_AVATAR_READ_FAILED: definition("owner_metadata", "storage", "manual"),
+  SYNC_AVATAR_WRITE_FAILED: definition("owner_metadata", "storage", "manual"),
+  SYNC_CHANGE_FEED_UNAVAILABLE: definition("history", "configuration", "after_user_action"),
+  SYNC_CHANGE_FEED_FAILED: definition("history", "storage", "manual"),
+});
+
+function cleanMessage(value, fallback = "Desktop sync failed") {
+  const safeFallback = typeof fallback === "string" && fallback.trim().length > 0
+    ? fallback
+    : "Desktop sync failed";
+  const source = typeof value === "string" && value.trim().length > 0
+    ? value
+    : safeFallback;
+  const redacted = source
+    .replace(/\b(Bearer\s+)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)/gi, "$1[redacted]")
+    .replace(
+      /(\b(?:token|x[_-]?sync[_-]?token|sync[_-]?token|access[_-]?token|api[_-]?key|vcp[_-]?key|secret|password)\b\s*[:=]\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;&#]+)/gi,
+      "$1[redacted]",
+    )
+    .replace(
+      /([?&](?:token|sync(?:[_-]|%5f)?token|access(?:[_-]|%5f)?token|api(?:[_-]|%5f)?key|vcp(?:[_-]|%5f)?key|secret|password)=)[^&#\s]*/gi,
+      "$1[redacted]",
+    )
+    .replace(/[A-Za-z]:[\\/][^\s"'<>|]+/g, "[path]");
+  return Array.from(redacted
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ")
+    .trim())
+    .slice(0, MAX_ERROR_MESSAGE_LENGTH)
+    .join("");
+}
+
+function codePointLength(value) {
+  return Array.from(value).length;
+}
+
+function validEnum(value, allowed) {
+  return typeof value === "string" && allowed.has(value) ? value : null;
+}
+
+function validWireCode(value) {
+  return typeof value === "string" &&
+    ERROR_CODE_PATTERN.test(value) &&
+    !PLATFORM_ERROR_CODES.has(value) &&
+    !value.startsWith("EAI_") &&
+    !NON_WIRE_ERROR_CODE_PREFIXES.some((prefix) => value.startsWith(prefix));
+}
+
+function boundedTopicIds(value) {
+  if (!Array.isArray(value)) return [];
+  const result = [];
+  const seen = new Set();
+  for (const id of value) {
+    if (
+      typeof id !== "string" ||
+      id.length === 0 ||
+      codePointLength(id) > 512 ||
+      seen.has(id)
+    ) {
+      continue;
+    }
+    seen.add(id);
+    result.push(id);
+    if (result.length === MAX_FAILED_TOPIC_IDS) break;
+  }
+  return result;
+}
+
+function normalizeSyncError(error, fallback = {}) {
+  const source = error && typeof error === "object" ? error : {};
+  const sourceMessage = typeof error === "string" ? error : source.message;
+  const fallbackCode = validWireCode(fallback.code)
+    ? fallback.code
+    : "SYNC_ATTEMPT_FAILED";
+  const code = validWireCode(source.code)
+    ? source.code
+    : fallbackCode;
+  const registered = ERROR_DEFINITIONS[code] || {};
+
+  return {
+    code,
+    origin:
+      validEnum(source.origin, ERROR_ORIGINS) ||
+      validEnum(fallback.origin, ERROR_ORIGINS) ||
+      registered.origin ||
+      "desktop_plugin",
+    stage:
+      validEnum(source.stage, ERROR_STAGES) ||
+      validEnum(fallback.stage, ERROR_STAGES) ||
+      registered.stage ||
+      "startup",
+    kind:
+      registered.kind ||
+      validEnum(source.kind, ERROR_KINDS) ||
+      validEnum(fallback.kind, ERROR_KINDS) ||
+      "internal",
+    retry:
+      registered.retry ||
+      validEnum(source.retry, ERROR_RETRIES) ||
+      validEnum(fallback.retry, ERROR_RETRIES) ||
+      "manual",
+    message: cleanMessage(sourceMessage, fallback.message),
+    failedTopicIds: boundedTopicIds([
+      ...(Array.isArray(source.failedTopicIds) ? source.failedTopicIds : []),
+      ...(Array.isArray(fallback.failedTopicIds) ? fallback.failedTopicIds : []),
+    ]),
+  };
+}
+
+function parseSyncError(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw createSyncError("PROTOCOL_INVALID", "error must be an object", {
+      stage: "handshake",
+    });
+  }
+  if (!validWireCode(value.code)) {
+    throw createSyncError("PROTOCOL_INVALID", "error.code is invalid", {
+      stage: "handshake",
+    });
+  }
+  if (Object.keys(value).some((key) => !ERROR_FIELDS.has(key))) {
+    throw createSyncError("PROTOCOL_INVALID", "error contains unknown fields", {
+      stage: "handshake",
+    });
+  }
+  if (!validEnum(value.origin, ERROR_ORIGINS)) {
+    throw createSyncError("PROTOCOL_INVALID", "error.origin is invalid", {
+      stage: "handshake",
+    });
+  }
+  if (!validEnum(value.stage, ERROR_STAGES)) {
+    throw createSyncError("PROTOCOL_INVALID", "error.stage is invalid", {
+      stage: "handshake",
+    });
+  }
+  if (!validEnum(value.kind, ERROR_KINDS)) {
+    throw createSyncError("PROTOCOL_INVALID", "error.kind is invalid", {
+      stage: "handshake",
+    });
+  }
+  if (!validEnum(value.retry, ERROR_RETRIES)) {
+    throw createSyncError("PROTOCOL_INVALID", "error.retry is invalid", {
+      stage: "handshake",
+    });
+  }
+  if (
+    typeof value.message !== "string" ||
+    value.message.trim().length === 0 ||
+    codePointLength(value.message) > MAX_ERROR_MESSAGE_LENGTH
+  ) {
+    throw createSyncError("PROTOCOL_INVALID", "error.message is invalid", {
+      stage: "handshake",
+    });
+  }
+  if (
+    !Array.isArray(value.failedTopicIds) ||
+      value.failedTopicIds.length > MAX_FAILED_TOPIC_IDS ||
+      value.failedTopicIds.some(
+        (id) =>
+          typeof id !== "string" ||
+          id.length === 0 ||
+          codePointLength(id) > 512,
+      ) ||
+      new Set(value.failedTopicIds).size !== value.failedTopicIds.length
+  ) {
+    throw createSyncError("PROTOCOL_INVALID", "error.failedTopicIds is invalid", {
+      stage: "handshake",
+    });
+  }
+  const registered = ERROR_DEFINITIONS[value.code];
+  if (
+    registered &&
+    (value.kind !== registered.kind || value.retry !== registered.retry)
+  ) {
+    throw createSyncError(
+      "PROTOCOL_INVALID",
+      "error.kind or error.retry conflicts with its registered code",
+      { stage: "handshake" },
+    );
+  }
+  return normalizeSyncError(value);
+}
+
+function createSyncError(code, message, context = {}) {
+  const normalized = normalizeSyncError(
+    { ...context, code, message },
+    context,
+  );
+  const error = new Error(normalized.message);
+  Object.assign(error, normalized);
+  return error;
+}
+
+function withSyncErrorContext(error, fallback = {}) {
+  const normalized = normalizeSyncError(error, fallback);
+  // This helper is used at a boundary that knows where the failure was
+  // observed. Keep root code/kind/retry, but let that boundary narrow the two
+  // contextual dimensions even when an inner layer supplied broader values.
+  const boundaryOrigin = validEnum(fallback.origin, ERROR_ORIGINS);
+  const boundaryStage = validEnum(fallback.stage, ERROR_STAGES);
+  if (boundaryOrigin) normalized.origin = boundaryOrigin;
+  if (boundaryStage) normalized.stage = boundaryStage;
+  const target = error instanceof Error ? error : new Error(normalized.message);
+  target.message = normalized.message;
+  Object.assign(target, normalized);
+  return target;
+}
+
+function createSyncErrorFrame(error, fallback = {}) {
+  return {
+    type: "SYNC_ERROR",
+    error: normalizeSyncError(error, fallback),
+  };
+}
+
+function createHttpErrorBody(error, fallback = {}) {
+  return { error: normalizeSyncError(error, fallback) };
+}
+
+function createStreamErrorFrame(error, fallback = {}) {
+  return { _stream_error: normalizeSyncError(error, fallback) };
+}
+
+function normalizeFailureResult(result, fallback = {}) {
+  if (
+    !result ||
+    typeof result !== "object" ||
+    Array.isArray(result) ||
+    result.success !== false
+  ) {
+    return result;
+  }
+  return {
+    ...result,
+    error: normalizeSyncError(result.error, fallback),
+  };
+}
+
+module.exports = {
+  ERROR_DEFINITIONS,
+  ERROR_KINDS,
+  ERROR_ORIGINS,
+  ERROR_RETRIES,
+  ERROR_STAGES,
+  createHttpErrorBody,
+  createStreamErrorFrame,
+  createSyncError,
+  createSyncErrorFrame,
+  normalizeFailureResult,
+  normalizeSyncError,
+  parseSyncError,
+  withSyncErrorContext,
+};

--- a/VCPDistributedServer/Plugin/VCPMobileSync/fixtures/error_contract_1_2_golden.json
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/fixtures/error_contract_1_2_golden.json
@@ -1,0 +1,180 @@
+{
+  "schema": "vcp-sync-error-contract-1.2-golden",
+  "wireProtocol": "1.2",
+  "pluginVersion": "1.2.0",
+  "registeredSemantics": {
+    "AMBIGUOUS_IDENTITY": ["data", "manual"],
+    "ATTACHMENT_PATH_INVALID": ["storage", "after_user_action"],
+    "BATTERY_TOO_LOW": ["device", "after_user_action"],
+    "CANCELLED": ["internal", "never"],
+    "CDS_ERROR": ["internal", "manual"],
+    "CDS_PROTOCOL_MISMATCH": ["compatibility", "after_user_action"],
+    "CDS_UNAVAILABLE": ["internal", "manual"],
+    "FINAL_ACK_TIMEOUT": ["connection", "manual"],
+    "HEALTH_CHECK_FAILED": ["connection", "manual"],
+    "HISTORY_SOURCE_INVALID": ["data", "after_user_action"],
+    "HTTP_ERROR": ["connection", "manual"],
+    "INTERNAL_ERROR": ["internal", "manual"],
+    "INVALID_CONFIGURATION": ["configuration", "after_user_action"],
+    "INVALID_REQUEST": ["protocol", "after_user_action"],
+    "INVALID_RESPONSE": ["protocol", "after_user_action"],
+    "MANIFEST_RESPONSE_TIMEOUT": ["connection", "manual"],
+    "MESSAGE_DIFF_FAILED": ["storage", "manual"],
+    "MESSAGE_MANIFEST_FAILED": ["storage", "manual"],
+    "MOBILE_ATTACHMENT_INVALID": ["data", "after_user_action"],
+    "MOBILE_SYNC_ERROR": ["internal", "manual"],
+    "NOT_FOUND": ["data", "manual"],
+    "PHASE3_RESPONSE_TIMEOUT": ["connection", "manual"],
+    "PLUGIN_VERSION_MISMATCH": ["compatibility", "after_user_action"],
+    "POWER_SAVE_MODE": ["device", "after_user_action"],
+    "PROTOCOL_DUPLICATE_KEY": ["protocol", "after_user_action"],
+    "PROTOCOL_INVALID": ["protocol", "after_user_action"],
+    "PROTOCOL_MISMATCH": ["compatibility", "after_user_action"],
+    "RESPONSE_TOO_LARGE": ["data", "after_user_action"],
+    "SEARCH_UNAVAILABLE": ["storage", "manual"],
+    "SERVICE_BUSY": ["connection", "manual"],
+    "SYNC_ATTACHMENT_NOT_FOUND": ["data", "manual"],
+    "SYNC_ATTACHMENT_READ_FAILED": ["storage", "manual"],
+    "SYNC_ATTACHMENT_WRITE_FAILED": ["storage", "manual"],
+    "SYNC_ATTEMPT_FAILED": ["internal", "manual"],
+    "SYNC_AUTH_FAILED": ["configuration", "after_user_action"],
+    "SYNC_AVATAR_NOT_FOUND": ["data", "manual"],
+    "SYNC_AVATAR_READ_FAILED": ["storage", "manual"],
+    "SYNC_AVATAR_WRITE_FAILED": ["storage", "manual"],
+    "SYNC_BUDGET_EXCEEDED": ["data", "after_user_action"],
+    "SYNC_CHANGE_FEED_FAILED": ["storage", "manual"],
+    "SYNC_CHANGE_FEED_UNAVAILABLE": ["configuration", "after_user_action"],
+    "SYNC_DB_DRAIN_FAILED": ["storage", "manual"],
+    "SYNC_DB_QUERY_FAILED": ["storage", "manual"],
+    "SYNC_DB_UNAVAILABLE": ["storage", "manual"],
+    "SYNC_DELETE_FAILED": ["storage", "manual"],
+    "SYNC_DELETE_INVALID": ["protocol", "after_user_action"],
+    "SYNC_ENTITY_BATCH_FAILED": ["storage", "manual"],
+    "SYNC_ENTITY_NOT_FOUND": ["data", "manual"],
+    "SYNC_ENTITY_READ_FAILED": ["storage", "manual"],
+    "SYNC_ENTITY_WRITE_FAILED": ["storage", "manual"],
+    "SYNC_INDEX_INVALID": ["storage", "manual"],
+    "SYNC_MESSAGE_READ_FAILED": ["storage", "manual"],
+    "SYNC_MESSAGE_WRITE_FAILED": ["storage", "manual"],
+    "SYNC_OWNER_CONFLICT": ["data", "manual"],
+    "SYNC_PHASE_STALLED": ["internal", "manual"],
+    "SYNC_PREVIOUS_SESSION_EXIT_FAILED": ["internal", "manual"],
+    "SYNC_PROTOCOL_INVALID": ["protocol", "after_user_action"],
+    "SYNC_REQUEST_INVALID": ["protocol", "after_user_action"],
+    "SYNC_STREAM_FAILED": ["connection", "manual"],
+    "SYNC_VERSION_INCOMPATIBLE": ["compatibility", "after_user_action"],
+    "TIMEOUT": ["connection", "manual"],
+    "TOPIC_HASH_FAILED": ["storage", "manual"],
+    "TOPIC_HASH_RESPONSE_TIMEOUT": ["connection", "manual"],
+    "TOPIC_NOT_FOUND": ["data", "manual"],
+    "UNAUTHORIZED": ["configuration", "after_user_action"],
+    "UNAVAILABLE": ["connection", "manual"],
+    "VERSION_ACK_INVALID": ["protocol", "after_user_action"],
+    "VERSION_CHECK_DUPLICATE": ["protocol", "after_user_action"],
+    "VERSION_CHECK_INVALID": ["protocol", "after_user_action"],
+    "VERSION_CHECK_REQUIRED": ["protocol", "after_user_action"],
+    "VERSION_CHECK_TIMEOUT": ["connection", "manual"]
+  },
+  "validErrors": [
+    {
+      "name": "handshake_plugin_version_mismatch",
+      "error": {
+        "code": "PLUGIN_VERSION_MISMATCH",
+        "origin": "desktop_plugin",
+        "stage": "handshake",
+        "kind": "compatibility",
+        "retry": "after_user_action",
+        "message": "plugin package mismatch",
+        "failedTopicIds": []
+      }
+    },
+    {
+      "name": "desktop_cds_message_failure",
+      "error": {
+        "code": "SYNC_DB_QUERY_FAILED",
+        "origin": "desktop_cds",
+        "stage": "messages",
+        "kind": "storage",
+        "retry": "manual",
+        "message": "message diff query failed",
+        "failedTopicIds": ["topic-a"]
+      }
+    },
+    {
+      "name": "unknown_stable_upstream_code",
+      "error": {
+        "code": "UPSTREAM_EXTENSION_FAILED",
+        "origin": "desktop_plugin",
+        "stage": "finalize",
+        "kind": "internal",
+        "retry": "manual",
+        "message": "extension returned an unknown stable code",
+        "failedTopicIds": []
+      }
+    }
+  ],
+  "invalidErrors": [
+    {
+      "name": "legacy_string_error",
+      "error": "database failed"
+    },
+    {
+      "name": "missing_stage",
+      "error": {
+        "code": "SYNC_DB_QUERY_FAILED",
+        "origin": "desktop_plugin",
+        "kind": "storage",
+        "retry": "manual",
+        "message": "missing stage"
+      }
+    },
+    {
+      "name": "invalid_code",
+      "error": {
+        "code": "desktop raw code",
+        "origin": "desktop_plugin",
+        "stage": "messages",
+        "kind": "internal",
+        "retry": "manual",
+        "message": "invalid code"
+      }
+    },
+    {
+      "name": "platform_dns_code",
+      "error": {
+        "code": "EAI_AGAIN",
+        "origin": "desktop_plugin",
+        "stage": "connect",
+        "kind": "connection",
+        "retry": "manual",
+        "message": "platform DNS code must use a boundary code",
+        "failedTopicIds": []
+      }
+    },
+    {
+      "name": "unknown_field",
+      "error": {
+        "code": "SYNC_DB_QUERY_FAILED",
+        "origin": "desktop_plugin",
+        "stage": "messages",
+        "kind": "storage",
+        "retry": "manual",
+        "message": "unexpected extension",
+        "failedTopicIds": [],
+        "debug": "not part of the wire contract"
+      }
+    },
+    {
+      "name": "known_code_kind_mismatch",
+      "error": {
+        "code": "POWER_SAVE_MODE",
+        "origin": "mobile_native",
+        "stage": "preflight",
+        "kind": "compatibility",
+        "retry": "after_user_action",
+        "message": "known code claims the wrong category",
+        "failedTopicIds": []
+      }
+    }
+  ]
+}

--- a/VCPDistributedServer/Plugin/VCPMobileSync/fixtures/protocol_1_2_golden.json
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/fixtures/protocol_1_2_golden.json
@@ -1,6 +1,6 @@
 {
-  "schema": "vcp-sync-protocol-1.1-golden",
-  "wireProtocol": "1.1",
+  "schema": "vcp-sync-protocol-1.2-golden",
+  "wireProtocol": "1.2",
   "validFrames": [
     {
       "name": "flat_nested_null_missing_conflict_unicode_html_empty",

--- a/VCPDistributedServer/Plugin/VCPMobileSync/index.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/index.js
@@ -34,6 +34,7 @@ const { createCentralSyncAdapter } = require("./sync/central");
 const { isWriteLocked, sanitizeId, deleteEntity, deleteMessage } = require("./sync/entity");
 const { getLogger, resetLogger } = require("./core/logger");
 const { createPhaseAck, createVersionAck } = require("./protocol");
+const { withSyncErrorContext } = require("./error-contract");
 const {
   AGENT_SYNC_FIELDS,
   GROUP_SYNC_FIELDS,
@@ -286,9 +287,10 @@ async function registerRoutes(app, pluginConfig, projectBasePath, services = {})
                 appDataPath,
               });
               if (!result?.success) {
-                const error = new Error(result?.error || "entity delete failed");
-                error.code = "SYNC_DELETE_FAILED";
-                throw error;
+                throw withSyncErrorContext(
+                  result?.error || "entity delete failed",
+                  { code: "SYNC_DELETE_FAILED", stage: "owner_metadata" },
+                );
               }
               await centralSync.reconcile();
             }
@@ -308,7 +310,16 @@ async function registerRoutes(app, pluginConfig, projectBasePath, services = {})
               topicId: safeTopicId,
               appDataPath,
             });
-            if (!result?.success) throw new Error(result?.error || "message delete failed");
+            if (!result?.success) {
+              throw withSyncErrorContext(
+                result?.error || "message delete failed",
+                {
+                  code: "SYNC_DELETE_FAILED",
+                  stage: "messages",
+                  failedTopicIds: [safeTopicId],
+                },
+              );
+            }
             logger.logOperation("websocket", "delete_notify", safeId, "success", "type=message");
           } else if (dataType === "avatar") {
             const result = await deleteEntity({
@@ -318,11 +329,29 @@ async function registerRoutes(app, pluginConfig, projectBasePath, services = {})
               deletedAt,
               appDataPath,
             });
-            if (!result?.success) throw new Error(result?.error || "avatar delete failed");
+            if (!result?.success) {
+              throw withSyncErrorContext(
+                result?.error || "avatar delete failed",
+                { code: "SYNC_DELETE_FAILED", stage: "owner_metadata" },
+              );
+            }
             logger.logOperation("websocket", "delete_notify", rawId, "success", "type=avatar");
           } else {
             const result = await deleteEntity({ id: safeId, type: dataType, deletedAt, appDataPath });
-            if (!result?.success) throw new Error(result?.error || "entity delete failed");
+            if (!result?.success) {
+              throw withSyncErrorContext(
+                result?.error || "entity delete failed",
+                {
+                  code: "SYNC_DELETE_FAILED",
+                  stage: ["topic", "agent_topic", "group_topic"].includes(dataType)
+                    ? "topic_metadata"
+                    : "owner_metadata",
+                  failedTopicIds: ["topic", "agent_topic", "group_topic"].includes(dataType)
+                    ? [safeId]
+                    : [],
+                },
+              );
+            }
             logger.logOperation("websocket", "delete_notify", safeId, "success", `type=${dataType}`);
           }
 

--- a/VCPDistributedServer/Plugin/VCPMobileSync/plugin-manifest.json
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/plugin-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "VCPMobileSync",
   "displayName": "VCP Mobile Sync Service",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Provides bidirectional sync API for VCPMobile to sync AppData securely.",
   "author": "Nova",
   "pluginType": "service",

--- a/VCPDistributedServer/Plugin/VCPMobileSync/protocol.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/protocol.js
@@ -1,8 +1,8 @@
 "use strict";
 
 const FINAL_ACK_IDENTITY_FIELDS = ["sessionId", "attemptId", "nonce"];
-const WIRE_PROTOCOL_VERSION = "1.1";
-const EXPECTED_PLUGIN_VERSION = "1.1.0";
+const WIRE_PROTOCOL_VERSION = "1.2";
+const EXPECTED_PLUGIN_VERSION = "1.2.0";
 
 function parseJsonWithoutDuplicateKeys(text) {
   if (typeof text !== "string") {

--- a/VCPDistributedServer/Plugin/VCPMobileSync/sync/canonical.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/sync/canonical.js
@@ -1,8 +1,9 @@
 "use strict";
 
 const { computeMessageFingerprint } = require("../core/hash");
+const { parseSyncError } = require("../error-contract");
 
-const WIRE_PROTOCOL_VERSION = "1.1";
+const WIRE_PROTOCOL_VERSION = "1.2";
 const MAX_WARNING_SAMPLES = 8;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/i;
 const MAX_SQLITE_INTEGER = BigInt("9223372036854775807");
@@ -297,7 +298,15 @@ function canonicalizeTopicFrame(value, { includeContentHash = true } = {}) {
     };
   }
   if (value._error !== undefined && value._error !== null) {
-    const error = requireNonEmptyString(value._error, `NDJSON error frame ${topicId} _error`);
+    if (
+      value.messages !== undefined &&
+      (!Array.isArray(value.messages) || value.messages.length !== 0)
+    ) {
+      throw new SyncProtocolError(
+        `NDJSON error frame for ${topicId} must not contain live messages`,
+      );
+    }
+    const error = parseSyncError(value._error);
     return {
       frame: { topicId, ...ownerIdentity, messages: [], _error: error },
       warningCount: 0,

--- a/VCPDistributedServer/Plugin/VCPMobileSync/sync/central.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/sync/central.js
@@ -6,12 +6,74 @@ const { parseJsonWithoutDuplicateKeys } = require("../protocol");
 const { SyncProtocolError, canonicalizeTopicFrame } = require("./canonical");
 const { projectMobileTopic } = require("./projection");
 const {
+  createSyncError,
+  normalizeSyncError,
+  withSyncErrorContext,
+} = require("../error-contract");
+const {
   MAX_NDJSON_MESSAGES,
   MAX_NDJSON_TOPICS,
   NdjsonWriter,
   decodeNdjsonLine,
   readNdjsonLines,
 } = require("../transport/ndjson");
+
+function withCdsErrorContext(error, fallback = {}) {
+  let root = error;
+  if (error?.code === "PROTOCOL_MISMATCH") {
+    root = Object.assign(new Error(error.message), error, {
+      code: "CDS_PROTOCOL_MISMATCH",
+    });
+  }
+  return withSyncErrorContext(root, {
+    ...fallback,
+    origin: "desktop_cds",
+  });
+}
+
+function translateCdsPullFrame(rawFrame) {
+  if (!rawFrame || typeof rawFrame !== "object" || Array.isArray(rawFrame)) {
+    return rawFrame;
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(rawFrame, "_stream_error") &&
+    rawFrame._stream_error !== null
+  ) {
+    throw withCdsErrorContext(rawFrame._stream_error, {
+      code: "SYNC_STREAM_FAILED",
+      origin: "desktop_cds",
+      stage: "messages",
+    });
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(rawFrame, "_error") &&
+    rawFrame._error !== null
+  ) {
+    const topicId = typeof rawFrame.topicId === "string" ? rawFrame.topicId : null;
+    return {
+      ...rawFrame,
+      _error: normalizeSyncError(rawFrame._error, {
+        code: "SYNC_MESSAGE_READ_FAILED",
+        origin: "desktop_cds",
+        stage: "messages",
+        failedTopicIds: topicId ? [topicId] : [],
+      }),
+    };
+  }
+  return rawFrame;
+}
+
+function cdsProtocolError(message, stage, failedTopicIds = []) {
+  return createSyncError("SYNC_PROTOCOL_INVALID", message, {
+    origin: "desktop_cds",
+    stage,
+    failedTopicIds,
+  });
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
 
 class CentralSyncAdapter {
   constructor(options) {
@@ -34,9 +96,10 @@ class CentralSyncAdapter {
   requireClient() {
     const client = this.client;
     if (!client) {
-      const error = new Error("VCP-CDS is unavailable");
-      error.code = "CDS_UNAVAILABLE";
-      throw error;
+      throw createSyncError("CDS_UNAVAILABLE", "VCP-CDS is unavailable", {
+        origin: "desktop_cds",
+        stage: "startup",
+      });
     }
     return client;
   }
@@ -71,49 +134,232 @@ class CentralSyncAdapter {
   }
 
   async handleSyncManifest(payload) {
-    return this.requireClient().syncManifest({
-      dataType: payload.dataType,
-      data: payload.data,
-      ...(payload.targetedOwners === undefined
-        ? {}
-        : { targetedOwners: payload.targetedOwners }),
-    });
+    const stage = payload.dataType === "topic"
+      ? "topic_metadata"
+      : "owner_metadata";
+    try {
+      const response = await this.requireClient().syncManifest({
+        dataType: payload.dataType,
+        data: payload.data,
+        ...(payload.targetedOwners === undefined
+          ? {}
+          : { targetedOwners: payload.targetedOwners }),
+      });
+      if (
+        !isRecord(response) ||
+        response.type !== "SYNC_DIFF_RESULTS" ||
+        response.dataType !== payload.dataType ||
+        !Array.isArray(response.data)
+      ) {
+        throw cdsProtocolError("CDS returned an invalid manifest response", stage);
+      }
+      return response;
+    } catch (error) {
+      throw withCdsErrorContext(error, {
+        code: "SYNC_DB_QUERY_FAILED",
+        origin: "desktop_cds",
+        stage,
+      });
+    }
   }
 
   async handleMessageManifest(payload) {
-    const result = await this.requireClient().syncMessageManifest({
-      topicId: payload.topicId,
-      ...(payload.ownerType === undefined
-        ? {}
-        : { ownerType: payload.ownerType }),
-      ...(payload.ownerId === undefined ? {} : { ownerId: payload.ownerId }),
-    });
-    return {
-      type: "MESSAGE_MANIFEST_RESULTS",
-      topicId: result.topicId,
-      ownerType: result.ownerType,
-      ownerId: result.ownerId,
-      messages: result.messages.map((message) => ({
-        msg_id: message.msgId,
-        content_hash: message.contentHash,
-        updated_at: message.updatedAt,
-        deleted_at: message.deletedAt ?? null,
-      })),
-    };
+    try {
+      const result = await this.requireClient().syncMessageManifest({
+        topicId: payload.topicId,
+        ...(payload.ownerType === undefined
+          ? {}
+          : { ownerType: payload.ownerType }),
+        ...(payload.ownerId === undefined ? {} : { ownerId: payload.ownerId }),
+      });
+      const seenMessageIds = new Set();
+      if (
+        !isRecord(result) ||
+        result.type !== "MESSAGE_MANIFEST_RESULTS" ||
+        result.topicId !== payload.topicId ||
+        !["agent", "group"].includes(result.ownerType) ||
+        typeof result.ownerId !== "string" ||
+        result.ownerId.length === 0 ||
+        (payload.ownerType !== undefined && result.ownerType !== payload.ownerType) ||
+        (payload.ownerId !== undefined && result.ownerId !== payload.ownerId) ||
+        !Array.isArray(result.messages) ||
+        result.messages.some((message) => {
+          if (
+            !isRecord(message) ||
+            typeof message.msgId !== "string" ||
+            message.msgId.length === 0 ||
+            seenMessageIds.has(message.msgId) ||
+            typeof message.contentHash !== "string" ||
+            !/^[a-f0-9]{64}$/.test(message.contentHash) ||
+            !Number.isSafeInteger(message.updatedAt) ||
+            message.updatedAt < 0 ||
+            (message.deletedAt !== null && message.deletedAt !== undefined &&
+              (!Number.isSafeInteger(message.deletedAt) || message.deletedAt < 0))
+          ) {
+            return true;
+          }
+          seenMessageIds.add(message.msgId);
+          return false;
+        })
+      ) {
+        throw cdsProtocolError(
+          "CDS returned an invalid message manifest response",
+          "messages",
+          typeof payload.topicId === "string" ? [payload.topicId] : [],
+        );
+      }
+      return {
+        type: "MESSAGE_MANIFEST_RESULTS",
+        topicId: result.topicId,
+        ownerType: result.ownerType,
+        ownerId: result.ownerId,
+        messages: result.messages.map((message) => ({
+          msg_id: message.msgId,
+          content_hash: message.contentHash,
+          updated_at: message.updatedAt,
+          deleted_at: message.deletedAt ?? null,
+        })),
+      };
+    } catch (error) {
+      throw withCdsErrorContext(error, {
+        code: "SYNC_MESSAGE_READ_FAILED",
+        origin: "desktop_cds",
+        stage: "messages",
+        failedTopicIds:
+          typeof payload.topicId === "string" ? [payload.topicId] : [],
+      });
+    }
   }
 
   async handleTopicHashBatch(payload) {
     const hasCompoundStates = Array.isArray(payload.topics) && payload.topics.length > 0;
-    return this.requireClient().syncTopicDiff({
-      hashes: hasCompoundStates ? {} : payload.hashes,
-      ...(hasCompoundStates ? { topics: payload.topics } : {}),
-    });
+    try {
+      const response = await this.requireClient().syncTopicDiff({
+        hashes: hasCompoundStates ? {} : payload.hashes,
+        ...(hasCompoundStates ? { topics: payload.topics } : {}),
+      });
+      const expected = new Set(
+        hasCompoundStates
+          ? payload.topics.map((topic) => topic?.topicId)
+          : Object.keys(payload.hashes || {}),
+      );
+      if (
+        !isRecord(response) ||
+        response.type !== "SYNC_TOPIC_HASH_RESULTS" ||
+        !Array.isArray(response.changedTopics) ||
+        response.changedTopics.some(
+          (topicId) => typeof topicId !== "string" || !expected.has(topicId),
+        ) ||
+        new Set(response.changedTopics).size !== response.changedTopics.length
+      ) {
+        throw cdsProtocolError(
+          "CDS returned an invalid topic hash response",
+          "topic_validation",
+        );
+      }
+      return response;
+    } catch (error) {
+      throw withCdsErrorContext(error, {
+        code: "SYNC_DB_QUERY_FAILED",
+        origin: "desktop_cds",
+        stage: "topic_validation",
+      });
+    }
   }
 
   async handleMessageDiffBatch(payload) {
-    return this.requireClient().syncMessageDiff({
-      topics: payload.topics,
-    });
+    try {
+      const response = await this.requireClient().syncMessageDiff({
+        topics: payload.topics,
+      });
+      if (
+        !isRecord(response) ||
+        response.type !== "SYNC_DIFF_RESULTS_BATCH" ||
+        !isRecord(response.results)
+      ) {
+        throw cdsProtocolError(
+          "CDS returned an invalid message diff response",
+          "messages",
+        );
+      }
+      const expectedTopicIds = Object.keys(
+        isRecord(payload.topics) ? payload.topics : {},
+      );
+      const resultTopicIds = Object.keys(response.results);
+      if (
+        resultTopicIds.length !== expectedTopicIds.length ||
+        resultTopicIds.some((topicId) => !expectedTopicIds.includes(topicId))
+      ) {
+        throw cdsProtocolError(
+          "CDS message diff response does not cover the requested topics",
+          "messages",
+          expectedTopicIds,
+        );
+      }
+      const results = {};
+      for (const [topicId, decision] of Object.entries(response.results)) {
+        if (!isRecord(decision)) {
+          throw cdsProtocolError(
+            `CDS returned an invalid message diff decision for ${topicId}`,
+            "messages",
+            [topicId],
+          );
+        }
+        if (decision.ok === false) {
+          if (
+            decision.error === undefined ||
+            decision.toPull !== undefined ||
+            decision.toPush !== undefined
+          ) {
+            throw cdsProtocolError(
+              `CDS returned an invalid rejected decision for ${topicId}`,
+              "messages",
+              [topicId],
+            );
+          }
+          results[topicId] = {
+            ok: false,
+            error: normalizeSyncError(decision.error, {
+              code: "MESSAGE_DIFF_FAILED",
+              origin: "desktop_cds",
+              stage: "messages",
+              failedTopicIds: [topicId],
+            }),
+          };
+          continue;
+        }
+        if (
+          decision.ok !== true ||
+          !Array.isArray(decision.toPull) ||
+          decision.toPull.some((id) => typeof id !== "string" || id.length === 0) ||
+          new Set(decision.toPull).size !== decision.toPull.length ||
+          typeof decision.toPush !== "boolean" ||
+          decision.error !== undefined
+        ) {
+          throw cdsProtocolError(
+            `CDS returned an invalid successful decision for ${topicId}`,
+            "messages",
+            [topicId],
+          );
+        }
+        results[topicId] = {
+          ok: true,
+          toPull: decision.toPull,
+          toPush: decision.toPush,
+        };
+      }
+      return { ...response, results };
+    } catch (error) {
+      throw withCdsErrorContext(error, {
+        code: "MESSAGE_DIFF_FAILED",
+        origin: "desktop_cds",
+        stage: "messages",
+        failedTopicIds:
+          payload.topics && typeof payload.topics === "object"
+            ? Object.keys(payload.topics).slice(0, 8)
+            : [],
+      });
+    }
   }
 
   async downloadMessagesStreamRaw(requests, res) {
@@ -122,7 +368,11 @@ class CentralSyncAdapter {
     res.flushHeaders();
 
     if (!Array.isArray(requests) || requests.length > MAX_NDJSON_TOPICS) {
-      throw new Error("Central pull requires at most 10000 topic requests");
+      throw createSyncError(
+        "SYNC_REQUEST_INVALID",
+        "Central pull requires at most 10000 topic requests",
+        { stage: "messages" },
+      );
     }
     const expected = new Map();
     let requestedMessages = 0;
@@ -136,24 +386,40 @@ class CentralSyncAdapter {
         request.ownerId.length === 0 ||
         !Array.isArray(request.msgIds)
       ) {
-        throw new Error("Central pull request requires exact topic owner identity");
+        throw createSyncError(
+          "SYNC_REQUEST_INVALID",
+          "Central pull request requires exact topic owner identity",
+          { stage: "messages" },
+        );
       }
       if (expected.has(request.topicId)) {
-        throw new Error(`Central pull contains duplicate topic ${request.topicId}`);
+        throw createSyncError(
+          "SYNC_REQUEST_INVALID",
+          `Central pull contains duplicate topic ${request.topicId}`,
+          { stage: "messages", failedTopicIds: [request.topicId] },
+        );
       }
       const uniqueIds = new Set(request.msgIds);
       if (
         uniqueIds.size !== request.msgIds.length ||
         request.msgIds.some((id) => typeof id !== "string" || id.length === 0)
       ) {
-        throw new Error(`Central pull ${request.topicId} has invalid message ids`);
+        throw createSyncError(
+          "SYNC_REQUEST_INVALID",
+          `Central pull ${request.topicId} has invalid message ids`,
+          { stage: "messages", failedTopicIds: [request.topicId] },
+        );
       }
       requestedMessages += request.msgIds.length;
       if (
         request.msgIds.length > 10_000 ||
         requestedMessages > MAX_NDJSON_MESSAGES
       ) {
-        throw new Error("Central pull exceeds the message count budget");
+        throw createSyncError(
+          "SYNC_BUDGET_EXCEEDED",
+          "Central pull exceeds the message count budget",
+          { stage: "messages", failedTopicIds: [request.topicId] },
+        );
       }
       expected.set(request.topicId, {
         ownerType: request.ownerType,
@@ -172,27 +438,45 @@ class CentralSyncAdapter {
     for await (const rawFrame of this.requireClient().syncMessagesPullStream({
       requests: normalizedRequests,
     })) {
-      const canonical = canonicalizeTopicFrame(rawFrame);
+      // CDS protocol 2 still uses a diagnostic string in pull `_error` frames.
+      // Translate it here; only the complete Wire object may cross to Mobile.
+      const canonical = canonicalizeTopicFrame(translateCdsPullFrame(rawFrame));
       const topicId = canonical.frame.topicId;
       if (!expected.has(topicId)) {
-        throw new Error(`CDS pull returned unexpected topic ${topicId}`);
+        throw createSyncError(
+          "SYNC_PROTOCOL_INVALID",
+          `CDS pull returned unexpected topic ${topicId}`,
+          { origin: "desktop_cds", stage: "messages", failedTopicIds: [topicId] },
+        );
       }
       if (seen.has(topicId)) {
-        throw new Error(`CDS pull returned duplicate topic ${topicId}`);
+        throw createSyncError(
+          "SYNC_PROTOCOL_INVALID",
+          `CDS pull returned duplicate topic ${topicId}`,
+          { origin: "desktop_cds", stage: "messages", failedTopicIds: [topicId] },
+        );
       }
       const identity = expected.get(topicId);
       if (
         canonical.frame.ownerType !== identity.ownerType ||
         canonical.frame.ownerId !== identity.ownerId
       ) {
-        throw new Error(`CDS pull returned conflicting owner identity for ${topicId}`);
+        throw createSyncError(
+          "SYNC_OWNER_CONFLICT",
+          `CDS pull returned conflicting owner identity for ${topicId}`,
+          { origin: "desktop_cds", stage: "messages", failedTopicIds: [topicId] },
+        );
       }
       seen.add(topicId);
       await writer.write(canonical.frame);
     }
     if (seen.size !== expected.size) {
       const missing = [...expected.keys()].filter((topicId) => !seen.has(topicId));
-      throw new Error(`CDS pull omitted topics: ${missing.slice(0, 8).join(", ")}`);
+      throw createSyncError(
+        "SYNC_MESSAGE_READ_FAILED",
+        `CDS pull omitted topics: ${missing.slice(0, 8).join(", ")}`,
+        { origin: "desktop_cds", stage: "messages", failedTopicIds: missing },
+      );
     }
     res.end();
   }
@@ -259,7 +543,11 @@ class CentralSyncAdapter {
           identity?.ownerType !== frame.ownerType ||
           identity?.ownerId !== frame.ownerId
         ) {
-          throw new Error(`CDS returned an invalid identity for topic ${topicId}`);
+          throw createSyncError(
+            "SYNC_PROTOCOL_INVALID",
+            `CDS returned an invalid identity for topic ${topicId}`,
+            { origin: "desktop_cds", stage: "messages", failedTopicIds: [topicId] },
+          );
         }
         const projected = await projectMobileTopic({
           topicId,
@@ -278,15 +566,31 @@ class CentralSyncAdapter {
           deletedMessageTombstones: [],
         });
         if (result?.topicId !== topicId || typeof result?.success !== "boolean") {
-          throw new Error(`CDS returned an invalid push result for ${topicId}`);
+          throw createSyncError(
+            "SYNC_PROTOCOL_INVALID",
+            `CDS returned an invalid push result for ${topicId}`,
+            { origin: "desktop_cds", stage: "messages", failedTopicIds: [topicId] },
+          );
         }
         if (!result.success) {
-          throw new Error(result.error || `CDS rejected topic ${topicId}`);
+          throw withCdsErrorContext(
+            result.error || `CDS rejected topic ${topicId}`,
+            {
+              code: "SYNC_MESSAGE_WRITE_FAILED",
+              origin: "desktop_cds",
+              stage: "messages",
+              failedTopicIds: [topicId],
+            },
+          );
         }
         const needed = new Set(projected.neededAttachmentHashes);
         const cdsNeeded = result.neededAttachmentHashes;
         if (!Array.isArray(cdsNeeded)) {
-          throw new Error(`CDS omitted neededAttachmentHashes for ${topicId}`);
+          throw createSyncError(
+            "SYNC_PROTOCOL_INVALID",
+            `CDS omitted neededAttachmentHashes for ${topicId}`,
+            { origin: "desktop_cds", stage: "messages", failedTopicIds: [topicId] },
+          );
         }
         for (const hash of cdsNeeded) needed.add(hash);
         await writer.write({
@@ -308,7 +612,12 @@ class CentralSyncAdapter {
           topicId,
           success: false,
           neededAttachmentHashes: [],
-          error: error.message,
+          error: normalizeSyncError(error, {
+            code: "SYNC_MESSAGE_WRITE_FAILED",
+            origin: "desktop_cds",
+            stage: "messages",
+            failedTopicIds: [topicId],
+          }),
         });
       }
     }
@@ -334,7 +643,11 @@ class CentralSyncAdapter {
       typeof identity?.ownerId !== "string" ||
       identity.ownerId.length === 0
     ) {
-      throw new Error(`CDS returned an invalid identity for topic ${topicId}`);
+      throw createSyncError(
+        "SYNC_PROTOCOL_INVALID",
+        `CDS returned an invalid identity for topic ${topicId}`,
+        { origin: "desktop_cds", stage: "messages", failedTopicIds: [topicId] },
+      );
     }
     const result = await client.syncMessagesPushTopic({
       topicId,
@@ -349,7 +662,15 @@ class CentralSyncAdapter {
       result?.success !== true ||
       !Array.isArray(result?.neededAttachmentHashes)
     ) {
-      throw new Error(result?.error || `CDS rejected message deletion for ${topicId}`);
+      throw withCdsErrorContext(
+        result?.error || `CDS rejected message deletion for ${topicId}`,
+        {
+          code: "SYNC_DELETE_FAILED",
+          origin: "desktop_cds",
+          stage: "messages",
+          failedTopicIds: [topicId],
+        },
+      );
     }
     return { success: true, topicId, msgId };
   }

--- a/VCPDistributedServer/Plugin/VCPMobileSync/sync/diff.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/sync/diff.js
@@ -6,6 +6,10 @@
 const { getDb } = require("../core/db");
 const { getLogger } = require("../core/logger");
 const { assertHistoryTopicHealthy } = require("./message");
+const {
+  normalizeSyncError,
+  withSyncErrorContext,
+} = require("../error-contract");
 
 const CONTENT_HASH_PATTERN = /^(?:|[a-f0-9]{64})$/;
 
@@ -141,10 +145,11 @@ function handleSyncTopicHashBatch(payload, database = getDb()) {
       }
       changedTopics.push(topicId);
     } catch (e) {
-      throw Object.assign(
-        new Error(`Topic hash lookup failed for ${topicId}: ${e.message}`),
-        { code: "SYNC_DB_QUERY_FAILED" },
-      );
+      throw withSyncErrorContext(e, {
+        code: "SYNC_DB_QUERY_FAILED",
+        stage: "topic_validation",
+        failedTopicIds: [topicId],
+      });
     }
   }
 
@@ -214,10 +219,11 @@ function handleSyncTopicHashBatchV2(payload, database = getDb()) {
         changedTopics.push(topicId);
       }
     } catch (e) {
-      throw Object.assign(
-        new Error(`Topic hash lookup failed for ${topicId}: ${e.message}`),
-        { code: "SYNC_DB_QUERY_FAILED" },
-      );
+      throw withSyncErrorContext(e, {
+        code: "SYNC_DB_QUERY_FAILED",
+        stage: "topic_validation",
+        failedTopicIds: [topicId],
+      });
     }
   }
 
@@ -315,10 +321,14 @@ function handleSyncMessageDiffBatch(payload, database = getDb()) {
       if (!topicRow) {
         results[topicId] = {
           ok: false,
-          error: {
-            code: "TOPIC_NOT_FOUND",
-            message: `Topic ${topicId} was not found in the desktop index`,
-          },
+          error: normalizeSyncError(
+            `Topic ${topicId} was not found in the desktop index`,
+            {
+              code: "TOPIC_NOT_FOUND",
+              stage: "messages",
+              failedTopicIds: [topicId],
+            },
+          ),
         };
         continue;
       }
@@ -379,10 +389,11 @@ function handleSyncMessageDiffBatch(payload, database = getDb()) {
       logger.logOperation("messages", "diff", topicId, "error", e.message);
       results[topicId] = {
         ok: false,
-        error: {
+        error: normalizeSyncError(e, {
           code: "MESSAGE_DIFF_FAILED",
-          message: e.message,
-        },
+          stage: "messages",
+          failedTopicIds: [topicId],
+        }),
       };
     }
   }

--- a/VCPDistributedServer/Plugin/VCPMobileSync/sync/entity.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/sync/entity.js
@@ -29,6 +29,11 @@ const {
 const { acquireLock } = require("../utils/lock");
 const { getLogger } = require("../core/logger");
 const {
+  createSyncError,
+  normalizeSyncError,
+  withSyncErrorContext,
+} = require("../error-contract");
+const {
   extractAgentDTO,
   applyAgentDTO,
   AGENT_SYNC_FIELDS,
@@ -51,6 +56,20 @@ const {
 
 const writeIntentLock = new Set();
 
+function entityStage(type) {
+  return ["topic", "agent_topic", "group_topic"].includes(type)
+    ? "topic_metadata"
+    : "owner_metadata";
+}
+
+function entityFailure(error, fallback, fields = {}) {
+  return {
+    success: false,
+    ...fields,
+    error: normalizeSyncError(error, fallback),
+  };
+}
+
 /**
  * 下载实体 - 从桌面端配置提取 DTO
  * @param {object} params
@@ -61,7 +80,11 @@ const writeIntentLock = new Set();
 async function downloadEntity({ id, type }) {
   const db = getDb();
   const logger = getLogger();
-  if (!db) return null;
+  if (!db) {
+    throw createSyncError("SYNC_DB_UNAVAILABLE", "Database not initialized", {
+      stage: entityStage(type),
+    });
+  }
 
   const safeId = sanitizeId(id);
   if (
@@ -69,7 +92,9 @@ async function downloadEntity({ id, type }) {
     safeId !== id ||
     !["agent", "group", "topic", "agent_topic", "group_topic"].includes(type)
   ) {
-    throw new Error("Invalid entity identity");
+    throw createSyncError("SYNC_REQUEST_INVALID", "Invalid entity identity", {
+      stage: entityStage(type),
+    });
   }
   const phase = (type === "topic" || type === "agent_topic" || type === "group_topic") ? "topic_metadata" : "owner_metadata";
 
@@ -105,7 +130,11 @@ async function downloadEntity({ id, type }) {
     }
   } catch (e) {
     logger.logOperation(phase, "download", safeId, "error", e.message);
-    return null;
+    throw withSyncErrorContext(e, {
+      code: "SYNC_ENTITY_READ_FAILED",
+      stage: phase,
+      failedTopicIds: entityStage(type) === "topic_metadata" ? [safeId] : [],
+    });
   }
 }
 
@@ -132,25 +161,22 @@ async function downloadEntities(requests) {
       "group_topic",
     ].includes(req.type);
     if (!safeId || safeId !== req.id || !validType || seen.has(key)) {
-      results.push({
-        id: req.id,
-        type: req.type,
-        success: false,
-        error: seen.has(key)
-          ? "duplicate entity request"
-          : "invalid entity identity",
-      });
+      results.push(entityFailure(
+        seen.has(key) ? "duplicate entity request" : "invalid entity identity",
+        { code: "SYNC_REQUEST_INVALID", stage: entityStage(req.type) },
+        { id: req.id, type: req.type },
+      ));
       continue;
     }
     seen.add(key);
     const row = getEntityIndex(safeId, req.type);
     if (!row) {
-      results.push({
-        id: req.id,
-        type: req.type,
-        success: false,
-        error: "entity not found",
-      });
+      results.push(entityFailure("entity not found", {
+        code: "SYNC_ENTITY_NOT_FOUND",
+        stage: entityStage(req.type),
+        failedTopicIds:
+          entityStage(req.type) === "topic_metadata" ? [safeId] : [],
+      }, { id: req.id, type: req.type }));
       continue;
     }
 
@@ -194,23 +220,27 @@ async function downloadEntities(requests) {
         if (dto) {
           results.push({ id: req.id, type, success: true, data: dto });
         } else {
-          results.push({
-            id: req.id,
-            type,
-            success: false,
-            error: "entity data was not found in its config",
-          });
+          results.push(entityFailure(
+            "entity data was not found in its config",
+            {
+              code: "SYNC_ENTITY_NOT_FOUND",
+              stage: entityStage(type),
+              failedTopicIds:
+                entityStage(type) === "topic_metadata" ? [safeId] : [],
+            },
+            { id: req.id, type },
+          ));
         }
       }
     } catch (e) {
       logger.logOperation("owner_metadata", "download", filePath, "error", e.message);
       for (const { req } of reqs) {
-        results.push({
-          id: req.id,
-          type: req.type,
-          success: false,
-          error: e.message,
-        });
+        results.push(entityFailure(e, {
+          code: "SYNC_ENTITY_READ_FAILED",
+          stage: entityStage(req.type),
+          failedTopicIds:
+            entityStage(req.type) === "topic_metadata" ? [req.id] : [],
+        }, { id: req.id, type: req.type }));
       }
     }
   }
@@ -251,13 +281,17 @@ async function uploadEntitiesBatch(items, appDataPath) {
       typeof data.ownerId !== "string" ||
       sanitizeId(data.ownerId) !== data.ownerId
     ) {
-      results.push({
-        id,
-        success: false,
-        error: seenIds.has(safeId)
+      results.push(entityFailure(
+        seenIds.has(safeId)
           ? "Duplicate entity id"
           : "Batch upload only accepts valid agent_topic/group_topic items",
-      });
+        {
+          code: "SYNC_REQUEST_INVALID",
+          stage: "topic_metadata",
+          failedTopicIds: safeId ? [safeId] : [],
+        },
+        { id },
+      ));
       continue;
     }
     seenIds.add(safeId);
@@ -278,7 +312,11 @@ async function uploadEntitiesBatch(items, appDataPath) {
     }
 
     if (!configPath) {
-      results.push({ id, success: false, error: "Cannot resolve config path" });
+      results.push(entityFailure("Cannot resolve config path", {
+        code: "SYNC_ENTITY_NOT_FOUND",
+        stage: "topic_metadata",
+        failedTopicIds: [safeId],
+      }, { id }));
       continue;
     }
     const actualOwnerId = path.basename(path.dirname(configPath));
@@ -287,7 +325,11 @@ async function uploadEntitiesBatch(items, appDataPath) {
       actualOwnerId !== data.ownerId ||
       actualIsGroup !== (type === "group_topic")
     ) {
-      results.push({ id, success: false, error: "Topic owner identity conflict" });
+      results.push(entityFailure("Topic owner identity conflict", {
+        code: "SYNC_OWNER_CONFLICT",
+        stage: "topic_metadata",
+        failedTopicIds: [safeId],
+      }, { id }));
       continue;
     }
 
@@ -332,7 +374,11 @@ async function uploadEntitiesBatch(items, appDataPath) {
             results.push({ id, success: true });
             successfulIds.add(id);
           } catch (e) {
-            results.push({ id, success: false, error: e.message });
+            results.push(entityFailure(e, {
+              code: "SYNC_ENTITY_WRITE_FAILED",
+              stage: "topic_metadata",
+              failedTopicIds: [id],
+            }, { id }));
           }
         }
 
@@ -363,7 +409,11 @@ async function uploadEntitiesBatch(items, appDataPath) {
           if (groupIds.has(results[index].id)) results.splice(index, 1);
         }
         for (const item of group.items) {
-          results.push({ id: item.id, success: false, error: `File error: ${e.message}` });
+          results.push(entityFailure(e, {
+            code: "SYNC_ENTITY_BATCH_FAILED",
+            stage: "topic_metadata",
+            failedTopicIds: [item.id],
+          }, { id: item.id }));
         }
       } finally {
         release();
@@ -387,12 +437,17 @@ async function uploadEntitiesBatch(items, appDataPath) {
  * @param {string} params.type - 实体类型 (agent/group/topic)
  * @param {object} params.data - DTO 数据
  * @param {string} params.appDataPath - AppData 路径
- * @returns {Promise<{success: boolean, error?: string}>}
+ * @returns {Promise<{success: boolean, error?: object}>}
  */
 async function uploadEntity({ id, type, data, appDataPath }) {
   const db = getDb();
   const logger = getLogger();
-  if (!db) return { success: false, error: "Database not initialized" };
+  if (!db) {
+    return entityFailure("Database not initialized", {
+      code: "SYNC_DB_UNAVAILABLE",
+      stage: entityStage(type),
+    });
+  }
 
   const safeId = sanitizeId(id);
   if (
@@ -403,7 +458,10 @@ async function uploadEntity({ id, type, data, appDataPath }) {
     typeof data !== "object" ||
     Array.isArray(data)
   ) {
-    return { success: false, id, error: "Invalid entity upload payload" };
+    return entityFailure("Invalid entity upload payload", {
+      code: "SYNC_REQUEST_INVALID",
+      stage: entityStage(type),
+    }, { id });
   }
   const isTopic =
     type === "topic" || type === "agent_topic" || type === "group_topic";
@@ -438,17 +496,25 @@ async function uploadEntity({ id, type, data, appDataPath }) {
     );
     try {
       await fs.access(configPath);
-    } catch (e) {
+    } catch {
       logger.logOperation(phase, "upload", safeId, "error", `parent entity ${data.ownerId} not found`);
-      return {
-        success: false,
-        id: safeId,
-        error: `Parent entity ${data.ownerId} not found on desktop`,
-      };
+      return entityFailure(
+        `Parent entity ${data.ownerId} not found on desktop`,
+        {
+          code: "SYNC_ENTITY_NOT_FOUND",
+          stage: "topic_metadata",
+          failedTopicIds: [safeId],
+        },
+        { id: safeId },
+      );
     }
   } else {
     logger.logOperation(phase, "upload", safeId, "error", "topic parent entity metadata missing");
-    return { success: false, id: safeId, error: "Topic parent entity metadata missing" };
+    return entityFailure("Topic parent entity metadata missing", {
+      code: "SYNC_REQUEST_INVALID",
+      stage: "topic_metadata",
+      failedTopicIds: [safeId],
+    }, { id: safeId });
   }
 
   if (isTopic) {
@@ -460,7 +526,11 @@ async function uploadEntity({ id, type, data, appDataPath }) {
       data.ownerId !== actualOwnerId ||
       actualIsGroup !== (type === "group_topic")
     ) {
-      return { success: false, id: safeId, error: "Topic owner identity conflict" };
+      return entityFailure("Topic owner identity conflict", {
+        code: "SYNC_OWNER_CONFLICT",
+        stage: "topic_metadata",
+        failedTopicIds: [safeId],
+      }, { id: safeId });
     }
   }
 
@@ -539,7 +609,11 @@ async function uploadEntity({ id, type, data, appDataPath }) {
     return { success: true, id: safeId };
   } catch (e) {
     logger.logOperation(phase, "upload", safeId, "error", e.message);
-    return { success: false, id: safeId, error: e.message };
+    return entityFailure(e, {
+      code: "SYNC_ENTITY_WRITE_FAILED",
+      stage: phase,
+      failedTopicIds: isTopic ? [safeId] : [],
+    }, { id: safeId });
   } finally {
     release();
     setTimeout(() => writeIntentLock.delete(safeId), 1000);
@@ -813,12 +887,17 @@ function isWriteLocked(id) {
  * @param {string} params.type - 实体类型 (agent/group/agent_topic/group_topic/avatar)
  * @param {number} params.deletedAt - 删除时间戳
  * @param {string} params.appDataPath - AppData 路径
- * @returns {Promise<{success: boolean, error?: string}>}
+ * @returns {Promise<{success: boolean, error?: object}>}
  */
 async function deleteEntity({ id, type, ownerType = null, deletedAt, appDataPath }) {
   const db = getDb();
   const logger = getLogger();
-  if (!db) return { success: false, error: "Database not initialized" };
+  if (!db) {
+    return entityFailure("Database not initialized", {
+      code: "SYNC_DB_UNAVAILABLE",
+      stage: entityStage(type),
+    });
+  }
 
   const safeId = sanitizeId(id);
   const allowedTypes = new Set([
@@ -838,7 +917,10 @@ async function deleteEntity({ id, type, ownerType = null, deletedAt, appDataPath
     (type === "avatar" && !["agent", "group", "user"].includes(ownerType)) ||
     (type === "avatar" && ownerType === "user" && safeId !== "user_avatar")
   ) {
-    return { success: false, id, error: "Invalid entity deletion payload" };
+    return entityFailure("Invalid entity deletion payload", {
+      code: "SYNC_DELETE_INVALID",
+      stage: entityStage(type),
+    }, { id });
   }
   const isTopic = type === "agent_topic" || type === "group_topic" || type === "topic";
   const actualPhase = isTopic ? "topic_metadata" : "owner_metadata";
@@ -920,7 +1002,11 @@ async function deleteEntity({ id, type, ownerType = null, deletedAt, appDataPath
     return { success: true, id: safeId };
   } catch (e) {
     logger.logOperation(actualPhase, "delete", safeId, "error", e.message);
-    return { success: false, error: e.message };
+    return entityFailure(e, {
+      code: "SYNC_DELETE_FAILED",
+      stage: actualPhase,
+      failedTopicIds: isTopic ? [safeId] : [],
+    });
   } finally {
     if (release) release();
     if (isTopic) {
@@ -935,12 +1021,18 @@ async function deleteEntity({ id, type, ownerType = null, deletedAt, appDataPath
  * @param {string} params.msgId - 消息 ID
  * @param {number} params.deletedAt - 删除时间戳
  * @param {string} [params.topicId] - 话题 ID
- * @returns {Promise<{success: boolean, error?: string}>}
+ * @returns {Promise<{success: boolean, error?: object}>}
  */
 async function deleteMessage({ msgId, deletedAt, topicId, appDataPath }) {
   const db = getDb();
   const logger = getLogger();
-  if (!db) return { success: false, error: "Database not initialized" };
+  if (!db) {
+    return entityFailure("Database not initialized", {
+      code: "SYNC_DB_UNAVAILABLE",
+      stage: "messages",
+      failedTopicIds: typeof topicId === "string" ? [topicId] : [],
+    });
+  }
 
   const safeMsgId = sanitizeId(msgId);
   const safeTopicId = topicId ? sanitizeId(topicId) : null;
@@ -965,7 +1057,11 @@ async function deleteMessage({ msgId, deletedAt, topicId, appDataPath }) {
     return { success: true, topicId: safeTopicId, msgId: safeMsgId };
   } catch (e) {
     logger.logOperation("messages", "delete", safeMsgId, "error", e.message);
-    return { success: false, error: e.message };
+    return entityFailure(e, {
+      code: "SYNC_DELETE_FAILED",
+      stage: "messages",
+      failedTopicIds: safeTopicId ? [safeTopicId] : [],
+    });
   }
 }
 

--- a/VCPDistributedServer/Plugin/VCPMobileSync/sync/message.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/sync/message.js
@@ -22,6 +22,12 @@ const { parseJsonWithoutDuplicateKeys } = require("../protocol");
 const { canonicalizeHistory } = require("./canonical");
 const { projectMobileTopic } = require("./projection");
 const {
+  createHttpErrorBody,
+  createStreamErrorFrame,
+  createSyncError,
+  normalizeSyncError,
+} = require("../error-contract");
+const {
   MAX_NDJSON_MESSAGES,
   MAX_NDJSON_TOPICS,
   NdjsonWriter,
@@ -130,7 +136,10 @@ async function downloadMessagesStreamRaw(requests, appDataPath, res) {
   const logger = getLogger();
   const db = getDb();
   if (!db) {
-    res.status(500).json({ error: "Database not initialized" });
+    res.status(500).json(createHttpErrorBody("Database not initialized", {
+      code: "SYNC_DB_UNAVAILABLE",
+      stage: "messages",
+    }));
     return;
   }
   if (
@@ -138,7 +147,11 @@ async function downloadMessagesStreamRaw(requests, appDataPath, res) {
     requests.length === 0 ||
     requests.some((request) => !request || typeof request !== "object")
   ) {
-    throw new Error("Message pull requires non-empty object requests");
+    throw createSyncError(
+      "SYNC_REQUEST_INVALID",
+      "Message pull requires non-empty object requests",
+      { stage: "messages" },
+    );
   }
 
   res.setHeader("Content-Type", "application/x-ndjson; charset=utf-8");
@@ -152,37 +165,67 @@ async function downloadMessagesStreamRaw(requests, appDataPath, res) {
   const seenTopics = new Set();
   let requestedMessages = 0;
   if (requests.length > MAX_NDJSON_TOPICS) {
-    throw new Error("Message pull exceeds 10000 topics");
+    throw createSyncError(
+      "SYNC_BUDGET_EXCEEDED",
+      "Message pull exceeds 10000 topics",
+      { stage: "messages" },
+    );
   }
   for (const { topicId, ownerType, ownerId, msgIds = [] } of requests) {
     const safeTopicId = sanitizeId(topicId);
     try {
       if (!safeTopicId || safeTopicId !== topicId || seenTopics.has(safeTopicId)) {
-        throw new Error("Message pull topic IDs must be non-empty and unique");
+        throw createSyncError(
+          "SYNC_REQUEST_INVALID",
+          "Message pull topic IDs must be non-empty and unique",
+          { stage: "messages", failedTopicIds: [topicId] },
+        );
       }
       if (
         !Array.isArray(msgIds) ||
         new Set(msgIds).size !== msgIds.length ||
         msgIds.some((id) => typeof id !== "string" || id.length === 0)
       ) {
-        throw new Error("Message pull IDs must be non-empty strings and unique");
+        throw createSyncError(
+          "SYNC_REQUEST_INVALID",
+          "Message pull IDs must be non-empty strings and unique",
+          { stage: "messages", failedTopicIds: [safeTopicId] },
+        );
       }
       if (
         !["agent", "group"].includes(ownerType) ||
         typeof ownerId !== "string" ||
         ownerId.length === 0
       ) {
-        throw new Error("Message pull requires exact ownerType and ownerId");
+        throw createSyncError(
+          "SYNC_REQUEST_INVALID",
+          "Message pull requires exact ownerType and ownerId",
+          { stage: "messages", failedTopicIds: [safeTopicId] },
+        );
       }
       seenTopics.add(safeTopicId);
       assertHistoryTopicHealthy(safeTopicId);
       requestedMessages += msgIds.length;
       if (msgIds.length > 10_000 || requestedMessages > MAX_NDJSON_MESSAGES) {
-        throw new Error("Message pull exceeds message count budget");
+        throw createSyncError(
+          "SYNC_BUDGET_EXCEEDED",
+          "Message pull exceeds message count budget",
+          { stage: "messages", failedTopicIds: [safeTopicId] },
+        );
       }
       const row = getEntityIndex(safeTopicId, "topic");
       if (!row) {
-        await writer.write({ topicId, ownerType, ownerId, messages: [], _error: "topic not found" });
+        await writer.write({
+          topicId,
+          ownerType,
+          ownerId,
+          messages: [],
+          _error: normalizeSyncError("topic not found", {
+            code: "TOPIC_NOT_FOUND",
+            stage: "messages",
+            failedTopicIds: [safeTopicId],
+          }),
+        });
         errorCount++;
         continue;
       }
@@ -193,7 +236,11 @@ async function downloadMessagesStreamRaw(requests, appDataPath, res) {
         ownerType !== actualOwnerType ||
         ownerId !== parentId
       ) {
-        throw new Error("topic owner identity conflicts with desktop index");
+        throw createSyncError(
+          "SYNC_OWNER_CONFLICT",
+          "topic owner identity conflicts with desktop index",
+          { stage: "messages", failedTopicIds: [safeTopicId] },
+        );
       }
       const historyPath = path.join(
         appDataPath,
@@ -213,7 +260,11 @@ async function downloadMessagesStreamRaw(requests, appDataPath, res) {
       if (wanted.size > 0) {
         const actual = new Set(messages.map((message) => message.id));
         if (actual.size !== wanted.size || [...wanted].some((id) => !actual.has(id))) {
-          throw new Error("requested message set is incomplete");
+          throw createSyncError(
+            "SYNC_MESSAGE_READ_FAILED",
+            "requested message set is incomplete",
+            { stage: "messages", failedTopicIds: [safeTopicId] },
+          );
         }
       }
       await writer.write({
@@ -240,7 +291,17 @@ async function downloadMessagesStreamRaw(requests, appDataPath, res) {
       successCount++;
     } catch (e) {
       // 单 topic 失败写错误帧，不中断流
-      await writer.write({ topicId, ownerType, ownerId, messages: [], _error: e.message });
+      await writer.write({
+        topicId,
+        ownerType,
+        ownerId,
+        messages: [],
+        _error: normalizeSyncError(e, {
+          code: "SYNC_MESSAGE_READ_FAILED",
+          stage: "messages",
+          failedTopicIds: [safeTopicId],
+        }),
+      });
       errorCount++;
     }
   }
@@ -322,7 +383,10 @@ async function uploadMessagesBatchRaw(req, appDataPath, res) {
   const logger = getLogger();
   const db = getDb();
   if (!db) {
-    res.status(500).json({ error: "Database not initialized" });
+    res.status(500).json(createHttpErrorBody("Database not initialized", {
+      code: "SYNC_DB_UNAVAILABLE",
+      stage: "messages",
+    }));
     return;
   }
 
@@ -341,23 +405,36 @@ async function uploadMessagesBatchRaw(req, appDataPath, res) {
   try {
     for await (const line of readNdjsonLines(req)) {
       let topicId = null;
+      let streamFatal = false;
       try {
         const frame = parseJsonWithoutDuplicateKeys(decodeNdjsonLine(line));
         topicId = frame.topicId;
         const { messages, ownerType, ownerId } = frame;
         const safeTopicId = sanitizeId(topicId);
         if (!safeTopicId || safeTopicId !== topicId) {
-          throw new Error("topicId is missing or contains unsupported characters");
+          throw createSyncError(
+            "SYNC_REQUEST_INVALID",
+            "topicId is missing or contains unsupported characters",
+            { stage: "messages" },
+          );
         }
         if (!Array.isArray(messages)) {
-          throw new Error("messages must be an array");
+          throw createSyncError(
+            "SYNC_REQUEST_INVALID",
+            "messages must be an array",
+            { stage: "messages", failedTopicIds: [safeTopicId] },
+          );
         }
         if (
           !["agent", "group"].includes(ownerType) ||
           typeof ownerId !== "string" ||
           ownerId.length === 0
         ) {
-          throw new Error("Message push requires exact ownerType and ownerId");
+          throw createSyncError(
+            "SYNC_REQUEST_INVALID",
+            "Message push requires exact ownerType and ownerId",
+            { stage: "messages", failedTopicIds: [safeTopicId] },
+          );
         }
         topicCount += 1;
         messageCount += messages.length;
@@ -366,10 +443,20 @@ async function uploadMessagesBatchRaw(req, appDataPath, res) {
           messages.length > 10_000 ||
           messageCount > MAX_NDJSON_MESSAGES
         ) {
-          throw new Error("Message push exceeds topic or message count budget");
+          streamFatal = true;
+          throw createSyncError(
+            "SYNC_BUDGET_EXCEEDED",
+            "Message push exceeds topic or message count budget",
+            { stage: "messages", failedTopicIds: [safeTopicId] },
+          );
         }
         if (seenTopics.has(safeTopicId)) {
-          throw new Error("Message push contains a duplicate topic identity");
+          streamFatal = true;
+          throw createSyncError(
+            "SYNC_REQUEST_INVALID",
+            "Message push contains a duplicate topic identity",
+            { stage: "messages", failedTopicIds: [safeTopicId] },
+          );
         }
         seenTopics.add(safeTopicId);
 
@@ -379,7 +466,11 @@ async function uploadMessagesBatchRaw(req, appDataPath, res) {
             topicId,
             success: false,
             neededAttachmentHashes: [],
-            error: "topic not found",
+            error: normalizeSyncError("topic not found", {
+              code: "TOPIC_NOT_FOUND",
+              stage: "messages",
+              failedTopicIds: [safeTopicId],
+            }),
           });
           errorCount++;
           continue;
@@ -392,7 +483,11 @@ async function uploadMessagesBatchRaw(req, appDataPath, res) {
           ownerType !== actualOwnerType ||
           ownerId !== actualOwnerId
         ) {
-          throw new Error("topic owner identity conflicts with desktop index");
+          throw createSyncError(
+            "SYNC_OWNER_CONFLICT",
+            "topic owner identity conflicts with desktop index",
+            { stage: "messages", failedTopicIds: [safeTopicId] },
+          );
         }
 
         writeIntentLock.add(safeTopicId);
@@ -407,12 +502,17 @@ async function uploadMessagesBatchRaw(req, appDataPath, res) {
         successCount++;
       } catch (e) {
         logger.logOperation("messages", "upload_batch_stream", "line_parse", "error", e.message);
+        if (streamFatal) throw e;
         if (typeof topicId === "string" && topicId.length > 0) {
           await writer.write({
             topicId,
             success: false,
             neededAttachmentHashes: [],
-            error: e.message,
+            error: normalizeSyncError(e, {
+              code: "SYNC_MESSAGE_WRITE_FAILED",
+              stage: "messages",
+              failedTopicIds: [topicId],
+            }),
           });
         } else {
           throw e;
@@ -426,7 +526,10 @@ async function uploadMessagesBatchRaw(req, appDataPath, res) {
   } catch (e) {
     logger.logOperation("messages", "upload_messages_batch_stream", "global", "error", e.message);
     if (!res.writableEnded) {
-      await writer.write({ _stream_error: e.message }).catch(() => {});
+      await writer.write(createStreamErrorFrame(e, {
+        code: "SYNC_STREAM_FAILED",
+        stage: "messages",
+      })).catch(() => {});
     }
   } finally {
     res.end();

--- a/VCPDistributedServer/Plugin/VCPMobileSync/transport/routes.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/transport/routes.js
@@ -3,12 +3,7 @@
  */
 
 const express = require("express");
-const { getDb } = require("../core/db");
 const { checkIdempotency, recordOperation } = require("../core/idempotency");
-const {
-  handleSyncManifest,
-  handleMessageManifest,
-} = require("../sync/manifest");
 const {
   downloadEntity,
   downloadEntities,
@@ -26,6 +21,50 @@ const {
   uploadAttachmentStream,
 } = require("../sync/message");
 const { getLogger } = require("../core/logger");
+const {
+  createHttpErrorBody,
+  createStreamErrorFrame,
+  normalizeFailureResult,
+} = require("../error-contract");
+
+function entityStage(type) {
+  return ["topic", "agent_topic", "group_topic"].includes(type)
+    ? "topic_metadata"
+    : "owner_metadata";
+}
+
+function failedTopicIds(type, id) {
+  return ["topic", "agent_topic", "group_topic"].includes(type) &&
+    typeof id === "string" && id.length > 0
+    ? [id]
+    : [];
+}
+
+function sendHttpError(res, status, error, fallback) {
+  return res.status(status).json(createHttpErrorBody(error, fallback));
+}
+
+function streamErrorFallback(centralSync, code = "SYNC_STREAM_FAILED") {
+  return {
+    code,
+    origin: centralSync ? "desktop_cds" : "desktop_plugin",
+    stage: "messages",
+  };
+}
+
+function requestStage(req) {
+  const route = req.path || "";
+  if (route.includes("message") || route.includes("attachment")) return "messages";
+  if (route === "/changes") return "history";
+  if (route === "/upload-entities-batch") return "topic_metadata";
+  if (route === "/download-avatar" || route === "/upload-avatar") {
+    return "owner_metadata";
+  }
+  if (route.includes("entity") || route.includes("entities")) {
+    return entityStage(req.body?.type || req.query?.type);
+  }
+  return "startup";
+}
 
 /**
  * 注册 HTTP 路由
@@ -53,7 +92,10 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
     }
 
     if (providedToken !== syncToken) {
-      return res.status(401).json({ error: "Unauthorized" });
+      return sendHttpError(res, 401, "Unauthorized", {
+        code: "SYNC_AUTH_FAILED",
+        stage: "connect",
+      });
     }
 
     next();
@@ -68,7 +110,8 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
       const duration = Date.now() - start;
       const status = res.statusCode;
       const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
-      logger.logOperation("http", `${req.method}`, routePath, level === "error" ? "error" : "success", `status=${status} duration=${duration}ms`);
+      const result = level === "error" ? "error" : level === "warn" ? "warn" : "success";
+      logger.logOperation("http", `${req.method}`, routePath, result, `status=${status} duration=${duration}ms`);
     });
 
     next();
@@ -81,11 +124,19 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
     try {
       const dto = await downloadEntity({ id, type });
       if (!dto) {
-        return res.status(404).json({ error: "Not found" });
+        return sendHttpError(res, 404, "Entity not found", {
+          code: "SYNC_ENTITY_NOT_FOUND",
+          stage: entityStage(type),
+          failedTopicIds: failedTopicIds(type, id),
+        });
       }
       res.json(dto);
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      sendHttpError(res, 500, e, {
+        code: "SYNC_ENTITY_READ_FAILED",
+        stage: entityStage(type),
+        failedTopicIds: failedTopicIds(type, id),
+      });
     }
   });
 
@@ -93,14 +144,28 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
   router.post("/download-entities", express.json(), async (req, res) => {
     const { requests } = req.body;
     if (!Array.isArray(requests) || requests.length > 10_000) {
-      return res.status(400).json({ error: "requests must be an array of at most 10000 items" });
+      return sendHttpError(
+        res,
+        400,
+        "requests must be an array of at most 10000 items",
+        { code: "SYNC_REQUEST_INVALID", stage: "owner_metadata" },
+      );
     }
 
     try {
-      const results = await downloadEntities(requests);
+      const results = (await downloadEntities(requests)).map((result) =>
+        normalizeFailureResult(result, {
+          code: "SYNC_ENTITY_READ_FAILED",
+          stage: entityStage(result?.type),
+          failedTopicIds: failedTopicIds(result?.type, result?.id),
+        }),
+      );
       res.json(results);
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      sendHttpError(res, 500, e, {
+        code: "SYNC_ENTITY_READ_FAILED",
+        stage: "owner_metadata",
+      });
     }
   });
 
@@ -117,18 +182,34 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
       } = checkIdempotency(opId);
       if (duplicate) {
         logger.logOperation("http", "idempotency", "upload-entity", "warn", `duplicate detected: ${opId}`);
-        return res.status(previousStatus).json(prevResult);
+        return res.status(previousStatus).json(
+          normalizeFailureResult(prevResult, {
+            code: "SYNC_ENTITY_WRITE_FAILED",
+            stage: entityStage(prevResult?.type),
+          }),
+        );
       }
 
       const { id, type, data } = req.body;
 
       try {
-        const result = await uploadEntity({ id, type, data, appDataPath });
+        const result = normalizeFailureResult(
+          await uploadEntity({ id, type, data, appDataPath }),
+          {
+            code: "SYNC_ENTITY_WRITE_FAILED",
+            stage: entityStage(type),
+            failedTopicIds: failedTopicIds(type, id),
+          },
+        );
         const statusCode = result?.success === true ? 200 : 409;
         recordOperation(opId, result, statusCode);
         res.status(statusCode).json(result);
       } catch (e) {
-        res.status(500).json({ error: e.message });
+        sendHttpError(res, 500, e, {
+          code: "SYNC_ENTITY_WRITE_FAILED",
+          stage: entityStage(type),
+          failedTopicIds: failedTopicIds(type, id),
+        });
       }
     },
   );
@@ -140,20 +221,36 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
     async (req, res) => {
       const { items } = req.body;
       if (!Array.isArray(items)) {
-        return res.status(400).json({ error: "items must be an array" });
+        return sendHttpError(res, 400, "items must be an array", {
+          code: "SYNC_REQUEST_INVALID",
+          stage: "topic_metadata",
+        });
       }
       if (items.length > 10_000) {
-        return res.status(413).json({ error: "items exceed the 10000 item budget" });
+        return sendHttpError(res, 413, "items exceed the 10000 item budget", {
+          code: "SYNC_BUDGET_EXCEEDED",
+          stage: "topic_metadata",
+        });
       }
 
       try {
-        const results = await uploadEntitiesBatch(items, appDataPath);
+        const results = (await uploadEntitiesBatch(items, appDataPath)).map(
+          (result) => normalizeFailureResult(result, {
+            code: "SYNC_ENTITY_BATCH_FAILED",
+            stage: "topic_metadata",
+            failedTopicIds:
+              typeof result?.id === "string" ? [result.id] : [],
+          }),
+        );
         const success =
           results.length === items.length &&
           results.every((result) => result?.success === true);
         res.json({ success, results });
       } catch (e) {
-        res.status(500).json({ error: e.message });
+        sendHttpError(res, 500, e, {
+          code: "SYNC_ENTITY_BATCH_FAILED",
+          stage: "topic_metadata",
+        });
       }
     },
   );
@@ -162,7 +259,10 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
   router.post("/download-messages-stream", express.json({ limit: "5mb" }), async (req, res) => {
     const { requests } = req.body;
     if (!Array.isArray(requests) || requests.length === 0) {
-      return res.status(400).json({ error: "requests must be a non-empty array" });
+      return sendHttpError(res, 400, "requests must be a non-empty array", {
+        code: "SYNC_REQUEST_INVALID",
+        stage: "messages",
+      });
     }
 
     try {
@@ -173,10 +273,15 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
       }
     } catch (e) {
       if (!res.headersSent) {
-        res.status(500).json({ error: e.message });
+        sendHttpError(res, 500, e, streamErrorFallback(centralSync));
       } else {
         // 流已经开始，写入错误帧并结束
-        res.write(JSON.stringify({ _stream_error: e.message }) + "\n");
+        res.write(
+          `${JSON.stringify(createStreamErrorFrame(
+            e,
+            streamErrorFallback(centralSync),
+          ))}\n`,
+        );
         res.end();
       }
     }
@@ -194,9 +299,14 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
         }
       } catch (e) {
         if (!res.headersSent) {
-          res.status(500).json({ error: e.message });
+          sendHttpError(res, 500, e, streamErrorFallback(centralSync));
         } else {
-          res.write(JSON.stringify({ _stream_error: e.message }) + "\n");
+          res.write(
+            `${JSON.stringify(createStreamErrorFrame(
+              e,
+              streamErrorFallback(centralSync),
+            ))}\n`,
+          );
           res.end();
         }
       }
@@ -208,7 +318,12 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
     "/upload-attachment",
     async (req, res) => {
       const { hash, name, type } = req.query;
-      if (!hash) return res.status(400).send("Missing hash");
+      if (!hash) {
+        return sendHttpError(res, 400, "Missing hash", {
+          code: "MOBILE_ATTACHMENT_INVALID",
+          stage: "messages",
+        });
+      }
 
       const rawLength = req.headers["content-length"];
       const declaredLength = rawLength === undefined
@@ -226,7 +341,10 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
         });
         res.json(result);
       } catch (e) {
-        res.status(500).json({ error: e.message });
+        sendHttpError(res, 500, e, {
+          code: "SYNC_ATTACHMENT_WRITE_FAILED",
+          stage: "messages",
+        });
       }
     },
   );
@@ -238,11 +356,17 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
     try {
       const result = await downloadAttachment(hash);
       if (!result) {
-        return res.status(404).send("Not Found");
+        return sendHttpError(res, 404, "Attachment not found", {
+          code: "SYNC_ATTACHMENT_NOT_FOUND",
+          stage: "messages",
+        });
       }
       res.sendFile(result.filePath);
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      sendHttpError(res, 500, e, {
+        code: "SYNC_ATTACHMENT_READ_FAILED",
+        stage: "messages",
+      });
     }
   });
 
@@ -254,11 +378,17 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
     try {
       const result = await downloadAvatar(id, type);
       if (!result) {
-        return res.status(404).send("Not Found");
+        return sendHttpError(res, 404, "Avatar not found", {
+          code: "SYNC_AVATAR_NOT_FOUND",
+          stage: "owner_metadata",
+        });
       }
       res.sendFile(result.filePath);
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      sendHttpError(res, 500, e, {
+        code: "SYNC_AVATAR_READ_FAILED",
+        stage: "owner_metadata",
+      });
     }
   });
 
@@ -278,7 +408,10 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
         });
         res.json(result);
       } catch (e) {
-        res.status(500).json({ error: e.message });
+        sendHttpError(res, 500, e, {
+          code: "SYNC_AVATAR_WRITE_FAILED",
+          stage: "owner_metadata",
+        });
       }
     },
   );
@@ -303,7 +436,10 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
       deletedAt < 0 ||
       (type === "avatar" && !["agent", "group", "user"].includes(ownerType))
     ) {
-      return res.status(400).json({ error: "Invalid delete entity fields" });
+      return sendHttpError(res, 400, "Invalid delete entity fields", {
+        code: "SYNC_DELETE_INVALID",
+        stage: entityStage(type),
+      });
     }
 
     try {
@@ -314,9 +450,18 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
         deletedAt,
         appDataPath,
       });
-      res.status(result?.success === true ? 200 : 409).json(result);
+      const response = normalizeFailureResult(result, {
+        code: "SYNC_DELETE_FAILED",
+        stage: entityStage(type),
+        failedTopicIds: failedTopicIds(type, id),
+      });
+      res.status(response?.success === true ? 200 : 409).json(response);
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      sendHttpError(res, 500, e, {
+        code: "SYNC_DELETE_FAILED",
+        stage: entityStage(type),
+        failedTopicIds: failedTopicIds(type, id),
+      });
     }
   });
 
@@ -333,7 +478,12 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
       !Number.isSafeInteger(deletedAt) ||
       deletedAt < 0
     ) {
-      return res.status(400).json({ error: "Missing required fields" });
+      return sendHttpError(res, 400, "Missing required fields", {
+        code: "SYNC_DELETE_INVALID",
+        stage: "messages",
+        failedTopicIds:
+          typeof topicId === "string" && topicId.length > 0 ? [topicId] : [],
+      });
     }
 
     try {
@@ -348,24 +498,73 @@ function registerRoutes(app, { syncToken, appDataPath, centralSync = null }) {
         topicId,
         appDataPath,
       });
-      res.status(result?.success === true ? 200 : 409).json(result);
+      const response = normalizeFailureResult(result, {
+        code: "SYNC_DELETE_FAILED",
+        stage: "messages",
+        failedTopicIds: [topicId],
+      });
+      res.status(response?.success === true ? 200 : 409).json(response);
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      sendHttpError(res, 500, e, {
+        code: "SYNC_DELETE_FAILED",
+        stage: "messages",
+        failedTopicIds: [topicId],
+      });
     }
   });
 
   // Change Feed 为移动端断线续传与删除事件提供中央游标。
   router.get("/changes", async (req, res) => {
     if (!centralSync) {
-      return res.status(404).json({ error: "Central sync is disabled" });
+      return sendHttpError(res, 404, "Central sync is disabled", {
+        code: "SYNC_CHANGE_FEED_UNAVAILABLE",
+        stage: "history",
+      });
     }
     try {
       const after = Number.parseInt(req.query.after || "0", 10) || 0;
       const limit = Number.parseInt(req.query.limit || "200", 10) || 200;
       res.json(await centralSync.changes(after, limit));
     } catch (e) {
-      res.status(500).json({ error: e.message });
+      sendHttpError(res, 500, e, {
+        code: "SYNC_CHANGE_FEED_FAILED",
+        origin: "desktop_cds",
+        stage: "history",
+      });
     }
+  });
+
+  // Keep parser failures and unknown MobileSync routes inside the same Wire
+  // contract. Route-level express.json() errors otherwise bypass the handlers
+  // above and fall through to the host application's generic HTML response.
+  router.use((req, res) => sendHttpError(res, 404, "Unknown MobileSync route", {
+    code: "SYNC_REQUEST_INVALID",
+    stage: requestStage(req),
+  }));
+  router.use((error, req, res, next) => {
+    if (res.headersSent) return next(error);
+    const status = Number.isInteger(error?.status) && error.status >= 400 && error.status <= 599
+      ? error.status
+      : 500;
+    const tooLarge = status === 413 || error?.type === "entity.too.large";
+    const invalidJson = status === 400 || error?.type === "entity.parse.failed";
+    return sendHttpError(
+      res,
+      tooLarge ? 413 : invalidJson ? 400 : status,
+      tooLarge
+        ? "Request body exceeds the endpoint byte budget"
+        : invalidJson
+          ? "Request body is not valid JSON"
+          : error,
+      {
+        code: tooLarge
+          ? "SYNC_BUDGET_EXCEEDED"
+          : invalidJson
+            ? "SYNC_REQUEST_INVALID"
+            : "SYNC_ATTEMPT_FAILED",
+        stage: requestStage(req),
+      },
+    );
   });
 
   app.use("/api/mobile-sync", router);

--- a/VCPDistributedServer/Plugin/VCPMobileSync/transport/websocket.js
+++ b/VCPDistributedServer/Plugin/VCPMobileSync/transport/websocket.js
@@ -4,6 +4,12 @@
 
 const { getLogger, setWss } = require("../core/logger");
 const { parseJsonWithoutDuplicateKeys } = require("../protocol");
+const {
+  createSyncError,
+  createSyncErrorFrame,
+  parseSyncError,
+  withSyncErrorContext,
+} = require("../error-contract");
 const { TextDecoder } = require("node:util");
 
 let WebSocket;
@@ -15,6 +21,51 @@ try {
 
 let wss = null;
 let wsServerPort = null;
+
+function errorStageForPayload(payload, versionAccepted, currentStage) {
+  if (!versionAccepted || payload?.type === "VERSION_CHECK") return "handshake";
+  if (payload?.type === "SYNC_ERROR") return "shutdown";
+  if (payload?.type === "SYNC_MESSAGE_DIFF_BATCH") return "messages";
+  if (payload?.type === "GET_MESSAGE_MANIFEST") return "messages";
+  if (
+    payload?.type === "SYNC_TOPIC_HASH_BATCH" ||
+    payload?.type === "SYNC_TOPIC_HASH_BATCH_V2"
+  ) {
+    return "topic_validation";
+  }
+  if (payload?.type === "SYNC_MANIFEST") {
+    return ["topic", "agent_topic", "group_topic"].includes(payload.dataType)
+      ? "topic_metadata"
+      : "owner_metadata";
+  }
+  if (payload?.type === "SYNC_ENTITY_UPDATE" || payload?.type === "SYNC_ENTITY_DELETE") {
+    if (payload.dataType === "message") return "messages";
+    return ["topic", "agent_topic", "group_topic"].includes(payload.dataType)
+      ? "topic_metadata"
+      : "owner_metadata";
+  }
+  if (
+    (payload?.type === "PHASE_START" || payload?.type === "PHASE_COMPLETED") &&
+    [
+      "owner_metadata",
+      "topic_metadata",
+      "topic_validation",
+      "messages",
+      "finalize",
+    ].includes(payload.phase)
+  ) {
+    if (
+      payload.type === "PHASE_COMPLETED" &&
+      Number.isSafeInteger(payload.sessionId) &&
+      Number.isSafeInteger(payload.attemptId) &&
+      typeof payload.nonce === "string"
+    ) {
+      return "finalize";
+    }
+    return payload.phase;
+  }
+  return currentStage;
+}
 
 /**
  * 启动 WebSocket 服务器
@@ -99,48 +150,56 @@ function startWsServer({ port, syncToken, onMessage }) {
     );
 
     let versionAccepted = false;
+    let currentStage = "handshake";
     let terminated = false;
     let messageChain = Promise.resolve();
     const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
     const handleMessage = async (message) => {
       if (terminated) return;
+      let payload = null;
       try {
         const text =
           typeof message === "string" ? message : utf8Decoder.decode(message);
-        const payload = parseJsonWithoutDuplicateKeys(text);
+        payload = parseJsonWithoutDuplicateKeys(text);
         if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-          const error = new Error("WebSocket payload must be an object");
-          error.code = "PROTOCOL_INVALID";
-          throw error;
+          throw createSyncError(
+            "PROTOCOL_INVALID",
+            "WebSocket payload must be an object",
+            { stage: "handshake" },
+          );
         }
         if (!versionAccepted && payload.type !== "VERSION_CHECK") {
-          const error = new Error("VERSION_CHECK must be the first business frame");
-          error.code = "VERSION_CHECK_REQUIRED";
-          throw error;
+          throw createSyncError(
+            "VERSION_CHECK_REQUIRED",
+            "VERSION_CHECK must be the first business frame",
+          );
         }
         if (versionAccepted && payload.type === "VERSION_CHECK") {
-          const error = new Error("VERSION_CHECK may only appear once per connection");
-          error.code = "VERSION_CHECK_DUPLICATE";
-          throw error;
+          throw createSyncError(
+            "VERSION_CHECK_DUPLICATE",
+            "VERSION_CHECK may only appear once per connection",
+          );
         }
         if (payload.type === "SYNC_ERROR") {
-          const code = payload.error?.code;
-          const message = payload.error?.message;
-          const error = new Error(
-            typeof message === "string" && message.length > 0
-              ? message
-              : "Mobile reported a sync failure",
-          );
-          error.code =
-            typeof code === "string" && code.length > 0
-              ? code
-              : "MOBILE_SYNC_ERROR";
-          throw error;
+          throw withSyncErrorContext(parseSyncError(payload.error), {
+            code: "MOBILE_SYNC_ERROR",
+            origin: "mobile_sync",
+            stage: "shutdown",
+          });
         }
 
         const response = await onMessage(payload);
-        if (payload.type === "VERSION_CHECK") versionAccepted = true;
+        if (payload.type === "VERSION_CHECK") {
+          versionAccepted = true;
+          currentStage = "startup";
+        } else {
+          currentStage = errorStageForPayload(
+            payload,
+            versionAccepted,
+            currentStage,
+          );
+        }
         if (response) {
           const responseText = JSON.stringify(response);
           const logger = getLogger();
@@ -159,15 +218,20 @@ function startWsServer({ port, syncToken, onMessage }) {
       } catch (e) {
         terminated = true;
         const logger = getLogger();
-        logger.logOperation("websocket", "message_handler", "error", "error", e.message);
+        const error = withSyncErrorContext(e, {
+          code: "SYNC_ATTEMPT_FAILED",
+          origin: "desktop_plugin",
+          stage: errorStageForPayload(payload, versionAccepted, currentStage),
+        });
+        logger.logOperation(
+          "websocket",
+          "message_handler",
+          error.code,
+          "error",
+          `origin=${error.origin} stage=${error.stage} ${error.message}`,
+        );
         if (ws.readyState === WebSocket.OPEN) {
-          const frame = JSON.stringify({
-            type: "SYNC_ERROR",
-            error: {
-              code: e.code || "SYNC_ATTEMPT_FAILED",
-              message: e.message || "Desktop sync failed",
-            },
-          });
+          const frame = JSON.stringify(createSyncErrorFrame(error));
           try {
             await new Promise((resolve) => ws.send(frame, resolve));
           } catch {}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "node rust_chat_data_service/build-runtime.js",
     "pack": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder",
-    "test:mobile-sync": "node --test tests/mobile-sync-protocol.test.js tests/mobile-sync-central-adapter.test.js tests/mobile-sync-canonical.test.js tests/mobile-sync-failure-contract.test.js tests/mobile-sync-streaming.test.js tests/mobile-sync-package.test.js",
+    "test:mobile-sync": "node --test tests/mobile-sync-protocol.test.js tests/mobile-sync-error-contract.test.js tests/mobile-sync-central-adapter.test.js tests/mobile-sync-canonical.test.js tests/mobile-sync-failure-contract.test.js tests/mobile-sync-streaming.test.js tests/mobile-sync-package.test.js",
     "test:cds": "cargo test --manifest-path rust_chat_data_service/Cargo.toml --locked",
     "check:cds:fmt": "cargo fmt --manifest-path rust_chat_data_service/Cargo.toml -- --check",
     "check:cds:clippy": "cargo clippy --manifest-path rust_chat_data_service/Cargo.toml --locked --all-targets -- -D warnings"

--- a/rust_chat_data_service/src/sync_wire.rs
+++ b/rust_chat_data_service/src/sync_wire.rs
@@ -318,15 +318,15 @@ mod tests {
     use super::{canonicalize_message, message_fingerprint, normalize_integer, WireWarnings};
 
     const GOLDEN: &[u8] = include_bytes!(
-        "../../VCPDistributedServer/Plugin/VCPMobileSync/fixtures/protocol_1_1_golden.json"
+        "../../VCPDistributedServer/Plugin/VCPMobileSync/fixtures/protocol_1_2_golden.json"
     );
-    const GOLDEN_SHA256: &str = "3b5f56d0731c1babede9aba001d9664117fae6bbc8d97cae56882f12a48e8e60";
+    const GOLDEN_SHA256: &str = "7226118ea55766f952575032efc8cfff883a19c9d196f637ac267cb8795fcef8";
 
     #[test]
-    fn protocol_1_1_golden_bundle_matches_mobile() {
+    fn protocol_1_2_golden_bundle_matches_mobile() {
         assert_eq!(hex::encode(Sha256::digest(GOLDEN)), GOLDEN_SHA256);
         let bundle: serde_json::Value = serde_json::from_slice(GOLDEN).expect("golden JSON");
-        assert_eq!(bundle["wireProtocol"], "1.1");
+        assert_eq!(bundle["wireProtocol"], "1.2");
 
         for fixture in bundle["validFrames"].as_array().expect("valid frames") {
             let input = &fixture["input"];

--- a/tests/mobile-sync-canonical.test.js
+++ b/tests/mobile-sync-canonical.test.js
@@ -17,12 +17,12 @@ const FIXTURE_PATH = path.join(
   "Plugin",
   "VCPMobileSync",
   "fixtures",
-  "protocol_1_1_golden.json",
+  "protocol_1_2_golden.json",
 );
 const EXPECTED_FIXTURE_SHA256 =
-  "3b5f56d0731c1babede9aba001d9664117fae6bbc8d97cae56882f12a48e8e60";
+  "7226118ea55766f952575032efc8cfff883a19c9d196f637ac267cb8795fcef8";
 
-test("协议 1.1 golden bundle 与 Mobile 字节一致", () => {
+test("协议 1.2 golden bundle 与 Mobile 字节一致", () => {
   const bytes = fs.readFileSync(FIXTURE_PATH);
   assert.equal(
     crypto.createHash("sha256").update(bytes).digest("hex"),
@@ -32,7 +32,7 @@ test("协议 1.1 golden bundle 与 Mobile 字节一致", () => {
 
 test("canonicalizer 与 Mobile golden 输出和消息指纹一致", () => {
   const bundle = JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf8"));
-  assert.equal(bundle.wireProtocol, "1.1");
+  assert.equal(bundle.wireProtocol, "1.2");
 
   for (const fixture of bundle.validFrames) {
     const result = canonicalizeTopicFrame(fixture.input, {
@@ -77,5 +77,49 @@ test("canonicalizer 保留完整复合 Owner 身份", () => {
         messages: [],
       }),
     /requires ownerType and ownerId together/,
+  );
+});
+
+test("canonicalizer 只接受 Wire 1.2 结构化 topic 错误", () => {
+  const error = {
+    code: "TOPIC_NOT_FOUND",
+    origin: "desktop_plugin",
+    stage: "messages",
+    kind: "data",
+    retry: "manual",
+    message: "topic not found",
+    failedTopicIds: ["topic-missing"],
+  };
+  assert.deepEqual(
+    canonicalizeTopicFrame({
+      topicId: "topic-missing",
+      ownerType: "agent",
+      ownerId: "agent-a",
+      messages: [],
+      _error: error,
+    }).frame,
+    {
+      topicId: "topic-missing",
+      ownerType: "agent",
+      ownerId: "agent-a",
+      messages: [],
+      _error: error,
+    },
+  );
+  assert.throws(
+    () => canonicalizeTopicFrame({
+      topicId: "topic-missing",
+      messages: [],
+      _error: "legacy string error",
+    }),
+    /error must be an object/,
+  );
+  assert.throws(
+    () => canonicalizeTopicFrame({
+      topicId: "topic-a",
+      messages: [{ id: "message-a" }],
+      _error: error,
+    }),
+    /must not contain live messages/,
   );
 });

--- a/tests/mobile-sync-central-adapter.test.js
+++ b/tests/mobile-sync-central-adapter.test.js
@@ -12,13 +12,14 @@ function createClient(overrides = {}) {
     reconcile: async () => ({ stats: {} }),
     syncManifest: async (request) => ({ type: "SYNC_DIFF_RESULTS", data: [], ...request }),
     syncMessageManifest: async () => ({
+      type: "MESSAGE_MANIFEST_RESULTS",
       topicId: "topic_1",
       ownerType: "agent",
       ownerId: "agent_1",
       messages: [
         {
           msgId: "msg_1",
-          contentHash: "hash_1",
+          contentHash: "a".repeat(64),
           updatedAt: 100,
           deletedAt: null,
         },
@@ -52,7 +53,7 @@ test("中央适配器保持旧消息 Manifest 字段格式", async () => {
   assert.deepEqual(result.messages, [
     {
       msg_id: "msg_1",
-      content_hash: "hash_1",
+      content_hash: "a".repeat(64),
       updated_at: 100,
       deleted_at: null,
     },
@@ -167,5 +168,140 @@ test("CDS 不可用时中央适配器显式失败而非静默写旧库", async (
   await assert.rejects(
     () => adapter.handleMessageDiffBatch({ topics: {} }),
     (error) => error.code === "CDS_UNAVAILABLE",
+  );
+});
+
+test("中央适配器保留未知 CDS 根因并补齐来源、阶段与 Topic", async () => {
+  const root = Object.assign(new Error("new CDS failure"), {
+    code: "UPSTREAM_EXTENSION_FAILED",
+  });
+  const adapter = createCentralSyncAdapter({
+    client: createClient({
+      syncMessageDiff: async () => {
+        throw root;
+      },
+    }),
+  });
+
+  await assert.rejects(
+    () => adapter.handleMessageDiffBatch({ topics: { "topic-a": {} } }),
+    (error) => {
+      assert.equal(error.code, "UPSTREAM_EXTENSION_FAILED");
+      assert.equal(error.origin, "desktop_cds");
+      assert.equal(error.stage, "messages");
+      assert.equal(error.kind, "internal");
+      assert.equal(error.retry, "manual");
+      assert.deepEqual(error.failedTopicIds, ["topic-a"]);
+      return true;
+    },
+  );
+});
+
+test("中央客户端通用 TIMEOUT 不会被误归为内部错误", async () => {
+  const adapter = createCentralSyncAdapter({
+    client: createClient({
+      syncTopicDiff: async () => {
+        throw Object.assign(new Error("CDS timed out"), { code: "TIMEOUT" });
+      },
+    }),
+  });
+
+  await assert.rejects(
+    () => adapter.handleTopicHashBatch({ hashes: {}, topics: [] }),
+    (error) => {
+      assert.equal(error.code, "TIMEOUT");
+      assert.equal(error.origin, "desktop_cds");
+      assert.equal(error.stage, "topic_validation");
+      assert.equal(error.kind, "connection");
+      return true;
+    },
+  );
+});
+
+test("CDS internal protocol mismatch 不会冒充 Mobile wire mismatch", async () => {
+  const adapter = createCentralSyncAdapter({
+    client: createClient({
+      syncTopicDiff: async () => {
+        throw Object.assign(new Error("CDS protocol 2 mismatch"), {
+          code: "PROTOCOL_MISMATCH",
+        });
+      },
+    }),
+  });
+
+  await assert.rejects(
+    () => adapter.handleTopicHashBatch({ hashes: {}, topics: [] }),
+    (error) => {
+      assert.equal(error.code, "CDS_PROTOCOL_MISMATCH");
+      assert.equal(error.origin, "desktop_cds");
+      assert.equal(error.stage, "topic_validation");
+      assert.equal(error.kind, "compatibility");
+      return true;
+    },
+  );
+});
+
+test("中央 Phase 3 的二字段错误会在插件边界补全而不改写根因", async () => {
+  const adapter = createCentralSyncAdapter({
+    client: createClient({
+      syncMessageDiff: async () => ({
+        type: "SYNC_DIFF_RESULTS_BATCH",
+        results: {
+          "topic-a": {
+            ok: false,
+            error: {
+              code: "TOPIC_HASH_FAILED",
+              message: "failed to read topic hash",
+            },
+          },
+        },
+      }),
+    }),
+  });
+
+  const response = await adapter.handleMessageDiffBatch({
+    topics: { "topic-a": {} },
+  });
+  assert.deepEqual(response.results["topic-a"], {
+    ok: false,
+    error: {
+      code: "TOPIC_HASH_FAILED",
+      origin: "desktop_cds",
+      stage: "messages",
+      kind: "storage",
+      retry: "manual",
+      message: "failed to read topic hash",
+      failedTopicIds: ["topic-a"],
+    },
+  });
+});
+
+test("中央适配器将畸形 CDS Phase 3 成功帧归为上游协议错误", async () => {
+  const adapter = createCentralSyncAdapter({
+    client: createClient({
+      syncMessageDiff: async () => ({
+        type: "SYNC_DIFF_RESULTS_BATCH",
+        results: {
+          "topic-a": {
+            ok: true,
+            toPull: [],
+            toPush: false,
+            error: { code: "INTERNAL_ERROR", message: "contradictory" },
+          },
+        },
+      }),
+    }),
+  });
+
+  await assert.rejects(
+    () => adapter.handleMessageDiffBatch({ topics: { "topic-a": {} } }),
+    (error) => {
+      assert.equal(error.code, "SYNC_PROTOCOL_INVALID");
+      assert.equal(error.origin, "desktop_cds");
+      assert.equal(error.stage, "messages");
+      assert.equal(error.kind, "protocol");
+      assert.deepEqual(error.failedTopicIds, ["topic-a"]);
+      return true;
+    },
   );
 });

--- a/tests/mobile-sync-error-contract.test.js
+++ b/tests/mobile-sync-error-contract.test.js
@@ -1,0 +1,370 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const { once } = require("node:events");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+const express = require("express");
+const WebSocket = require("ws");
+
+const {
+  ERROR_DEFINITIONS,
+  createHttpErrorBody,
+  createStreamErrorFrame,
+  createSyncError,
+  createSyncErrorFrame,
+  normalizeFailureResult,
+  normalizeSyncError,
+  parseSyncError,
+  withSyncErrorContext,
+} = require("../VCPDistributedServer/Plugin/VCPMobileSync/error-contract");
+const {
+  startWsServer,
+} = require("../VCPDistributedServer/Plugin/VCPMobileSync/transport/websocket");
+const {
+  registerRoutes,
+} = require("../VCPDistributedServer/Plugin/VCPMobileSync/transport/routes");
+
+const fixturePath = path.join(
+  __dirname,
+  "..",
+  "VCPDistributedServer",
+  "Plugin",
+  "VCPMobileSync",
+  "fixtures",
+  "error_contract_1_2_golden.json",
+);
+const fixtureBytes = fs.readFileSync(fixturePath);
+const fixture = JSON.parse(fixtureBytes);
+
+function createWsFrameReader(socket) {
+  const frames = [];
+  let wake = null;
+  socket.on("message", (bytes) => {
+    frames.push(JSON.parse(String(bytes)));
+    if (wake) {
+      const resolve = wake;
+      wake = null;
+      resolve();
+    }
+  });
+  return async (type) => {
+    for (;;) {
+      const index = frames.findIndex((frame) => frame.type === type);
+      if (index >= 0) return frames.splice(index, 1)[0];
+      await new Promise((resolve) => {
+        wake = resolve;
+      });
+    }
+  };
+}
+
+test("Wire 1.2 golden errors are strict and stable", () => {
+  assert.equal(fixture.wireProtocol, "1.2");
+  assert.equal(fixture.pluginVersion, "1.2.0");
+  assert.equal(
+    crypto.createHash("sha256").update(fixtureBytes).digest("hex"),
+    "434279b33a86a2206c1e4f47caccb4e72f05b2f9d48e093af95d5ebae6947adb",
+  );
+  for (const entry of fixture.validErrors) {
+    assert.deepEqual(parseSyncError(entry.error), entry.error);
+  }
+  for (const entry of fixture.invalidErrors) {
+    assert.throws(() => parseSyncError(entry.error), /error/);
+  }
+  for (const [code, [kind, retry]] of Object.entries(fixture.registeredSemantics)) {
+    assert.deepEqual(
+      [ERROR_DEFINITIONS[code]?.kind, ERROR_DEFINITIONS[code]?.retry],
+      [kind, retry],
+      `registered semantics for ${code}`,
+    );
+  }
+});
+
+test("WebSocket, HTTP and NDJSON reuse the same error object", () => {
+  const error = createSyncError("PLUGIN_VERSION_MISMATCH", "wrong package");
+  const expected = normalizeSyncError(error);
+  assert.deepEqual(createSyncErrorFrame(error), {
+    type: "SYNC_ERROR",
+    error: expected,
+  });
+  assert.deepEqual(createHttpErrorBody(error), { error: expected });
+  assert.deepEqual(createStreamErrorFrame(error), {
+    _stream_error: expected,
+  });
+  assert.deepEqual(
+    normalizeFailureResult(
+      { topicId: "topic-a", success: false, error: "query failed" },
+      {
+        code: "SYNC_DB_QUERY_FAILED",
+        stage: "messages",
+        failedTopicIds: ["topic-a"],
+      },
+    ),
+    {
+      topicId: "topic-a",
+      success: false,
+      error: {
+        code: "SYNC_DB_QUERY_FAILED",
+        origin: "desktop_plugin",
+        stage: "messages",
+        kind: "storage",
+        retry: "manual",
+        message: "query failed",
+        failedTopicIds: ["topic-a"],
+      },
+    },
+  );
+});
+
+test("catch boundaries preserve an existing root code and narrow its stage", () => {
+  const root = Object.assign(new Error("owner conflict"), {
+    code: "SYNC_OWNER_CONFLICT",
+    origin: "desktop_plugin",
+    stage: "topic_metadata",
+  });
+  const contextual = withSyncErrorContext(root, {
+    code: "SYNC_DB_QUERY_FAILED",
+    origin: "desktop_cds",
+    stage: "topic_validation",
+  });
+  assert.equal(contextual.code, "SYNC_OWNER_CONFLICT");
+  assert.equal(contextual.origin, "desktop_cds");
+  assert.equal(contextual.stage, "topic_validation");
+  assert.equal(contextual.kind, "data");
+  assert.deepEqual(
+    normalizeSyncError(
+      {
+        code: "SYNC_OWNER_CONFLICT",
+        message: "root",
+        failedTopicIds: [],
+      },
+      { failedTopicIds: ["topic-a"] },
+    ).failedTopicIds,
+    ["topic-a"],
+  );
+});
+
+test("exact registry keeps device, version, lifecycle and storage layers separate", () => {
+  const cases = [
+    ["POWER_SAVE_MODE", "mobile_native", "preflight", "device"],
+    ["VERSION_ACK_INVALID", "mobile_sync", "handshake", "protocol"],
+    ["SYNC_VERSION_INCOMPATIBLE", "desktop_plugin", "handshake", "compatibility"],
+    ["SYNC_PHASE_STALLED", "mobile_sync", "topic_metadata", "internal"],
+    ["SYNC_DB_DRAIN_FAILED", "mobile_sync", "finalize", "storage"],
+  ];
+
+  for (const [code, origin, stage, kind] of cases) {
+    assert.deepEqual(
+      normalizeSyncError({ code, message: "diagnostic" }),
+      {
+        code,
+        origin,
+        stage,
+        kind,
+        retry: code === "POWER_SAVE_MODE" || code.includes("VERSION_")
+          ? "after_user_action"
+          : "manual",
+        message: "diagnostic",
+        failedTopicIds: [],
+      },
+    );
+  }
+});
+
+test("timeout registry preserves the phase that actually timed out", () => {
+  const cases = [
+    ["VERSION_CHECK_TIMEOUT", "handshake"],
+    ["MANIFEST_RESPONSE_TIMEOUT", "owner_metadata"],
+    ["TOPIC_HASH_RESPONSE_TIMEOUT", "topic_validation"],
+    ["PHASE3_RESPONSE_TIMEOUT", "messages"],
+    ["FINAL_ACK_TIMEOUT", "finalize"],
+  ];
+
+  for (const [code, stage] of cases) {
+    const error = normalizeSyncError({ code, message: "timeout" });
+    assert.equal(error.kind, "connection");
+    assert.equal(error.stage, stage);
+  }
+});
+
+test("unknown stable codes survive while invalid codes use the boundary fallback", () => {
+  assert.equal(
+    normalizeSyncError(
+      { code: "EXTENSIONFAILED", message: "unknown" },
+      { stage: "finalize" },
+    ).code,
+    "EXTENSIONFAILED",
+  );
+  assert.equal(
+    normalizeSyncError(
+      { code: "UPSTREAM_EXTENSION_FAILED", message: "unknown" },
+      { stage: "finalize" },
+    ).code,
+    "UPSTREAM_EXTENSION_FAILED",
+  );
+  assert.equal(
+    normalizeSyncError(
+      { code: "desktop raw code", message: "invalid" },
+      { code: "SYNC_STREAM_FAILED", stage: "messages" },
+    ).code,
+    "SYNC_STREAM_FAILED",
+  );
+  assert.equal(
+    normalizeSyncError(
+      Object.assign(new Error("file missing"), { code: "ENOENT" }),
+      { code: "SYNC_ENTITY_READ_FAILED", stage: "owner_metadata" },
+    ).code,
+    "SYNC_ENTITY_READ_FAILED",
+  );
+  const redacted = normalizeSyncError({
+    code: "UPSTREAM_EXTENSION_FAILED",
+    message: "Bearer desktop-secret token=second-secret C:\\Users\\Nova\\AppData\\history.json",
+  }).message;
+  assert.equal(redacted.includes("desktop-secret"), false);
+  assert.equal(redacted.includes("second-secret"), false);
+  assert.equal(redacted.includes("Nova"), false);
+});
+
+test("known codes cannot claim a different category or retry policy", () => {
+  assert.throws(
+    () => parseSyncError({
+      code: "POWER_SAVE_MODE",
+      origin: "mobile_native",
+      stage: "preflight",
+      kind: "compatibility",
+      retry: "after_user_action",
+      message: "wrong category",
+      failedTopicIds: [],
+    }),
+    /conflicts with its registered code/,
+  );
+});
+
+test("string bounds count Unicode code points consistently with Rust", () => {
+  const valid = {
+    code: "UPSTREAM_EXTENSION_FAILED",
+    origin: "desktop_plugin",
+    stage: "messages",
+    kind: "internal",
+    retry: "manual",
+    message: "🙂".repeat(1024),
+    failedTopicIds: ["🙂".repeat(512)],
+  };
+  assert.deepEqual(parseSyncError(valid), valid);
+  assert.throws(
+    () => parseSyncError({ ...valid, message: "🙂".repeat(1025) }),
+    /message/,
+  );
+});
+
+test("WebSocket transport emits the complete root-cause error envelope", async (t) => {
+  const server = startWsServer({
+    port: 0,
+    syncToken: "wire-1.2-test-token",
+    onMessage: async (payload) => {
+      if (payload.type === "VERSION_CHECK") {
+        return {
+          type: "VERSION_ACK",
+          pluginVersion: "1.2.0",
+          protocolVersion: "1.2",
+        };
+      }
+      throw Object.assign(new Error("owner identity conflict"), {
+        code: "SYNC_OWNER_CONFLICT",
+      });
+    },
+  });
+  t.after(() => server.close());
+  if (!server.address()) await once(server, "listening");
+  const port = server.address().port;
+  const socket = new WebSocket(
+    `ws://127.0.0.1:${port}/ws-sync?token=wire-1.2-test-token`,
+  );
+  const nextFrame = createWsFrameReader(socket);
+  t.after(() => socket.terminate());
+  await once(socket, "open");
+
+  socket.send(JSON.stringify({
+    type: "VERSION_CHECK",
+    mobileVersion: "1.1.4",
+    protocolVersion: "1.2",
+  }));
+  assert.equal((await nextFrame("VERSION_ACK")).type, "VERSION_ACK");
+
+  socket.send(JSON.stringify({ type: "SYNC_TOPIC_HASH_BATCH", hashes: {} }));
+  assert.deepEqual(await nextFrame("SYNC_ERROR"), {
+    type: "SYNC_ERROR",
+    error: {
+      code: "SYNC_OWNER_CONFLICT",
+      origin: "desktop_plugin",
+      stage: "topic_validation",
+      kind: "data",
+      retry: "manual",
+      message: "owner identity conflict",
+      failedTopicIds: [],
+    },
+  });
+});
+
+test("HTTP transport returns the same structured error contract", async (t) => {
+  const app = express();
+  registerRoutes(app, {
+    syncToken: "wire-1.2-http-token",
+    appDataPath: "/unused-in-validation-test",
+  });
+  const server = app.listen(0, "127.0.0.1");
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  await once(server, "listening");
+  const port = server.address().port;
+
+  const response = await fetch(
+    `http://127.0.0.1:${port}/api/mobile-sync/download-entities`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-sync-token": "wire-1.2-http-token",
+      },
+      body: JSON.stringify({ requests: "not-an-array" }),
+    },
+  );
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: {
+      code: "SYNC_REQUEST_INVALID",
+      origin: "desktop_plugin",
+      stage: "owner_metadata",
+      kind: "protocol",
+      retry: "after_user_action",
+      message: "requests must be an array of at most 10000 items",
+      failedTopicIds: [],
+    },
+  });
+
+  const malformed = await fetch(
+    `http://127.0.0.1:${port}/api/mobile-sync/download-entities`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-sync-token": "wire-1.2-http-token",
+      },
+      body: "{not-json",
+    },
+  );
+  assert.equal(malformed.status, 400);
+  assert.deepEqual(await malformed.json(), {
+    error: {
+      code: "SYNC_REQUEST_INVALID",
+      origin: "desktop_plugin",
+      stage: "owner_metadata",
+      kind: "protocol",
+      retry: "after_user_action",
+      message: "Request body is not valid JSON",
+      failedTopicIds: [],
+    },
+  });
+});

--- a/tests/mobile-sync-error-contract.test.js
+++ b/tests/mobile-sync-error-contract.test.js
@@ -2,12 +2,11 @@
 
 const assert = require("node:assert/strict");
 const crypto = require("node:crypto");
-const { once } = require("node:events");
+const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
+const Module = require("node:module");
 const path = require("node:path");
 const { test } = require("node:test");
-const express = require("express");
-const WebSocket = require("ws");
 
 const {
   ERROR_DEFINITIONS,
@@ -22,10 +21,76 @@ const {
 } = require("../VCPDistributedServer/Plugin/VCPMobileSync/error-contract");
 const {
   startWsServer,
-} = require("../VCPDistributedServer/Plugin/VCPMobileSync/transport/websocket");
-const {
   registerRoutes,
-} = require("../VCPDistributedServer/Plugin/VCPMobileSync/transport/routes");
+} = (() => {
+  class FakeRouter {
+    constructor() {
+      this.layers = [];
+    }
+
+    use(...handlers) {
+      this.layers.push({ method: "USE", path: null, handlers });
+      return this;
+    }
+
+    get(routePath, ...handlers) {
+      this.layers.push({ method: "GET", path: routePath, handlers });
+      return this;
+    }
+
+    post(routePath, ...handlers) {
+      this.layers.push({ method: "POST", path: routePath, handlers });
+      return this;
+    }
+  }
+
+  class FakeWebSocketServer extends EventEmitter {
+    constructor(options) {
+      super();
+      this.options = options;
+      this.clients = new Set();
+    }
+
+    address() {
+      return { address: "127.0.0.1", family: "IPv4", port: this.options.port };
+    }
+
+    close() {
+      this.emit("close");
+    }
+  }
+
+  const fakeExpress = {
+    Router: () => new FakeRouter(),
+    json: () => (_req, _res, next) => next(),
+    raw: () => (_req, _res, next) => next(),
+  };
+  const fakeWebSocket = {
+    OPEN: 1,
+    Server: FakeWebSocketServer,
+  };
+  const originalLoad = Module._load;
+  Module._load = function loadTransportDependency(request, parent, isMain) {
+    if (request === "express") return fakeExpress;
+    if (request === "ws") return fakeWebSocket;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    const websocket = require(
+      "../VCPDistributedServer/Plugin/VCPMobileSync/transport/websocket"
+    );
+    const routes = require(
+      "../VCPDistributedServer/Plugin/VCPMobileSync/transport/routes"
+    );
+    return {
+      startWsServer: websocket.startWsServer,
+      registerRoutes: routes.registerRoutes,
+    };
+  } finally {
+    Module._load = originalLoad;
+  }
+})();
 
 const fixturePath = path.join(
   __dirname,
@@ -42,7 +107,7 @@ const fixture = JSON.parse(fixtureBytes);
 function createWsFrameReader(socket) {
   const frames = [];
   let wake = null;
-  socket.on("message", (bytes) => {
+  socket.on("sent", (bytes) => {
     frames.push(JSON.parse(String(bytes)));
     if (wake) {
       const resolve = wake;
@@ -59,6 +124,51 @@ function createWsFrameReader(socket) {
       });
     }
   };
+}
+
+class FakeWebSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.readyState = 1;
+  }
+
+  send(bytes, callback) {
+    this.emit("sent", bytes);
+    if (callback) callback();
+  }
+
+  close(code = 1000, reason = "") {
+    this.readyState = 3;
+    this.emit("close", code, Buffer.from(reason));
+  }
+
+  terminate() {
+    if (this.readyState !== 3) this.close(1006, "terminated");
+  }
+}
+
+class FakeHttpResponse extends EventEmitter {
+  constructor() {
+    super();
+    this.statusCode = 200;
+    this.headersSent = false;
+    this.body = undefined;
+  }
+
+  header() {
+    return this;
+  }
+
+  status(statusCode) {
+    this.statusCode = statusCode;
+    return this;
+  }
+
+  json(body) {
+    this.body = body;
+    this.headersSent = true;
+    return this;
+  }
 }
 
 test("Wire 1.2 golden errors are strict and stable", () => {
@@ -278,23 +388,26 @@ test("WebSocket transport emits the complete root-cause error envelope", async (
     },
   });
   t.after(() => server.close());
-  if (!server.address()) await once(server, "listening");
-  const port = server.address().port;
-  const socket = new WebSocket(
-    `ws://127.0.0.1:${port}/ws-sync?token=wire-1.2-test-token`,
-  );
+  const socket = new FakeWebSocket();
   const nextFrame = createWsFrameReader(socket);
   t.after(() => socket.terminate());
-  await once(socket, "open");
+  server.emit("connection", socket, {
+    url: "/ws-sync?token=wire-1.2-test-token",
+    headers: { host: "127.0.0.1" },
+    socket: { remoteAddress: "127.0.0.1" },
+  });
 
-  socket.send(JSON.stringify({
+  socket.emit("message", JSON.stringify({
     type: "VERSION_CHECK",
     mobileVersion: "1.1.4",
     protocolVersion: "1.2",
   }));
   assert.equal((await nextFrame("VERSION_ACK")).type, "VERSION_ACK");
 
-  socket.send(JSON.stringify({ type: "SYNC_TOPIC_HASH_BATCH", hashes: {} }));
+  socket.emit(
+    "message",
+    JSON.stringify({ type: "SYNC_TOPIC_HASH_BATCH", hashes: {} }),
+  );
   assert.deepEqual(await nextFrame("SYNC_ERROR"), {
     type: "SYNC_ERROR",
     error: {
@@ -309,30 +422,28 @@ test("WebSocket transport emits the complete root-cause error envelope", async (
   });
 });
 
-test("HTTP transport returns the same structured error contract", async (t) => {
-  const app = express();
+test("HTTP route handlers return the same structured error contract", async () => {
+  const app = {
+    use(mountPath, router) {
+      this.mountPath = mountPath;
+      this.router = router;
+    },
+  };
   registerRoutes(app, {
     syncToken: "wire-1.2-http-token",
     appDataPath: "/unused-in-validation-test",
   });
-  const server = app.listen(0, "127.0.0.1");
-  t.after(() => new Promise((resolve) => server.close(resolve)));
-  await once(server, "listening");
-  const port = server.address().port;
-
-  const response = await fetch(
-    `http://127.0.0.1:${port}/api/mobile-sync/download-entities`,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-sync-token": "wire-1.2-http-token",
-      },
-      body: JSON.stringify({ requests: "not-an-array" }),
-    },
+  assert.equal(app.mountPath, "/api/mobile-sync");
+  const route = app.router.layers.find(
+    (layer) => layer.method === "POST" && layer.path === "/download-entities",
   );
-  assert.equal(response.status, 400);
-  assert.deepEqual(await response.json(), {
+  const response = new FakeHttpResponse();
+  await route.handlers.at(-1)(
+    { body: { requests: "not-an-array" }, query: {}, path: route.path },
+    response,
+  );
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
     error: {
       code: "SYNC_REQUEST_INVALID",
       origin: "desktop_plugin",
@@ -344,19 +455,23 @@ test("HTTP transport returns the same structured error contract", async (t) => {
     },
   });
 
-  const malformed = await fetch(
-    `http://127.0.0.1:${port}/api/mobile-sync/download-entities`,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-sync-token": "wire-1.2-http-token",
-      },
-      body: "{not-json",
+  const parserErrorHandler = app.router.layers.find(
+    (layer) => layer.method === "USE" && layer.handlers[0].length === 4,
+  );
+  const malformed = new FakeHttpResponse();
+  parserErrorHandler.handlers[0](
+    Object.assign(new SyntaxError("invalid JSON"), {
+      status: 400,
+      type: "entity.parse.failed",
+    }),
+    { body: {}, query: {}, path: route.path },
+    malformed,
+    (error) => {
+      throw error;
     },
   );
-  assert.equal(malformed.status, 400);
-  assert.deepEqual(await malformed.json(), {
+  assert.equal(malformed.statusCode, 400);
+  assert.deepEqual(malformed.body, {
     error: {
       code: "SYNC_REQUEST_INVALID",
       origin: "desktop_plugin",

--- a/tests/mobile-sync-failure-contract.test.js
+++ b/tests/mobile-sync-failure-contract.test.js
@@ -148,7 +148,12 @@ test("Phase 3 decision 只返回严格判别联合且不在 diff 中执行删除
     ok: false,
     error: {
       code: "TOPIC_NOT_FOUND",
+      origin: "desktop_plugin",
+      stage: "messages",
+      kind: "data",
+      retry: "manual",
       message: "Topic topic-missing was not found in the desktop index",
+      failedTopicIds: ["topic-missing"],
     },
   });
 });

--- a/tests/mobile-sync-protocol.test.js
+++ b/tests/mobile-sync-protocol.test.js
@@ -10,21 +10,21 @@ const {
   parseJsonWithoutDuplicateKeys,
 } = require("../VCPDistributedServer/Plugin/VCPMobileSync/protocol");
 
-test("VCPMobileSync 协议版本与移动端 1.1.0 对齐", () => {
-  assert.equal(manifest.version, "1.1.0");
+test("VCPMobileSync 错误契约版本与移动端 1.2.0 对齐", () => {
+  assert.equal(manifest.version, "1.2.0");
   assert.deepEqual(
     createVersionAck(
       {
         type: "VERSION_CHECK",
         mobileVersion: "1.1.4",
-        protocolVersion: "1.1",
+        protocolVersion: "1.2",
       },
       manifest.version,
     ),
     {
       type: "VERSION_ACK",
-      pluginVersion: "1.1.0",
-      protocolVersion: "1.1",
+      pluginVersion: "1.2.0",
+      protocolVersion: "1.2",
     },
   );
 });

--- a/tests/mobile-sync-streaming.test.js
+++ b/tests/mobile-sync-streaming.test.js
@@ -165,6 +165,49 @@ test("中央 pull 拒绝 CDS 返回的 Owner 身份漂移", async () => {
   );
 });
 
+test("中央 pull 将 CDS 字符串错误补全为 Wire 1.2 对象", async () => {
+  const adapter = createCentralSyncAdapter({
+    client: {
+      async *syncMessagesPullStream() {
+        yield {
+          topicId: "topic-a",
+          ownerType: "agent",
+          ownerId: "agent-a",
+          messages: [],
+          _error: "CDS message query failed",
+        };
+      },
+    },
+  });
+  const response = new FakeResponse();
+
+  await adapter.downloadMessagesStreamRaw(
+    [{
+      topicId: "topic-a",
+      ownerType: "agent",
+      ownerId: "agent-a",
+      msgIds: [],
+    }],
+    response,
+  );
+
+  assert.deepEqual(response.frames(), [{
+    topicId: "topic-a",
+    ownerType: "agent",
+    ownerId: "agent-a",
+    messages: [],
+    _error: {
+      code: "SYNC_MESSAGE_READ_FAILED",
+      origin: "desktop_cds",
+      stage: "messages",
+      kind: "storage",
+      retry: "manual",
+      message: "CDS message query failed",
+      failedTopicIds: ["topic-a"],
+    },
+  }]);
+});
+
 test("中央 push 逐 topic 投影为 VCPChat 原生附件并回传 needed hash", async (t) => {
   const appDataPath = fs.mkdtempSync(path.join(os.tmpdir(), "vcp-sync-central-"));
   t.after(() => fs.rmSync(appDataPath, { recursive: true, force: true }));
@@ -239,6 +282,54 @@ test("中央 push 逐 topic 投影为 VCPChat 原生附件并回传 needed hash"
     desktopAttachment._fileManagerData.internalPath,
     `file://${path.join(appDataPath, "UserData", "attachments", `${hash}.txt`)}`,
   );
+});
+
+test("中央 push 将 CDS 字符串错误补全为统一 NDJSON 错误对象", async (t) => {
+  const appDataPath = fs.mkdtempSync(path.join(os.tmpdir(), "vcp-sync-error-"));
+  t.after(() => fs.rmSync(appDataPath, { recursive: true, force: true }));
+  const client = {
+    async syncTopicIdentity({ topicId }) {
+      return { topicId, ownerType: "agent", ownerId: "agent-a" };
+    },
+    async syncMessagesPushTopic({ topicId }) {
+      return {
+        topicId,
+        success: false,
+        error: "CDS write transaction failed",
+      };
+    },
+  };
+  const adapter = createCentralSyncAdapter({
+    chatDataService: { client },
+    appDataPath,
+    compatibilityDb: { prepare: () => ({ get: () => undefined }) },
+  });
+  const request = Readable.from([
+    `${JSON.stringify({
+      topicId: "topic-a",
+      ownerType: "agent",
+      ownerId: "agent-a",
+      messages: [],
+    })}\n`,
+  ]);
+  const response = new FakeResponse();
+
+  await adapter.uploadMessagesBatchRaw(request, response);
+
+  assert.deepEqual(response.frames(), [{
+    topicId: "topic-a",
+    success: false,
+    neededAttachmentHashes: [],
+    error: {
+      code: "SYNC_MESSAGE_WRITE_FAILED",
+      origin: "desktop_cds",
+      stage: "messages",
+      kind: "storage",
+      retry: "manual",
+      message: "CDS write transaction failed",
+      failedTopicIds: ["topic-a"],
+    },
+  }]);
 });
 
 test("中央消息删除把稳定 deletedAt 作为逐消息墓碑交给 CDS", async () => {


### PR DESCRIPTION
## 变更摘要

- 将 VCPMobileSync 升级到 1.2.0 / Wire 1.2，统一 WebSocket、HTTP、NDJSON 与 Phase 3 的七字段错误对象。
- 用精确 code 注册表拆分 device、compatibility、protocol、data、storage、internal 等层级，不再根据错误文本猜测。
- 在 central.js 适配真实 VCP-CDS 错误形态：HTTP ErrorDetail、Phase 3 二字段错误、Pull/Push 字符串错误；保留未知稳定根因并校验成功响应结构与集合覆盖。
- 增加双端字节一致 fixture、跨端 code 语义锁定、传输边界及未知错误回归测试。

## 兼容边界

- 这是硬切协议，不与 Wire 1.1 或字符串错误格式混跑。
- 配对 VCPMobile 1.1.4 本地提交：226b79f546abc93d7878b33dc202f1c176bd8c4e。
- 本 PR 修改 MobileSync 插件、共享 fixture、对应 Node 测试与 CDS golden 契约测试；未修改 VCP-CDS 生产逻辑或普通聊天链路。

## 验证

- 本地 npm run test:mobile-sync：54 passed，0 failed，1 optional unpacked package smoke skipped。
- 本地 CDS：cargo test --locked 23 passed；cargo fmt --check 与 cargo clippy --locked --all-targets -- -D warnings 通过。
- PR CI：Node contract tests、CDS Rust gates、Electron unpacked smoke 全部通过。
- error fixture SHA-256：434279b33a86a2206c1e4f47caccb4e72f05b2f9d48e093af95d5ebae6947adb。
- protocol fixture SHA-256：7226118ea55766f952575032efc8cfff883a19c9d196f637ac267cb8795fcef8。
