### PR TITLE
fix(PowerShellExecutor): add where.exe fallback for winget/MSIX PS7 detection

### DIFF
--- a/VCPDistributedServer/Plugin/PowerShellExecutor/PowerShellExecutor.js
+++ b/VCPDistributedServer/Plugin/PowerShellExecutor/PowerShellExecutor.js
@@ -703,11 +703,25 @@ function createNewPtySession() {
 
     if (os.platform() === 'win32') {
         // 优先使用 PowerShell Core (pwsh.exe)，如果不存在则回退到 Windows PowerShell (powershell.exe)
+        // 检测顺序：Program Files 标准路径 → where.exe PATH 查找 → 回退 powershell.exe
         const pwshPath = path.join(process.env.PROGRAMFILES, 'PowerShell', '7', 'pwsh.exe');
         if (fs.existsSync(pwshPath)) {
             shell = pwshPath;
         } else {
-            shell = 'powershell.exe';
+            // 二级回退：winget/MSIX 安装的 PS7 位于 WindowsApps（AppExecution Alias），
+            // fs.existsSync 对此类特殊文件不可靠，直接信任 where.exe 结果。
+            try {
+                const { execSync } = require('child_process');
+                const whereResult = execSync('where.exe pwsh', { windowsHide: true, encoding: 'utf8', timeout: 5000 }).trim();
+                const firstLine = whereResult.split(/\r?\n/)[0].trim();
+                if (firstLine) {
+                    shell = firstLine;
+                } else {
+                    shell = 'powershell.exe';
+                }
+            } catch (e) {
+                shell = 'powershell.exe';
+            }
         }
         args = ['-NoLogo'];
     }


### PR DESCRIPTION
## 改动摘要

前端 PowerShellExecutor 的 `createNewPtySession()` 中，PS7 检测仅硬编码了 `C:\Program Files\PowerShell\7\pwsh.exe` 路径。

通过 winget 安装的 PS7（MSIX/AppX 包）位于 `%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe`，属于 App Execution Alias，不在 Program Files 下。导致已安装 PS7 的用户仍然回退到 PS5.1。

## 修复

在 Program Files 路径检测失败后，增加 `where.exe pwsh` 二级回退：
- `where.exe` 能正确发现 PATH 中的 WindowsApps 别名
- 直接信任 where 返回的路径，不做 `fs.existsSync` 验证（App Execution Alias 的 stat 行为不可靠）
- where 失败（pwsh 不在 PATH）时回退到 `powershell.exe`

## 兼容性

- PS7 未安装时行为与改动前完全一致（回退 powershell.exe）
- 通过 MSI 安装到 Program Files 的 PS7 仍然优先走第一条路径
- 仅影响 `createNewPtySession()` 的 shell 选择逻辑，不影响其他功能

## 测试

- ✅ winget 安装的 PS7 7.6.5（WindowsApps 路径）正确检测，PTY 返回 7.6.5
- ✅ 原有 Program Files 路径检测逻辑保留不变