### PR TITLE
feat(plugin): 接入 Wallpaper Engine 壁纸库作为聊天窗口动态背景

### DIFF
--- a/VCPDistributedServer/Plugin/VCPWEWallpaper/README.md
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaper/README.md
@@ -1,0 +1,78 @@
+# VCPWEWallpaper - Wallpaper Engine 壁纸服务
+
+> pluginType: `service` · 无 config.env · 无 AI 可见命令（纯基础设施）
+> 配套渲染端：`VCPWEWallpaperUI`（renderer 型前端插件）
+
+## 功能
+
+发现本机 Wallpaper Engine 安装，枚举壁纸库存（官方默认 / 我的项目 / 创意工坊订阅），并通过 VCPDistributedServer 主 Express 应用（默认 5974 端口）提供 HTTP 服务：
+
+| 路由 | 说明 |
+|---|---|
+| `GET /vcp-we-wallpaper/inventory` | 壁纸库存 JSON（id/title/type/playable/media/preview/web）。带 `?refresh=1` 则绕过缓存重扫 |
+| `GET /vcp-we-wallpaper/media/<token>` | 视频媒体流，支持 Range（拖进度条） |
+| `GET /vcp-we-wallpaper/preview/<token>` | 预览图 |
+| `GET /vcp-we-wallpaper/web/<token>/*` | **web 类型壁纸的目录子树托管**，入口 HTML 自动注入 WE API 垫片 |
+
+- **类型边界**：Video（mp4 等）与 Web（HTML）可动态呈现；Scene（WE 原生 3D，内容封在私有 `scene.pkg` 里）与 Application 无法在浏览器渲染，渲染端会退化为静态预览图。
+- **安全模型**：
+  - `media` / `preview`：token = base64url(绝对路径)，**逐文件白名单**，仅 inventory 枚举过的文件可被服务。
+  - `web`：静态站点的相对引用无法靠单文件白名单满足，因此收敛为**逐目录白名单 + 路径归一化校验**——token 只能是 inventory 枚举出的 web 壁纸目录；归一化后必须仍在该目录内（否则 403）；`lstat` 只服务普通文件，目录与符号链接一律拒绝。
+  - 未注册 token 一律 404，不暴露任意文件系统。
+- **缓存**：inventory 结果缓存 5 分钟（LRU），巨型库存重复扫描不阻塞事件循环。前端壁纸库弹窗的「重新扫描」按钮以 `?refresh=1` 强制失效——主人在 Steam 新订阅壁纸后不该被迫等一个 TTL 或重启服务器。
+- **开销实测**（136 个创意工坊壁纸）：WE 定位 58 ms（进程内仅首次）、目录枚举 26 ms（冷 fs 缓存）/ 19 ms（暖），堆增量 0.70 MB，其中 `project.json` 属性合计 0.11 MB。`registerRoutes` 只挂路由不做扫描，首次扫描发生在前端请求 inventory 时，因此不拖慢 VCPChat 启动。
+- **WE 定位**：Windows 注册表 `HKCU\Software\Valve\Steam` -> `libraryfolders.vdf` 解析 -> 多盘 SteamLibrary 探针，非默认安装路径可用。
+
+## WE API 垫片（`lib/we-api-shim.js`）
+
+web 类型壁纸在 Wallpaper Engine 里运行时，`wallpaper32.exe` 会向页面注入一组私有全局函数。浏览器里这些全是 `undefined`，壁纸脚本直接调用会抛 `TypeError` 导致整页白屏。垫片在入口 HTML 的 `<head>` 之后注入，早于壁纸自身脚本执行：
+
+| WE API | 垫片行为 |
+|---|---|
+| `wallpaperPropertyListener` | 用 `Object.defineProperty` setter 拦截赋值时机，壁纸刚挂上监听器就回喂 `project.json` 里的 `general.properties`（无需猜时序） |
+| `wallpaperRegisterAudioListener` | 128 段全零频谱，15Hz 空转（不喂会让部分壁纸卡在等待态） |
+| `wallpaperRegisterMedia*Listener` | 空实现，壁纸走「无播放」分支 |
+
+注入的属性 JSON 会把 `</` 转义成 `<\/`，防止壁纸属性文本里的 `</script>` 提前闭合注入点。
+
+前端侧配套：iframe 在窗口不可见时会被卸载（`removeAttribute('src')`），壁纸的 `requestAnimationFrame` 随文档一起停；回到前台重新挂回同一 URL。因此本插件的目录托管路由会在切窗口时被重复请求，属预期行为。
+
+## 文件结构
+
+```
+VCPWEWallpaper/
+├── plugin-manifest.json    # service 型清单（entryPoint.type: nodejs）
+├── we-wallpaper-service.js # 入口：initialize + registerRoutes 协议
+└── lib/
+    ├── locate.js           # Steam/WE 定位（注册表 + VDF）
+    ├── inventory.js        # 三源枚举 + project.json 分型 + MIME 表
+    ├── we-api-shim.js      # WE 私有 JS API 垫片（web 壁纸必需）
+    └── media-server.js     # 四条路由 + Range 流式 + 目录托管 + 缓存
+```
+
+## 启用方式
+
+1. 在 VCPChat 的插件管理器中启用本插件（需分布式服务器开启）。
+2. 重启后访问 `http://127.0.0.1:5974/vcp-we-wallpaper/inventory` 验证。
+3. 安装并启用 `VCPWEWallpaperUI` 前端插件即可在聊天窗口选择壁纸。
+4. **web 壁纸需要主程序 `main.html` 的 CSP 放通 `frame-src 'self' http://127.0.0.1:5974 http://localhost:5974`**（本仓库已加）。缺这一行时 web 壁纸会被浏览器拦下，渲染端自动降级为静态预览图，其余功能不受影响。
+
+## 测试
+
+```
+node tests/vcp-we-wallpaper-service.test.js
+```
+
+用真 Express + 本机真实库存跑：inventory 200 / 入口页垫片注入 / 相对资源 MIME 正确 / 编码穿越判 403 / 目录请求 404 / 未注册 token 404 / 垫片 `</script>` 转义。本机未装 WE 或库中无 web 壁纸时相关用例明确跳过，不伪装成通过。
+
+## 已知限制
+
+- **Scene 壁纸无法动态渲染**：内容封在私有二进制 `scene.pkg`（实测 10–22MB/个），需要 WE 自家 3D 引擎。`Almamu/linux-wallpaperengine` 确实实现了 scene 渲染，但那是原生 C++/OpenGL 程序，形态上无法塞进 Electron 渲染进程。渲染端对 scene 一律用自带 `preview.jpg` 静态铺底。
+- **音频律动类 web 壁纸会静止**：垫片喂的是全零频谱。接真实频谱需要把主程序的 `AnalyserNode` 数据 `postMessage` 进 iframe，属后续增强。
+- **依赖外网 CDN 的 web 壁纸可能白屏**：实测库中有壁纸引用 `fonts.googleapis.com` 和已下线的 `html5shiv.googlecode.com`。渲染端有 8 秒载入超时保护，超时自动降级为静态预览图。
+- **依赖正在播放媒体信息的壁纸**显示「无播放」。
+- 播放列表轮转为 v1.1 规划（当前 `playlists` 字段为占位空数组）；渲染端的轮播基于过滤范围而非 WE 播放列表。
+
+## 致谢
+
+核心定位/枚举/流式逻辑移植自 [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine)（MIT）。该项目的渲染端会为 web 壁纸创建 iframe，但服务端只有单文件 `media`/`preview` 路由，没有目录托管也没有 API 垫片——本插件的目录子树托管与垫片是新增实现。

--- a/VCPDistributedServer/Plugin/VCPWEWallpaper/lib/inventory.js
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaper/lib/inventory.js
@@ -1,0 +1,145 @@
+/**
+ * inventory.js - 枚举 Wallpaper Engine 壁纸库存
+ *
+ * 移植自 elysia395/dsh-wallpaper-engine (MIT)，适配 VCPWEWallpaper service 插件。
+ * 三源扫描：
+ *   1. <WE>/projects/defaultprojects   官方默认
+ *   2. <WE>/projects/myprojects        用户自建
+ *   3. <SteamLib>/steamapps/workshop/content/431960/*   创意工坊订阅
+ * 每个 wallpaper 目录含 project.json: { title, type, file, preview }
+ */
+'use strict';
+
+const {
+    existsSync,
+    readFileSync,
+    readdirSync,
+    statSync,
+} = require('node:fs');
+const { join, resolve, basename } = require('node:path');
+
+const { WE_APPID } = require('./locate');
+
+const KINDS = ['scene', 'video', 'web', 'application'];
+
+/** project.json 缺失 type 字段时按 file 扩展名推断。 */
+function inferType(file) {
+    if (/\.(mp4|webm|mkv|avi|mov)$/i.test(file)) return 'video';
+    if (/\.(html?|js)$/i.test(file)) return 'web';
+    return 'scene';
+}
+
+/** 读取单个 wallpaper 目录的 project.json；无效则返回 null。 */
+function readProject(dir) {
+    const pj = join(dir, 'project.json');
+    if (!existsSync(pj)) return null;
+    try {
+        const o = JSON.parse(readFileSync(pj, 'utf8'));
+        if (!o || typeof o !== 'object' || !o.file) return null;
+        let type = typeof o.type === 'string' ? o.type.toLowerCase() : inferType(o.file);
+        if (!KINDS.includes(type)) type = 'scene';
+        return {
+            id: basename(dir),
+            title: typeof o.title === 'string' ? o.title : basename(dir),
+            type,
+            file: o.file,
+            preview: typeof o.preview === 'string' ? o.preview : null,
+            // web 壁纸的用户自定义配置，交给 we-api-shim 回喂给壁纸脚本。
+            // 部分壁纸的 project.json 有上百 KB 全在这里面（实测 1509243786 = 111KB）。
+            properties: (o.general && typeof o.general === 'object'
+                && o.general.properties && typeof o.general.properties === 'object')
+                ? o.general.properties : null,
+        };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * 枚举全部壁纸（去重、按标题排序）。
+ * @param {string|null} installDir WE 安装目录（locateWallpaperEngine 结果）
+ * @param {string[]} libraryDirs 拥有 WE 的 Steam 库目录列表
+ * @returns {Array<{id,title,type,file,preview,fileAbs,previewAbs}>}
+ */
+function enumerateWallpapers(installDir, libraryDirs) {
+    const found = new Map();
+    const roots = [];
+
+    if (installDir) {
+        for (const sub of ['defaultprojects', 'myprojects']) {
+            const p = join(installDir, 'projects', sub);
+            if (existsSync(p)) roots.push(p);
+        }
+    }
+    for (const lib of libraryDirs) {
+        const ws = join(lib, 'steamapps', 'workshop', 'content', WE_APPID);
+        if (existsSync(ws)) roots.push(ws);
+    }
+
+    for (const root of roots) {
+        let entries = [];
+        try {
+            entries = readdirSync(root);
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            const dir = join(root, entry);
+            let st;
+            try {
+                st = statSync(dir);
+            } catch {
+                continue;
+            }
+            if (!st.isDirectory()) continue;
+            const proj = readProject(dir);
+            if (!proj || found.has(proj.id)) continue;
+            proj.dirAbs = resolve(dir);              // web 壁纸目录托管的根，用于 traversal 校验
+            proj.fileAbs = resolve(dir, proj.file);
+            proj.previewAbs = proj.preview ? resolve(dir, proj.preview) : null;
+            found.set(proj.id, proj);
+        }
+    }
+
+    return [...found.values()].sort((a, b) =>
+        (a.title || '').localeCompare(b.title || ''));
+}
+
+/**
+ * 文件的 MIME 类型（media / preview / web 三条路由的 Content-Type 用）。
+ *
+ * web 壁纸是完整的静态站点，会引用 css/字体/音频/json 等各类资源，
+ * 因此这里的表必须覆盖到浏览器会挑食的所有类型（尤其字体与 css：
+ * MIME 不对时 Chromium 会直接拒绝应用样式）。
+ */
+function mimeFor(absPath) {
+    const ext = absPath.slice(absPath.lastIndexOf('.') + 1).toLowerCase();
+    return {
+        // 视频
+        mp4: 'video/mp4', webm: 'video/webm', mkv: 'video/x-matroska',
+        avi: 'video/x-msvideo', mov: 'video/quicktime',
+        // 文档与脚本
+        html: 'text/html', htm: 'text/html',
+        js: 'text/javascript', mjs: 'text/javascript',
+        css: 'text/css', json: 'application/json',
+        txt: 'text/plain', md: 'text/plain', xml: 'application/xml',
+        // 图片
+        jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
+        png: 'image/png', webp: 'image/webp', bmp: 'image/bmp',
+        svg: 'image/svg+xml', ico: 'image/x-icon', avif: 'image/avif',
+        // 字体（MIME 错误会导致 @font-face 静默失效）
+        woff: 'font/woff', woff2: 'font/woff2', ttf: 'font/ttf',
+        otf: 'font/otf', eot: 'application/vnd.ms-fontobject',
+        // 音频
+        mp3: 'audio/mpeg', ogg: 'audio/ogg', wav: 'audio/wav',
+        m4a: 'audio/mp4', flac: 'audio/flac',
+    }[ext] || 'application/octet-stream';
+}
+
+module.exports = {
+    KINDS,
+    inferType,
+    readProject,
+    enumerateWallpapers,
+    mimeFor,
+};

--- a/VCPDistributedServer/Plugin/VCPWEWallpaper/lib/locate.js
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaper/lib/locate.js
@@ -1,0 +1,123 @@
+/**
+ * locate.js - 定位本机 Wallpaper Engine 安装
+ *
+ * 移植自 elysia395/dsh-wallpaper-engine (MIT)，适配 VCPWEWallpaper service 插件。
+ * 策略（按优先级）：
+ *   1. Windows 注册表 HKCU\Software\Valve\Steam -> SteamPath
+ *   2. 常见 Steam 安装目录探针（含多盘 SteamLibrary）
+ *   3. 解析 libraryfolders.vdf 找到拥有 WE (appid 431960) 的库
+ *   4. 校验 wallpaper32.exe 存在性
+ */
+'use strict';
+
+const { existsSync, readFileSync } = require('node:fs');
+const { join, normalize } = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+/** Wallpaper Engine 的 Steam appid。 */
+const WE_APPID = '431960';
+
+/** 常见 Steam 安装位置（libraryfolders.vdf 缺失时的探针列表）。 */
+const STEAM_PROBE_DIRS = [
+    'C:\\Program Files (x86)\\Steam',
+    'C:\\Program Files\\Steam',
+    'D:\\Steam',
+    'D:\\SteamLibrary',
+    'E:\\SteamLibrary',
+];
+
+/** Windows 安装器写入注册表的 Steam 根目录；探针列表覆盖不到自定义目录。 */
+function steamPathFromRegistry() {
+    if (process.platform !== 'win32') return null;
+    try {
+        const reg = join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
+        const out = execFileSync(
+            reg,
+            ['query', 'HKCU\\Software\\Valve\\Steam', '/v', 'SteamPath'],
+            { encoding: 'utf8', windowsHide: true, timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] }
+        );
+        const m = /SteamPath\s+REG_SZ\s+(.+)/i.exec(out);
+        return m ? normalize(m[1].trim()) : null;
+    } catch {
+        return null;
+    }
+}
+
+/** 探针列表，注册表已知的 Steam 根目录排在最前。 */
+function steamProbeDirs() {
+    const reg = steamPathFromRegistry();
+    return reg ? [reg, ...STEAM_PROBE_DIRS] : STEAM_PROBE_DIRS;
+}
+
+/**
+ * Valve KeyValues 极简解析：从 libraryfolders.vdf 提取拥有 WE 的库目录。
+ * vdf 结构中每个库块含 "path" 行与其拥有的 appid 列表。
+ */
+function librariesFromVdf(vdfPath) {
+    const text = readFileSync(vdfPath, 'utf8');
+    const libs = [];
+    let current = null;
+    for (const line of text.split(/\r?\n/)) {
+        const m = /^\s*"path"\s+"([^"]+)"\s*$/.exec(line);
+        if (m) {
+            current = m[1].replace(/\\\\/g, '\\');
+            continue;
+        }
+        if (current && line.includes(WE_APPID) && !libs.includes(current)) libs.push(current);
+    }
+    return libs;
+}
+
+/** 返回所有 Steam 探针根目录（去重）。 */
+function steamRoots() {
+    const roots = [...steamProbeDirs()];
+    for (const probe of steamProbeDirs()) {
+        const vdf = join(probe, 'steamapps', 'libraryfolders.vdf');
+        if (existsSync(vdf)) {
+            try {
+                for (const lib of librariesFromVdf(vdf)) {
+                    if (!roots.includes(lib)) roots.push(lib);
+                }
+            } catch { /* 解析失败则跳过该 vdf */ }
+        }
+    }
+    return roots;
+}
+
+/**
+ * 定位 WE 安装目录（含 wallpaper32.exe）。
+ * @returns {string|null} 绝对路径或 null
+ */
+function locateWallpaperEngine() {
+    const candidates = [];
+    for (const root of steamRoots()) {
+        candidates.push(join(root, 'steamapps', 'common', 'wallpaper_engine'));
+    }
+    candidates.push('C:\\Program Files (x86)\\Wallpaper Engine');
+
+    const seen = new Set();
+    for (const raw of candidates) {
+        const dir = normalize(raw);
+        if (seen.has(dir)) continue;
+        seen.add(dir);
+        if (existsSync(join(dir, 'wallpaper32.exe'))) return dir;
+    }
+    return null;
+}
+
+/**
+ * 拥有 WE 的 Steam 库目录（用于 workshop content 根）。
+ * @returns {string[]}
+ */
+function owningLibraries() {
+    return steamRoots();
+}
+
+module.exports = {
+    WE_APPID,
+    steamPathFromRegistry,
+    librariesFromVdf,
+    steamRoots,
+    locateWallpaperEngine,
+    owningLibraries,
+};

--- a/VCPDistributedServer/Plugin/VCPWEWallpaper/lib/media-server.js
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaper/lib/media-server.js
@@ -1,0 +1,286 @@
+/**
+ * media-server.js - inventory / media / preview / web 四条 Express 路由
+ *
+ * 媒体路由模型移植自 elysia395/dsh-wallpaper-engine (MIT)，从 Cordis webServer
+ * 适配为 VCPDistributedServer 的 Express app.registerRoutes 协议。
+ *
+ * 安全模型：
+ *   - token = base64url(绝对路径)，仅 inventory 枚举过的文件进入服务 Map
+ *   - 未注册 token 一律 404，不暴露任意文件系统
+ *   - inventory 带 5 分钟 LRU 缓存，巨型库存重复扫描不卡 Express 事件循环
+ *
+ * web 壁纸目录托管（路线 B）：
+ *   web 类型壁纸是完整静态站点（index.html + css/ + js/ + img/），相对引用无法
+ *   靠"单文件白名单"满足，必须开放目录子树。安全模型因此从"逐文件白名单"
+ *   收敛为"逐目录白名单 + 路径归一化校验"：
+ *     1. token 只能是 inventory 枚举出的 web 壁纸目录（webMap 之外一律 404）
+ *     2. 归一化后必须仍在该目录内，否则 403（阻断 ../../ 穿越）
+ *     3. 只服务普通文件，lstat 拒绝目录与符号链接（阻断软链逃逸）
+ *   入口 HTML 会被注入 WE API 垫片，见 we-api-shim.js。
+ */
+'use strict';
+
+const { existsSync, statSync, lstatSync, createReadStream, readFileSync } = require('node:fs');
+const { resolve, sep, relative } = require('node:path');
+
+const { locateWallpaperEngine, owningLibraries } = require('./locate');
+const { enumerateWallpapers, mimeFor } = require('./inventory');
+const { injectShim } = require('./we-api-shim');
+
+/** 路由前缀（UI 插件 fetch 的基地址）。 */
+const BASE = '/vcp-we-wallpaper';
+
+/** inventory 缓存有效期（毫秒）。 */
+const INVENTORY_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * 路由注册器。
+ * @param {import('express').Express} app VCPDistributedServer 主 Express 应用
+ * @param {object} _config 插件配置（本插件暂不使用 config.env）
+ * @param {string} _projectBasePath 项目根（未使用，保留协议签名）
+ */
+function registerRoutes(app, _config, _projectBasePath) {
+    // token -> 绝对路径。URL 不暴露文件系统字符串，Map 只收 inventory 内文件。
+    const mediaMap = new Map();
+    const tokenFor = (absPath) => {
+        const token = Buffer.from(absPath, 'utf8').toString('base64url');
+        mediaMap.set(token, absPath);
+        return token;
+    };
+
+    // token -> { dirAbs, entryAbs, properties }。仅 web 类型壁纸的目录进入此表。
+    const webMap = new Map();
+    const webTokenFor = (proj) => {
+        const token = Buffer.from(proj.dirAbs, 'utf8').toString('base64url');
+        webMap.set(token, {
+            dirAbs: proj.dirAbs,
+            entryAbs: proj.fileAbs,
+            properties: proj.properties || null,
+        });
+        return token;
+    };
+
+    // ── inventory 构建与缓存 ─────────────────────────────────
+    let cache = { at: 0, payload: null };
+
+    function buildInventory() {
+        const installDir = locateWallpaperEngine();
+        if (!installDir) {
+            return {
+                status: 503,
+                payload: { error: 'Wallpaper Engine installation not found on this machine.' },
+            };
+        }
+        const libraryDirs = owningLibraries();
+        const all = enumerateWallpapers(installDir, libraryDirs);
+        const wallpapers = all.map((w) => {
+            const hasMedia = (w.type === 'video' || w.type === 'web')
+                ? existsSync(w.fileAbs) : false;
+            const hasPreview = w.previewAbs && existsSync(w.previewAbs);
+            // web 壁纸额外给出目录托管入口；入口 URL 以 / 结尾，
+            // 这样 iframe 内的相对引用会正确解析到 /web/<token>/xxx
+            const isWeb = w.type === 'web' && hasMedia && w.dirAbs;
+            return {
+                id: w.id,
+                title: w.title,
+                type: w.type,
+                playable: hasMedia,
+                media: hasMedia ? `${BASE}/media/${tokenFor(w.fileAbs)}` : null,
+                preview: hasPreview ? `${BASE}/preview/${tokenFor(w.previewAbs)}` : null,
+                web: isWeb ? `${BASE}/web/${webTokenFor(w)}/` : null,
+            };
+        });
+        return {
+            status: 200,
+            payload: {
+                installDir,
+                total: wallpapers.length,
+                portableCount: wallpapers.filter((w) => w.playable).length,
+                webCount: wallpapers.filter((w) => w.web).length,
+                wallpapers,
+                playlists: [], // v1.1 占位
+            },
+        };
+    }
+
+    function inventoryWithCache() {
+        const now = Date.now();
+        if (cache.payload && now - cache.at < INVENTORY_TTL_MS) {
+            return cache;
+        }
+        return rebuildInventory();
+    }
+
+    /** 无条件重扫并刷新缓存（供 ?refresh=1 使用）。 */
+    function rebuildInventory() {
+        cache = { at: Date.now(), ...buildInventory() };
+        return cache;
+    }
+
+    /** web 路由需要 webMap 已填充；冷启动直接命中 /web/... 时先建一次 inventory。 */
+    function ensureWebMap() {
+        if (webMap.size === 0) inventoryWithCache();
+    }
+
+    // ── 路由 1: inventory JSON ────────────────────────────────
+    app.get(`${BASE}/inventory`, (req, res) => {
+        try {
+            // ?refresh=1 绕过 5 分钟缓存重扫目录。主人在 Steam 新订阅壁纸后
+            // 不该被迫等一个 TTL 或重启服务器才能看到它。
+            const bust = req.query.refresh === '1' || req.query.refresh === 'true';
+            const { status, payload } = bust ? rebuildInventory() : inventoryWithCache();
+            res.status(status)
+                .setHeader('Content-Type', 'application/json; charset=utf-8')
+                .setHeader('Cache-Control', 'no-store');
+            res.end(JSON.stringify(payload));
+        } catch (err) {
+            res.status(500)
+                .setHeader('Content-Type', 'application/json')
+                .end(JSON.stringify({ error: String(err && err.message ? err.message : err) }));
+        }
+    });
+
+    // ── 路由 2/3: media + preview（流式，Range 支持 video 拖动） ──
+    function serveFile(absPath, req, res) {
+        if (!absPath || !existsSync(absPath)) {
+            res.status(404).end('not found');
+            return;
+        }
+        const st = statSync(absPath);
+        res.setHeader('Content-Type', mimeFor(absPath));
+        res.setHeader('Accept-Ranges', 'bytes');
+
+        const range = req.headers.range;
+        if (range) {
+            const m = /bytes=(\d*)-(\d*)/.exec(range);
+            let start = m && m[1] ? parseInt(m[1], 10) : 0;
+            let end = m && m[2] ? parseInt(m[2], 10) : st.size - 1;
+            if (Number.isNaN(start)) start = 0;
+            if (Number.isNaN(end) || end >= st.size) end = st.size - 1;
+            if (start > end) {
+                res.status(416)
+                    .setHeader('Content-Range', `bytes */${st.size}`)
+                    .end();
+                return;
+            }
+            res.status(206)
+                .setHeader('Content-Range', `bytes ${start}-${end}/${st.size}`)
+                .setHeader('Content-Length', String(end - start + 1));
+            createReadStream(absPath, { start, end }).pipe(res);
+            return;
+        }
+        res.setHeader('Content-Length', String(st.size));
+        createReadStream(absPath).pipe(res);
+    }
+
+    for (const seg of ['media', 'preview']) {
+        app.get(`${BASE}/${seg}/:token`, (req, res) => {
+            serveFile(mediaMap.get(req.params.token), req, res);
+        });
+    }
+
+    // ── 路由 4: web 壁纸目录托管 ───────────────────────────────
+
+    /**
+     * 把请求的相对路径解析成绝对路径，并确认它仍在壁纸目录内。
+     * @returns {string|null} 安全的绝对路径；越界返回 null
+     */
+    function safeResolve(dirAbs, relPath) {
+        let decoded;
+        try {
+            decoded = decodeURIComponent(relPath || '');
+        } catch {
+            return null;      // 非法百分号编码
+        }
+        if (decoded.includes('\0')) return null;   // NUL 截断攻击
+
+        const abs = resolve(dirAbs, '.' + (decoded.startsWith('/') ? decoded : '/' + decoded));
+        const rootAbs = resolve(dirAbs);
+        // 归一化后必须等于根目录或位于根目录之下
+        if (abs !== rootAbs && !abs.startsWith(rootAbs + sep)) return null;
+        // 双保险：relative 不得回溯
+        const rel = relative(rootAbs, abs);
+        if (rel.startsWith('..')) return null;
+        return abs;
+    }
+
+    /**
+     * app.use 挂前缀（而非 app.get 通配符）：Express 4/5 语义一致，
+     * 且 req.path 自动剥掉前缀，省去手工切串的差异。
+     */
+    app.use(`${BASE}/web`, (req, res, next) => {
+        if (req.method !== 'GET' && req.method !== 'HEAD') return next();
+
+        ensureWebMap();
+
+        // req.path 形如 /<token>/relative/path 或 /<token>/
+        const parts = req.path.split('/').filter(Boolean);
+        const token = parts.shift();
+        const entry = token ? webMap.get(token) : null;
+        if (!entry) {
+            res.status(404).end('unknown web wallpaper token');
+            return;
+        }
+
+        // 空路径 = 入口页：注入 WE API 垫片后返回
+        if (parts.length === 0) {
+            if (!existsSync(entry.entryAbs)) {
+                res.status(404).end('entry not found');
+                return;
+            }
+            let html;
+            try {
+                html = readFileSync(entry.entryAbs, 'utf8');
+            } catch (err) {
+                res.status(500).end('failed to read entry: ' + (err && err.message));
+                return;
+            }
+            const body = injectShim(html, entry.properties);
+            res.status(200)
+                .setHeader('Content-Type', 'text/html; charset=utf-8')
+                .setHeader('Cache-Control', 'no-store')
+                .end(body);
+            return;
+        }
+
+        const abs = safeResolve(entry.dirAbs, parts.join('/'));
+        if (!abs) {
+            res.status(403).end('path outside wallpaper directory');
+            return;
+        }
+
+        // lstat 而非 stat：符号链接不跟随，避免软链指向目录外
+        let st;
+        try {
+            st = lstatSync(abs);
+        } catch {
+            res.status(404).end('not found');
+            return;
+        }
+        if (!st.isFile()) {
+            res.status(404).end('not a file');
+            return;
+        }
+
+        // 壁纸目录内的 .html 也注入垫片（部分壁纸有 index2.html 之类的子页面）
+        if (/\.html?$/i.test(abs)) {
+            try {
+                const body = injectShim(readFileSync(abs, 'utf8'), entry.properties);
+                res.status(200)
+                    .setHeader('Content-Type', 'text/html; charset=utf-8')
+                    .end(body);
+                return;
+            } catch {
+                // 读取失败则退回二进制流式
+            }
+        }
+
+        res.setHeader('Content-Type', mimeFor(abs));
+        res.setHeader('Content-Length', String(st.size));
+        createReadStream(abs).pipe(res);
+    });
+
+    console.log(`[VCPWEWallpaper] 路由已注册: ${BASE}/inventory, ${BASE}/media/:token, ${BASE}/preview/:token, ${BASE}/web/:token/*`);
+}
+
+module.exports = { registerRoutes, BASE };

--- a/VCPDistributedServer/Plugin/VCPWEWallpaper/lib/we-api-shim.js
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaper/lib/we-api-shim.js
@@ -1,0 +1,126 @@
+/**
+ * we-api-shim.js - Wallpaper Engine 私有 JS API 垫片
+ *
+ * 背景：
+ *   web 类型壁纸在 Wallpaper Engine 里运行时，wallpaper32.exe 会向页面注入一组
+ *   全局函数供壁纸读取用户配置、音频频谱、正在播放的媒体信息等。浏览器里这些
+ *   全部是 undefined，壁纸脚本通常写成：
+ *       window.wallpaperPropertyListener = { applyUserProperties(p) {...} }
+ *   或
+ *       window.wallpaperRegisterAudioListener(cb)
+ *   前者不调用只会退化为默认配置，后者直接抛 TypeError 导致整页白屏。
+ *
+ *   实测本机库存中 1336332719 用了 1 个回调、1509243786 用了 3 个。
+ *
+ * 策略：
+ *   1. 用 Object.defineProperty 的 setter 拦截 wallpaperPropertyListener 的赋值
+ *      时机 —— 壁纸脚本刚挂上监听器就立刻回喂一次配置，无需猜时序。
+ *   2. project.json 的 general.properties 原样转成 WE 的 { value, type, text } 形状。
+ *   3. 音频/媒体类回调给出安全的空实现（静音频谱 + 无播放状态），保证不抛异常。
+ *
+ * 已知降级（写在 README 已知限制里）：
+ *   - 音频律动类壁纸会静止（喂的是全零频谱，真实频谱需接主程序 AnalyserNode）
+ *   - 依赖正在播放媒体信息的壁纸显示"无播放"
+ */
+'use strict';
+
+/** WE 用户属性 → 壁纸脚本期望的形状。 */
+function normalizeProperties(properties) {
+    const out = {};
+    if (!properties || typeof properties !== 'object') return out;
+    for (const [key, def] of Object.entries(properties)) {
+        if (!def || typeof def !== 'object') continue;
+        out[key] = {
+            value: def.value,
+            type: typeof def.type === 'string' ? def.type : undefined,
+            text: typeof def.text === 'string' ? def.text : undefined,
+        };
+    }
+    return out;
+}
+
+/**
+ * 生成注入用的垫片脚本正文（不含 <script> 标签）。
+ * @param {object} properties project.json 的 general.properties
+ * @returns {string}
+ */
+function buildShimSource(properties) {
+    // JSON.stringify 后再替换 </ 防止字符串里出现 </script> 提前闭合注入点
+    const json = JSON.stringify(normalizeProperties(properties)).replace(/<\//g, '<\\/');
+
+    return `/* VCPWEWallpaper: Wallpaper Engine API shim (injected) */
+(function () {
+  'use strict';
+  var PROPS = ${json};
+
+  function safeCall(fn, arg) {
+    try { if (typeof fn === 'function') fn(arg); }
+    catch (e) { console.warn('[VCPWEWallpaper shim]', e); }
+  }
+
+  // ── 用户属性：拦截赋值时机，挂上监听器的瞬间立刻回喂配置 ──
+  var listener = null;
+  try {
+    Object.defineProperty(window, 'wallpaperPropertyListener', {
+      configurable: true,
+      get: function () { return listener; },
+      set: function (v) {
+        listener = v;
+        if (!v || typeof v !== 'object') return;
+        safeCall(v.applyUserProperties, PROPS);
+        safeCall(v.applyGeneralProperties, { fps: 60 });
+        safeCall(v.setPaused, false);
+      }
+    });
+  } catch (e) {
+    // defineProperty 失败时退化为普通属性，至少不阻塞壁纸加载
+    window.wallpaperPropertyListener = null;
+  }
+
+  // ── 音频频谱：128 段全零，15Hz 空转（不喂会让部分壁纸卡在等待态）──
+  var SILENT = new Array(128).fill(0);
+  window.wallpaperRegisterAudioListener = function (cb) {
+    if (typeof cb !== 'function') return;
+    setInterval(function () { safeCall(cb, SILENT); }, 1000 / 15);
+  };
+
+  // ── 媒体信息类：空实现，壁纸走"无播放"分支 ──
+  var NOOP = function () {};
+  window.wallpaperRegisterMediaPropertiesListener = NOOP;
+  window.wallpaperRegisterMediaThumbnailListener = NOOP;
+  window.wallpaperRegisterMediaTimelineListener = NOOP;
+  window.wallpaperRegisterMediaPlaybackListener = NOOP;
+  window.wallpaperRequestRandomFileForProperty = NOOP;
+  window.wallpaperPluginListener = window.wallpaperPluginListener || {};
+
+  // 少数壁纸会探测这些能力位来决定走哪条分支
+  window.wallpaperRegisterAudioListener.isVCPShim = true;
+})();`;
+}
+
+/**
+ * 把垫片注入 HTML：插在 <head> 之后（或文档最前），保证早于壁纸自身脚本执行。
+ * @param {string} html 原始 index.html 文本
+ * @param {object} properties project.json 的 general.properties
+ * @returns {string}
+ */
+function injectShim(html, properties) {
+    const tag = `<script>${buildShimSource(properties)}</script>`;
+    const text = String(html);
+
+    // 优先插到 <head ...> 之后，这样壁纸的 <link>/<script> 都在垫片之后
+    const headOpen = /<head[^>]*>/i.exec(text);
+    if (headOpen) {
+        const at = headOpen.index + headOpen[0].length;
+        return text.slice(0, at) + '\n' + tag + text.slice(at);
+    }
+    // 无 <head> 的裸 HTML：插到 <html> 之后，再退化为文档最前
+    const htmlOpen = /<html[^>]*>/i.exec(text);
+    if (htmlOpen) {
+        const at = htmlOpen.index + htmlOpen[0].length;
+        return text.slice(0, at) + '\n' + tag + text.slice(at);
+    }
+    return tag + '\n' + text;
+}
+
+module.exports = { normalizeProperties, buildShimSource, injectShim };

--- a/VCPDistributedServer/Plugin/VCPWEWallpaper/plugin-manifest.json
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaper/plugin-manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "VCPWEWallpaper",
+  "displayName": "Wallpaper Engine 壁纸服务",
+  "version": "0.1.0",
+  "description": "发现本机 Wallpaper Engine 安装，枚举壁纸库存（video/web 可播放），并通过分布式服务器 Express 路由提供 inventory 与媒体流。",
+  "author": "PiCode (核心定位/枚举/流式逻辑移植自 elysia395/dsh-wallpaper-engine, MIT)",
+  "pluginType": "service",
+  "communication": {
+    "protocol": "direct",
+    "timeout": 10000
+  },
+  "entryPoint": {
+    "type": "nodejs",
+    "script": "we-wallpaper-service.js"
+  },
+  "capabilities": {
+    "invocationCommands": []
+  }
+}

--- a/VCPDistributedServer/Plugin/VCPWEWallpaper/we-wallpaper-service.js
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaper/we-wallpaper-service.js
@@ -1,0 +1,27 @@
+/**
+ * we-wallpaper-service.js - VCPWEWallpaper service 插件入口
+ *
+ * pluginType: "service" + communication.protocol: "direct"
+ * 由 VCPDistributedServer/Plugin.js 的 initializeServices() 加载：
+ *   - initialize():  常驻初始化（本插件无需，路由注册时自检）
+ *   - registerRoutes(app, config, projectBasePath, services):
+ *       把 inventory / media / preview 路由挂到主 Express 应用（默认 5974 端口）
+ *
+ * 无 config.env 依赖、无 invocationCommands（对 AI 不可见，纯基础设施）。
+ * 配套渲染端: VCPWEWallpaperUI (renderer 型前端插件)。
+ */
+'use strict';
+
+const { registerRoutes, BASE } = require('./lib/media-server');
+
+/** service 插件无重初始化需求，仅打印就绪日志。 */
+async function initialize({ logger = console } = {}) {
+    logger.log?.('[VCPWEWallpaper] service 插件已加载（路由将在服务器启动时注册）');
+}
+
+/** 模块级导出 registerRoutes：Plugin.js initializeServices 会直接调用它。 */
+module.exports = {
+    initialize,
+    registerRoutes,
+    BASE,
+};

--- a/VCPDistributedServer/Plugin/VCPWEWallpaperUI/README.md
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaperUI/README.md
@@ -1,0 +1,70 @@
+# VCPWEWallpaperUI - Wallpaper Engine 壁纸（前端）
+
+> pluginType: `renderer` · 由 frontend-plugin-loader.js 注入聊天窗口
+> 硬依赖：service 插件 `VCPWEWallpaper`（需启用分布式服务器）
+
+## 功能
+
+在聊天窗口使用 Wallpaper Engine 库存壁纸作为动态背景：
+
+- **三种呈现形态**，按壁纸实际能力自动分派：
+
+  | 形态 | 图层 | 适用 |
+  |---|---|---|
+  | `video` | `<video>` 硬解播放 | Video 类型壁纸（.mp4 等） |
+  | `web` | `<iframe>` 隔离渲染 | Web 类型壁纸，由 service 端托管目录并注入 WE API 垫片 |
+  | `image` | `<div>` 背景图铺底 | Scene 类型，或 web 载入超时后的降级兜底 |
+
+- **壁纸库网格选择器**：预览图 + 标题 + **形态徽章**（视频·动态 / 网页·动态 / 场景·静态 / 不可用），标题搜索 + 类型过滤 + 分页（每页 24 张）。徽章按「实际能得到什么」标注，而非 WE 原始类型。
+- **重新扫描**：弹窗右上角的回旋箭头按钮。service 端 inventory 有 5 分钟缓存，在 Steam 新订阅壁纸后不点它最多要等一个 TTL；该按钮以 `?refresh=1` 强制重扫，并回报本次新增/减少了几张。
+- **chat-header 控制面板**：壁纸库 / 播放暂停 / 静音 / 背景显隐 / 音量 / **轮播** / **下一张**。折叠后仅剩一枚 `header-button`（右键该图标也可直接开壁纸库）。非视频形态下播放/静音/音量三个控件自动隐藏（对静态图和 web 壁纸没有意义）。
+- **轮播**：在当前过滤范围内的「可动态呈现」壁纸（video + web）间定时轮换。左键开关，**右键循环切换间隔**（1 / 5 / 15 / 30 / 60 分钟），开启态按钮点亮。窗口不可见时跳过切换，不浪费解码。静态兜底图不参与轮播——一张不动的图轮换只会莫名闪烁。
+- **白屏保护**：web 壁纸 8 秒内未 `load` 视为白屏（多见于依赖外网 CDN 的壁纸），自动降级为该壁纸自带的 `preview` 静态图，并在本次会话内记住不再重试。
+- **无缝循环**：视频壁纸 `loop` 常开，播完立刻从头接上。这与轮播是两套独立机制——`loop` 管单张无限重播，轮播管到点换下一张；轮播关闭时单张就一直循环下去。
+- **断点续播**：重启 VCPChat 后从上次播放位置继续。
+- **窗口不可见即挂起**：`visibilitychange` 上暂停视频解码、卸载 web iframe（壁纸的 rAF 随文档一起停），回到前台自动恢复——视频从记下的进度接上，web 挂回同一入口页且不再重跑白屏超时判定（挂起前已验证过可载入，否则每次切窗口都会被误判降级）。主人自己按了「隐藏背景」时不擅自恢复。
+- **只取元数据**：`<video preload="metadata">`。HTML5 默认 `auto`，Chromium 会尽量把整个文件缓冲进内存；本机视频壁纸实测平均 76.6 MB、最大 205.5 MB，`auto` 就是几百 MB 的白花。`metadata` 只读时长/尺寸，播放时按 Range 流式取，画面表现无差别。
+- **互斥协调**：本插件激活时自动暂停 VChatDynamicWallpaper（辉宝）的背景视频，避免双层视频。只改其内存态，不动它的 localStorage。
+- **registry 暴露**：`{ destroy, pause, resume, openPicker, next, setRotate, state, active, kind }` 供 VCPGlass 等插件联动。
+
+## 使用
+
+1. 启用分布式服务器 + `VCPWEWallpaper` service 插件（先决条件）
+2. 启用本插件，重启 VCPChat
+3. 聊天窗口标题栏出现网格图标 -> 点击展开面板 -> 「壁纸库」-> 点选壁纸
+
+## web 壁纸的前置条件
+
+主程序 `main.html` 的 CSP 必须放通：
+
+```
+frame-src 'self' http://127.0.0.1:5974 http://localhost:5974;
+```
+
+本仓库已加。CSP 的多策略是**取交集**的，插件自己注入 `<meta>` 只能收紧不能放宽，所以这一行没有插件侧替代方案（`srcdoc` / `blob:` / `data:` iframe 都继承父页 CSP 且源为 opaque，`'self'` 匹配不到任何东西）。缺这一行时 web 壁纸会被浏览器拦下，8 秒后自动降级为静态预览图，其余功能不受影响。
+
+## 设置（localStorage `vcpWeWallpaper.settings.v1`）
+
+`enabled` / `wallpaperId` / `wallpaperKind`（`video`｜`web`｜`image`）/ `playing` / `muted` / `volume` / `currentTime` / `visible` / `serverBase`（默认 `http://127.0.0.1:5974`）/ `filterType` / `panelCollapsed` / `rotate` / `rotateMinutes`
+
+## 测试
+
+```
+node tests/vcp-we-wallpaper-ui.test.js
+```
+
+JSDOM 冒烟：结构注入（含 `loop` / `preload` 两个默认值断言）/ 分页 / 过滤 / 徽章形态 / 静态兜底 / 不可用拒绝 / web iframe 载入 / 超时降级 / 视频点选 / 辉宝互斥 / 轮播开关与间隔循环与手动下一张 / 隐藏挂起与恢复（视频暂停续播、主动隐藏不擅自恢复、web 卸载重挂不误降级）/ 持久化 / destroy 清理。
+
+## 已知限制
+
+- **Scene 壁纸只能静态铺底**：内容封在私有 `scene.pkg`，需要 WE 自家 3D 引擎才能渲染。
+- **音频律动类 web 壁纸会静止**：service 端垫片喂的是全零频谱。
+- **依赖外网 CDN 的 web 壁纸**可能白屏并降级为静态图（有超时保护，不会一直空白）。
+- **库存不会自动更新**：这是刻意的设计。前端 `fetchInventory` 首次取到库存后就锁在内存里，第二次打开壁纸库连请求都不发；service 端那 5 分钟 TTL 是惰性过期（只让缓存作废，重扫要等下一次请求触发），因此一个 VCPChat 会话内库存是稳定不变的。在 Steam 新订阅壁纸后，点弹窗右上角的「重新扫描」即可，不必重启。既无定时任务也无目录监听。
+- **轮播基于过滤范围**，不是 WE 自己的播放列表（service 端 `playlists` 仍是 v1.1 占位）。
+- **动态壁纸的开销来自壁纸本身**，不是本插件。插件自身实测：WE 定位 58 ms（仅首次）、136 个壁纸目录枚举 26 ms（冷）/ 19 ms（暖），堆增量 0.70 MB，库存缓存 5 分钟，两插件源码合计 77 KB。真正吃资源的是 1080p/4K 视频的持续流式读取与硬解——这是动态壁纸的固有成本，`preload=metadata` 与隐藏挂起已把可省的部分省掉。
+- 与辉宝插件同时启用时以本插件优先（激活即暂停辉宝）；关闭本插件背景后需手动重新启用辉宝。
+
+## 致谢
+
+播放器内核（状态机/失败跳过/断点续播模型）移植自 VCPChat 仓库内 VChatDynamicWallpaper（by 辉宝）。

--- a/VCPDistributedServer/Plugin/VCPWEWallpaperUI/plugin-manifest.json
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaperUI/plugin-manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifestVersion": "1.0.0",
+  "name": "VCPWEWallpaperUI",
+  "version": "0.1.0",
+  "displayName": "Wallpaper Engine 壁纸",
+  "description": "在聊天窗口使用 Wallpaper Engine 库存壁纸作为动态背景：网格选择器（预览图+类型过滤）+ 播放控制面板 + 断点续播。需配套 service 插件 VCPWEWallpaper。",
+  "author": "PiCode (播放内核移植自 VChatDynamicWallpaper by 辉宝)",
+  "pluginType": "renderer",
+  "frontend": {
+    "style": "plugin.css",
+    "script": "plugin.js"
+  },
+  "capabilities": {
+    "invocationCommands": []
+  }
+}

--- a/VCPDistributedServer/Plugin/VCPWEWallpaperUI/plugin.css
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaperUI/plugin.css
@@ -1,0 +1,473 @@
+/**
+ * VCPWEWallpaperUI - 样式
+ * 视频背景层 / chat-actions 控制面板（header-button 规格）/ 全屏紧凑网格选择器
+ * 面板按钮完全复用主程序 .header-button 类（32px 高 / 12px 圆角 / 18px 图标），
+ * 此处仅补充展开态与内部小控件的插件专属样式。
+ */
+
+/* ═══════════ 背景视频层（与辉宝插件同模型：fixed + z-index:-1） ═══════════ */
+
+#vcp-we-wallpaper-video {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: -1;
+    pointer-events: none;
+    display: none;          /* JS applyVisibility 控制显隐 */
+}
+
+/* ═══════════ 静态兜底层（scene / web 用自带 preview 大图铺底） ═══════════ */
+
+#vcp-we-wallpaper-image {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    display: none;          /* JS applyVisibility 控制显隐 */
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+/* ═══════════ web 壁纸层（iframe 隔离渲染真实 HTML 壁纸） ═══════════ */
+
+/*
+ * iframe 与 video/image 同处 z-index:-1 背景层。
+ * pointer-events:none 是硬要求：壁纸里的 canvas/a 标签绝不能抢聊天窗口的鼠标。
+ * 载入前 iframe 背景默认白，会在切换瞬间闪一下白屏，故显式压成透明。
+ */
+#vcp-we-wallpaper-web {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    z-index: -1;
+    pointer-events: none;
+    display: none;          /* JS applyVisibility 控制显隐 */
+    background: transparent;
+    color-scheme: normal;   /* 阻止宿主深色偏好给壁纸文档强行反色 */
+}
+
+/* 激活时掀掉 body 静态壁纸（与辉宝同策略） */
+body.vcp-we-wallpaper-visible {
+    background-image: none !important;
+}
+
+/* ═══════════ chat-actions 控制面板（挂在 header-button 按钮排中） ═══════════ */
+
+#vcp-we-wallpaper-panel {
+    display: flex;
+    align-items: center;
+    margin-left: 4px;       /* 与 .chat-actions .header-button 的 margin-left 一致 */
+    flex: 0 0 auto;
+}
+
+/* 折叠态：面板本身就是一个标准 header-button（.vwp-toggle 已套该类） */
+#vcp-we-wallpaper-panel .vwp-toggle {
+    margin-left: 0;
+}
+
+/* 展开态：外层变成一个 32px 高的胶囊容器，内部小按钮统一 24px 高 */
+#vcp-we-wallpaper-panel:not(.collapsed) {
+    height: 32px;
+    padding: 0 8px 0 0;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    transition: border-color 0.2s;
+}
+
+#vcp-we-wallpaper-panel:not(.collapsed) .vwp-toggle {
+    border: none;           /* 展开后融入胶囊，不再独立描边 */
+    background: transparent;
+}
+
+#vcp-we-wallpaper-panel .vwp-controls {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    max-width: 0;
+    opacity: 0;
+    transition: max-width .25s ease, opacity .25s ease, margin .25s ease;
+    margin-left: 0;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+#vcp-we-wallpaper-panel:not(.collapsed) .vwp-controls {
+    max-width: 300px;
+    opacity: 1;
+    margin-left: 4px;
+}
+
+/* 展开态内的功能小按钮：24px 方块，视觉是 header-button 的紧凑变体 */
+#vcp-we-wallpaper-panel .vwp-ctrl {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 24px;
+    min-width: 26px;
+    padding: 0 5px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--secondary-text);
+    cursor: pointer;
+    opacity: .8;
+    transition: background .15s ease, opacity .15s ease;
+}
+
+body:not(.light-theme) #vcp-we-wallpaper-panel .vwp-ctrl { color: var(--highlight-text); }
+
+#vcp-we-wallpaper-panel .vwp-ctrl:hover {
+    background: var(--button-hover-bg, rgba(255, 255, 255, 0.12));
+    opacity: 1;
+}
+
+/*
+ * 轮播开启态。纯静态声明，无动画/无滤镜：color-mix 只在样式解析时算一次，
+ * 触发点仅 updatePanel() 的 classList.toggle（用户操作驱动，不在 rAF/timer 里），
+ * 代价是一次 26×24px 的局部 repaint，不触发 layout。
+ */
+#vcp-we-wallpaper-panel .vwp-ctrl.on {
+    opacity: 1;
+    color: var(--highlight-text, #9fd8c8);
+    background: color-mix(in srgb, var(--highlight-text, #9fd8c8) 18%, transparent);
+}
+
+#vcp-we-wallpaper-panel .vwp-ctrl svg { display: block; }
+
+#vcp-we-wallpaper-panel .vwp-volume {
+    display: flex;
+    align-items: center;
+    padding: 0 2px;
+}
+
+#vcp-we-wallpaper-panel .vwp-volume input {
+    width: 64px;
+    height: 3px;
+    appearance: none;
+    -webkit-appearance: none;
+    border-radius: 2px;
+    background: var(--border-color, rgba(255, 255, 255, .2));
+    background-image: linear-gradient(currentColor, currentColor);
+    background-repeat: no-repeat;
+    cursor: pointer;
+    outline: none;
+}
+
+#vcp-we-wallpaper-panel .vwp-volume input::-webkit-slider-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+/* ═══════════ 全屏紧凑网格选择器（v1 风格 + 翻页 + 提示） ═══════════ */
+
+#vcp-we-wallpaper-picker {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+    background: rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-dialog {
+    display: flex;
+    flex-direction: column;
+    width: min(860px, 92vw);
+    height: min(640px, 86vh);
+    border-radius: 14px;
+    overflow: hidden;
+    /* 主题同步：只用每个主题都定义的核心变量 + color-mix 半透明化，
+       切换主题（含深浅模式）时弹窗自动跟随新主题配色 */
+    background: color-mix(in srgb, var(--primary-bg) 88%, transparent);
+    backdrop-filter: blur(24px) saturate(140%);
+    -webkit-backdrop-filter: blur(24px) saturate(140%);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.4);
+    color: var(--primary-text);
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-title {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-count {
+    font-size: 11px;
+    opacity: .6;
+    margin-right: auto;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-filters {
+    display: flex;
+    gap: 4px;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-filters button {
+    height: 26px;
+    padding: 0 10px;
+    border-radius: 13px;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--primary-text);
+    font-size: 11px;
+    cursor: pointer;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-filters button.on {
+    background: var(--highlight-text);
+    border-color: var(--highlight-text);
+    color: var(--text-on-accent, #fff);
+    font-weight: 600;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-search {
+    width: 150px;
+    height: 28px;
+    padding: 0 10px;
+    border-radius: 14px;
+    border: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--primary-bg) 70%, transparent);
+    color: var(--primary-text);
+    font-size: 12px;
+    outline: none;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-search:focus {
+    border-color: var(--highlight-text);
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-refresh {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: none;
+    background: transparent;
+    color: var(--primary-text);
+    cursor: pointer;
+    opacity: .75;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-refresh:hover {
+    opacity: 1;
+    background: var(--button-hover-bg, color-mix(in srgb, var(--primary-text) 12%, transparent));
+}
+
+/* 扫描中：静态置灰即可表达「正在忙」，不引入 @keyframes 旋转 */
+#vcp-we-wallpaper-picker .vwp-picker-refresh.busy {
+    opacity: .35;
+    cursor: default;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-close {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: none;
+    background: transparent;
+    color: var(--primary-text);
+    cursor: pointer;
+    font-size: 13px;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-close:hover {
+    background: var(--button-hover-bg, color-mix(in srgb, var(--primary-text) 12%, transparent));
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-status {
+    min-height: 22px;
+    padding: 4px 16px;
+    font-size: 11px;
+    opacity: .7;
+    flex-shrink: 0;
+}
+
+#vcp-we-wallpaper-picker .vwp-picker-status.hint {
+    opacity: 1;
+    color: var(--highlight-text, #e8c87f);
+}
+
+/* 网格：固定尺寸卡片（16:9 缩略图），分页保证永不压缩 */
+#vcp-we-wallpaper-picker .vwp-picker-grid {
+    flex: 1;
+    overflow-y: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 12px;
+    padding: 8px 16px 16px;
+    align-content: start;
+    scrollbar-width: thin;
+}
+
+/* ═══════════ 壁纸卡片（v1 紧凑风格） ═══════════ */
+/* 关键：卡片三段（缩略图 / 名称 / 徽章）全部 flex-shrink:0，
+   缩略图改固定高度而非 aspect-ratio —— 否则同一网格行内高卡片会把
+   矮卡片的徽章压扁，表现为「标签只显示上半部分」。 */
+
+#vcp-we-wallpaper-picker .vwp-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    border-radius: 10px;
+    overflow: hidden;
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+    background: color-mix(in srgb, var(--secondary-bg, #2a2a2a) 55%, transparent);
+    cursor: pointer;
+    padding: 0;
+    text-align: left;
+    color: var(--primary-text);
+    transition: transform .15s ease, border-color .15s ease, box-shadow .15s ease;
+}
+
+#vcp-we-wallpaper-picker .vwp-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--highlight-text, rgba(255, 255, 255, 0.4));
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.28);
+}
+
+#vcp-we-wallpaper-picker .vwp-card:focus-visible {
+    outline: none;
+    border-color: var(--highlight-text, #6fc8aa);
+}
+
+#vcp-we-wallpaper-picker .vwp-card.current {
+    border-color: var(--highlight-text, #6fc8aa);
+    box-shadow: 0 0 0 1px var(--highlight-text, #6fc8aa);
+}
+
+#vcp-we-wallpaper-picker .vwp-card-thumb {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 84px;
+    flex: 0 0 84px;
+    background-color: color-mix(in srgb, var(--primary-bg, #1e1e1e) 60%, transparent);
+    background-size: cover;
+    background-position: center;
+}
+
+#vcp-we-wallpaper-picker .vwp-thumb-empty {
+    font-size: 11px;
+    opacity: .4;
+}
+
+#vcp-we-wallpaper-picker .vwp-card-name {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    flex: 0 0 auto;
+    padding: 6px 8px 2px;
+    font-size: 11.5px;
+    line-height: 1.4;
+    height: 2.8em;
+    box-sizing: content-box;
+    word-break: break-word;
+    color: var(--primary-text);
+}
+
+#vcp-we-wallpaper-picker .vwp-card-badge {
+    align-self: flex-start;
+    flex: 0 0 auto;
+    margin: 2px 8px 8px;
+    padding: 1px 8px;
+    border-radius: 9px;
+    font-size: 10px;
+    line-height: 1.6;
+    white-space: nowrap;
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.18));
+    background: color-mix(in srgb, var(--primary-bg, #1e1e1e) 45%, transparent);
+    opacity: .9;
+}
+
+/* 徽章按「实际可用形态」着色，而非按 WE 原始类型 —— 主人一眼看出能得到什么 */
+#vcp-we-wallpaper-picker .vwp-badge-video {
+    color: var(--highlight-text, #9fd8c8);
+    border-color: color-mix(in srgb, var(--highlight-text, #9fd8c8) 45%, transparent);
+}
+
+#vcp-we-wallpaper-picker .vwp-badge-web {
+    color: var(--highlight-text, #9fd8c8);
+    border-color: color-mix(in srgb, var(--highlight-text, #9fd8c8) 45%, transparent);
+}
+
+#vcp-we-wallpaper-picker .vwp-badge-image {
+    color: var(--secondary-text, #b5b5b5);
+    opacity: .75;
+}
+
+#vcp-we-wallpaper-picker .vwp-badge-none {
+    opacity: .4;
+    text-decoration: line-through;
+}
+
+/* ═══════════ 分页脚 ═══════════ */
+
+#vcp-we-wallpaper-picker .vwp-picker-foot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 10px 16px;
+    border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+    flex-shrink: 0;
+}
+
+#vcp-we-wallpaper-picker .vwp-page-btn {
+    height: 28px;
+    padding: 0 14px;
+    border-radius: 14px;
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.16));
+    background: transparent;
+    color: var(--primary-text);
+    font-size: 11.5px;
+    cursor: pointer;
+    opacity: .8;
+    transition: all .15s ease;
+}
+
+#vcp-we-wallpaper-picker .vwp-page-btn:hover:not(:disabled) {
+    background: var(--button-hover-bg, color-mix(in srgb, var(--primary-text) 12%, transparent));
+    border-color: var(--highlight-text, rgba(255, 255, 255, 0.3));
+    opacity: 1;
+}
+
+#vcp-we-wallpaper-picker .vwp-page-btn:disabled {
+    opacity: .3;
+    cursor: default;
+}
+
+#vcp-we-wallpaper-picker .vwp-page-info {
+    font-size: 11.5px;
+    opacity: .6;
+    min-width: 80px;
+    text-align: center;
+}

--- a/VCPDistributedServer/Plugin/VCPWEWallpaperUI/plugin.js
+++ b/VCPDistributedServer/Plugin/VCPWEWallpaperUI/plugin.js
@@ -1,0 +1,813 @@
+/**
+ * VCPWEWallpaperUI - Wallpaper Engine 壁纸前端插件
+ *
+ * pluginType: renderer | 由 frontend-plugin-loader.js 注入聊天窗口
+ *
+ * 结构：
+ *   §1 播放器内核     移植自 VChatDynamicWallpaper (by 辉宝)：状态机/失败跳过/断点续播
+ *                     三种呈现形态：video 视频层 / web iframe 层 / image 静态兜底层
+ *   §2 WE 数据源      fetch service 插件的 inventory（替换原 IPC 选目录）
+ *   §3 网格选择器     预览图 + 标题 + 形态徽章 + 过滤 + 搜索 + 分页（弹层）
+ *   §4 控制面板       chat-actions 紧凑面板：壁纸库/播放/静音/音量/显隐/轮播/下一张
+ *   §4.5 轮播          按当前过滤范围在可动态呈现的壁纸间定时轮换
+ *   §5 互斥协调       与辉宝插件单向抑制（同层 video 二选一）
+ *   §6 registry 暴露  供 VCPGlass 等插件联动 {active, kind, pause}
+ */
+(() => {
+    'use strict';
+
+    const ID = 'vcp-we-wallpaper-ui';
+    if (window.VCPFrontendPlugins?.get(ID)) return;
+
+    /* ═══════════════ §0 常量与状态 ═══════════════ */
+
+    const STORE_KEY = 'vcpWeWallpaper.settings.v1';
+    const DEFAULT_SERVER_BASE = 'http://127.0.0.1:5974';
+    const PAGE_SIZE = 24;                       // 选择器每页卡片数
+
+    /** 轮播可选间隔（分钟）。点按钮循环切换，比塞一个输入框更省地方。 */
+    const ROTATE_STEPS = [1, 5, 15, 30, 60];
+
+    /** web 壁纸载入超时（毫秒）。超时未 load 视为白屏，自动降级回 preview。 */
+    const WEB_LOAD_TIMEOUT_MS = 8000;
+
+    const DEFAULTS = {
+        enabled: false,          // 总开关（默认关，用户首次选壁纸后自动开）
+        wallpaperId: '',         // 当前壁纸 id（目录名，跨重启稳定）
+        wallpaperKind: 'video',  // 'video' 视频层 | 'web' iframe 层 | 'image' 静态兜底层
+        playing: true,
+        muted: true,
+        volume: 0.5,
+        currentTime: 0,          // 断点续播
+        visible: true,           // 背景层显隐（不关播放）
+        serverBase: DEFAULT_SERVER_BASE,
+        filterType: 'video',     // 选择器记忆
+        panelCollapsed: true,
+        rotate: false,           // 轮播开关
+        rotateMinutes: 5         // 轮播间隔（分钟），取值来自 ROTATE_STEPS
+    };
+
+    const state = { ...DEFAULTS, inventory: null, inventoryError: '', switching: false };
+
+    let video;               // <video id="vcp-we-wallpaper-video"> z-index:-1
+    let imageLayer;          // <div id="vcp-we-wallpaper-image"> 静态兜底层，同 z-index:-1
+    let webFrame;            // <iframe id="vcp-we-wallpaper-web"> 真动态 web 壁纸层
+    let panel;               // chat-actions 控制面板
+    let pickerOverlay;       // 全屏网格选择器
+    let rotateTimer;         // 轮播计时器
+    let webLoadTimer;        // web 壁纸白屏超时计时器
+    /** 已降级为静态的 web 壁纸 id 集合（本次会话内不再重试 iframe）。 */
+    const webFallbackIds = new Set();
+
+    /* ═══════════════ §1 播放器内核（移植自辉宝，微调命名与持久化字段） ═══════════════ */
+
+    function loadSettings() {
+        try {
+            const saved = JSON.parse(localStorage.getItem(STORE_KEY) || '{}');
+            Object.assign(state, {
+                enabled: saved.enabled === true,
+                wallpaperId: typeof saved.wallpaperId === 'string' ? saved.wallpaperId : '',
+                wallpaperKind: ['video', 'web', 'image'].includes(saved.wallpaperKind)
+                    ? saved.wallpaperKind : 'video',
+                playing: saved.playing !== false,
+                muted: saved.muted !== false,
+                volume: Number.isFinite(saved.volume) ? saved.volume : 0.5,
+                currentTime: Number.isFinite(saved.currentTime) ? saved.currentTime : 0,
+                visible: saved.visible !== false,
+                serverBase: typeof saved.serverBase === 'string' ? saved.serverBase : DEFAULT_SERVER_BASE,
+                filterType: saved.filterType || 'video',
+                panelCollapsed: saved.panelCollapsed !== false,
+                rotate: saved.rotate === true,
+                rotateMinutes: ROTATE_STEPS.includes(saved.rotateMinutes)
+                    ? saved.rotateMinutes : 5
+            });
+        } catch { /* 损坏的存储按默认处理 */ }
+    }
+
+    function saveSettings() {
+        localStorage.setItem(STORE_KEY, JSON.stringify({
+            enabled: state.enabled,
+            wallpaperId: state.wallpaperId,
+            wallpaperKind: state.wallpaperKind,
+            playing: state.playing,
+            muted: state.muted,
+            volume: state.volume,
+            currentTime: state.currentTime,
+            visible: state.visible,
+            serverBase: state.serverBase,
+            filterType: state.filterType,
+            panelCollapsed: state.panelCollapsed,
+            rotate: state.rotate,
+            rotateMinutes: state.rotateMinutes
+        }));
+    }
+
+    function capturePlayback() {
+        if (!video || !Number.isFinite(video.currentTime)) return;
+        state.currentTime = Math.max(0, video.currentTime);
+    }
+
+    /** 当前壁纸对象（inventory 已加载时）。 */
+    function currentWallpaper() {
+        return state.inventory?.wallpapers?.find(w => w.id === state.wallpaperId) || null;
+    }
+
+    /**
+     * 判定一个壁纸在聊天窗口里能以什么形态呈现：
+     *   'video' → <video> 硬解播放
+     *   'web'   → iframe 隔离渲染真实 HTML 壁纸（service 端目录托管 + WE API 垫片；
+     *             需要 main.html 的 frame-src 放通 127.0.0.1:5974）
+     *   'image' → 静态兜底，用 preview 大图铺底
+     *             （scene 封在私有 scene.pkg 里无法渲染；web 白屏降级后也走这里）
+     *   null    → 三条路都走不通，彻底不可用
+     */
+    function resolveKind(wp) {
+        if (!wp) return null;
+        if (wp.type === 'video' && wp.playable) return 'video';
+        // 本次会话内已确认白屏的 web 壁纸不再重试 iframe，直接静态
+        if (wp.type === 'web' && wp.web && !webFallbackIds?.has(wp.id)) return 'web';
+        if (wp.preview) return 'image';
+        return null;
+    }
+
+    function applyVisibility({ resume = false } = {}) {
+        const kind = resolveKind(currentWallpaper());
+        const active = Boolean(state.enabled && state.visible && kind);
+        document.body.classList.toggle('vcp-we-wallpaper-visible', active);
+
+        if (imageLayer) imageLayer.style.display = active && kind === 'image' ? 'block' : 'none';
+        if (webFrame) webFrame.style.display = active && kind === 'web' ? 'block' : 'none';
+        if (!video) return;
+
+        const videoActive = active && kind === 'video';
+        video.style.display = videoActive ? 'block' : 'none';
+        if (!videoActive && !video.paused) {
+            video.pause();
+        } else if (videoActive && resume && state.playing && video.paused) {
+            video.play().catch(() => {});
+        }
+        if (active) suppressHunbao();
+    }
+
+    /** 释放视频解码资源——非视频形态期间不该留一个 <video> 在后台占显存。 */
+    function releaseVideo() {
+        if (!video) return;
+        video.pause();
+        video.removeAttribute('src');
+        try { video.load(); } catch { /* 忽略 */ }
+    }
+
+    /** 卸下 iframe 内容（web → 其他形态切换时必须做，否则壁纸脚本继续跑满 CPU）。 */
+    function releaseWeb() {
+        if (webLoadTimer) { clearTimeout(webLoadTimer); webLoadTimer = null; }
+        if (webFrame) webFrame.removeAttribute('src');
+    }
+
+    /* ── 窗口不可见时挂起动态图层 ──────────────────────────────
+     * 最小化到托盘 / 切到别的窗口后，视频仍会满帧硬解、web 壁纸的 rAF 仍在跑，
+     * 白烧 GPU 与内存却没人看。这里在 visibilitychange 上挂起两者，
+     * 回到前台再恢复。用户主动按「隐藏背景」时不擅自恢复。
+     */
+    let suspendedWebSrc = '';
+    let suspendedByHide = false;
+
+    function suspendForHidden() {
+        if (suspendedByHide) return;
+        suspendedByHide = true;
+        if (video && !video.paused) {
+            capturePlayback();          // 先记进度，恢复时才能接上
+            video.pause();
+        }
+        const src = webFrame?.getAttribute('src');
+        if (src) {
+            suspendedWebSrc = src;
+            releaseWeb();
+        }
+    }
+
+    function resumeFromHidden() {
+        if (!suspendedByHide) return;
+        suspendedByHide = false;
+        const src = suspendedWebSrc;
+        suspendedWebSrc = '';
+        // 总开关关了或用户主动隐藏了背景，就停在挂起状态，别自作主张
+        if (!state.enabled || !state.visible) return;
+
+        const kind = resolveKind(currentWallpaper());
+        if (kind === 'video' && state.playing) {
+            video?.play().catch(() => {});
+        } else if (kind === 'web' && src && webFrame) {
+            // 挂起前已成功载入过，无需再走一遍白屏超时判定
+            webFrame.dataset.loaded = '1';
+            webFrame.src = src;
+        }
+    }
+
+    function onVisibilityChange() {
+        if (document.hidden) suspendForHidden();
+        else resumeFromHidden();
+    }
+
+    /** 静态兜底：把壁纸自带的 preview 大图铺成背景。 */
+    function showImageWallpaper(wallpaper) {
+        if (!wallpaper?.preview) return false;
+        releaseVideo();
+        releaseWeb();
+        state.wallpaperId = wallpaper.id;
+        state.wallpaperKind = 'image';
+        state.enabled = true;
+        state.currentTime = 0;
+        if (imageLayer) {
+            imageLayer.style.backgroundImage = `url("${state.serverBase + wallpaper.preview}")`;
+        }
+        applyVisibility();
+        saveSettings();
+        updatePanel();
+        return true;
+    }
+
+    /**
+     * 真动态 web 壁纸：把 service 端托管的入口页装进 iframe。
+     *
+     * 白屏保护：壁纸依赖外网资源或用了我们没垫的 WE API 时可能永远不 load。
+     * 因此设一个超时，超时未 load 就把它记入 webFallbackIds 并降级为 preview 静态图，
+     * 保证主人不会对着一片空白发懵。
+     */
+    function showWebWallpaper(wallpaper) {
+        if (!wallpaper?.web || !webFrame) return false;
+        releaseVideo();
+        if (webLoadTimer) clearTimeout(webLoadTimer);
+
+        state.wallpaperId = wallpaper.id;
+        state.wallpaperKind = 'web';
+        state.enabled = true;
+        state.currentTime = 0;
+        if (imageLayer) imageLayer.style.backgroundImage = '';
+        webFrame.dataset.loaded = '0';          // 换页必须清零，否则沿用上一张的成功标记
+        webFrame.src = state.serverBase + wallpaper.web;
+
+        webLoadTimer = setTimeout(() => {
+            webLoadTimer = null;
+            // load 事件已到过则 dataset.loaded 为 '1'，此处不再降级
+            if (webFrame?.dataset.loaded === '1') return;
+            webFallbackIds.add(wallpaper.id);
+            console.warn(`[VCPWEWallpaperUI] web 壁纸「${wallpaper.title}」载入超时，降级为静态预览`);
+            if (wallpaper.preview) showImageWallpaper(wallpaper);
+        }, WEB_LOAD_TIMEOUT_MS);
+
+        applyVisibility();
+        saveSettings();
+        updatePanel();
+        return true;
+    }
+
+    /** 统一入口：按壁纸能力分派到 video / web / image 三种呈现形态。 */
+    function selectWallpaper(wallpaper, { autoplay = true, startTime = 0 } = {}) {
+        const kind = resolveKind(wallpaper);
+        if (kind === 'video') return playWallpaper(wallpaper, { autoplay, startTime });
+        if (kind === 'web') return showWebWallpaper(wallpaper);
+        if (kind === 'image') return showImageWallpaper(wallpaper);
+        return false;
+    }
+
+    /** 播放指定视频壁纸。 */
+    function playWallpaper(wallpaper, { startTime = 0, autoplay = true } = {}) {
+        if (!wallpaper?.playable || wallpaper.type !== 'video' || state.switching) return false;
+        state.switching = true;
+        state.wallpaperId = wallpaper.id;
+        state.wallpaperKind = 'video';
+        state.enabled = true;
+        state.currentTime = Math.max(0, startTime);
+        state.playing = Boolean(autoplay);
+
+        releaseWeb();
+        if (imageLayer) imageLayer.style.backgroundImage = '';
+        video.src = state.serverBase + wallpaper.media;
+        const restoreTime = () => {
+            if (!Number.isFinite(state.currentTime) || state.currentTime <= 0) return;
+            try {
+                video.currentTime = Math.min(state.currentTime,
+                    Number.isFinite(video.duration) ? video.duration : state.currentTime);
+            } catch { /* seek 时机未到则忽略 */ }
+        };
+        video.addEventListener('loadedmetadata', restoreTime, { once: true });
+        video.load();
+        restoreTime();
+        state.switching = false;
+        applyVisibility();
+        saveSettings();
+        updatePanel();
+        if (state.playing) {
+            video.play().catch(() => { state.playing = false; saveSettings(); });
+        }
+        return true;
+    }
+
+    /** 重启后按持久化的 wallpaperId 恢复（动态/静态都恢复）。 */
+    function restoreSelection() {
+        if (!state.enabled || !state.wallpaperId) return;
+        fetchInventory().then(() => {
+            selectWallpaper(currentWallpaper(), {
+                startTime: state.currentTime,
+                autoplay: state.playing
+            });
+        }).catch(() => { /* service 未启动时静默 */ });
+    }
+
+    /* ═══════════════ §2 WE 数据源 ═══════════════ */
+
+    async function fetchInventory({ force = false } = {}) {
+        if (state.inventory && !force) return state.inventory;
+        // force 时带上 refresh=1：service 端 inventory 有 5 分钟缓存，
+        // 不打这个参数的话新订阅的壁纸最多要等一个 TTL 才出现。
+        const url = `${state.serverBase}/vcp-we-wallpaper/inventory${force ? '?refresh=1' : ''}`;
+        const res = await fetch(url, { cache: 'no-store' });
+        if (!res.ok) {
+            const err = res.status === 503
+                ? '未找到 Wallpaper Engine 安装（请确认 Steam 与 WE 已安装）'
+                : `inventory 请求失败 (HTTP ${res.status})——请确认分布式服务器已开启且 VCPWEWallpaper 插件已启用`;
+            state.inventoryError = err;
+            throw new Error(err);
+        }
+        state.inventory = await res.json();
+        state.inventoryError = '';
+        return state.inventory;
+    }
+
+    /* ═══════════════ §3 网格选择器（过滤 + 搜索 + 分页） ═══════════════ */
+
+    const TYPE_LABELS = { video: '视频', web: '网页', scene: '场景', application: '应用' };
+    const pickerState = { page: 1, hintUntil: 0 };
+
+    function openPicker() {
+        closePicker();
+        pickerState.page = 1;
+        pickerState.hintUntil = 0;
+        pickerOverlay = document.createElement('div');
+        pickerOverlay.id = 'vcp-we-wallpaper-picker';
+        pickerOverlay.innerHTML = `
+            <div class="vwp-picker-dialog" role="dialog" aria-label="选择 Wallpaper Engine 壁纸">
+                <div class="vwp-picker-head">
+                    <span class="vwp-picker-title">Wallpaper Engine 壁纸库</span>
+                    <span class="vwp-picker-count"></span>
+                    <div class="vwp-picker-filters">
+                        <button data-filter="video">视频</button>
+                        <button data-filter="web">网页</button>
+                        <button data-filter="scene">场景</button>
+                        <button data-filter="all">全部</button>
+                    </div>
+                    <input class="vwp-picker-search" type="search" placeholder="搜索标题…">
+                    <button class="vwp-picker-refresh" title="重新扫描壁纸库（新订阅的壁纸在此刷新）">${icons.refresh}</button>
+                    <button class="vwp-picker-close" title="关闭 (Esc)">✕</button>
+                </div>
+                <div class="vwp-picker-status"></div>
+                <div class="vwp-picker-grid"></div>
+                <div class="vwp-picker-foot">
+                    <button class="vwp-page-btn" data-page="prev" title="上一页">‹ 上一页</button>
+                    <span class="vwp-page-info"></span>
+                    <button class="vwp-page-btn" data-page="next" title="下一页">下一页 ›</button>
+                </div>
+            </div>`;
+        document.body.appendChild(pickerOverlay);
+
+        pickerOverlay.addEventListener('click', (e) => {
+            if (e.target === pickerOverlay) closePicker();
+        });
+        pickerOverlay.querySelector('.vwp-picker-close').addEventListener('click', closePicker);
+        pickerOverlay.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') closePicker();
+        });
+
+        const grid = pickerOverlay.querySelector('.vwp-picker-grid');
+        const statusEl = pickerOverlay.querySelector('.vwp-picker-status');
+        const countEl = pickerOverlay.querySelector('.vwp-picker-count');
+        const searchEl = pickerOverlay.querySelector('.vwp-picker-search');
+        const pagePrev = pickerOverlay.querySelector('[data-page="prev"]');
+        const pageNext = pickerOverlay.querySelector('[data-page="next"]');
+        const pageInfo = pickerOverlay.querySelector('.vwp-page-info');
+        const filterBtns = pickerOverlay.querySelectorAll('.vwp-picker-filters button');
+        const refreshBtn = pickerOverlay.querySelector('.vwp-picker-refresh');
+
+        refreshBtn.addEventListener('click', async () => {
+            refreshBtn.classList.add('busy');
+            refreshBtn.disabled = true;
+            setHint('正在重新扫描 Wallpaper Engine 库…', true);
+            const before = state.inventory?.total ?? 0;
+            try {
+                const inv = await fetchInventory({ force: true });
+                pickerState.page = 1;
+                renderGrid();
+                const delta = (inv.total ?? 0) - before;
+                setHint(delta > 0 ? `已刷新，新增 ${delta} 张壁纸`
+                    : delta < 0 ? `已刷新，减少 ${-delta} 张壁纸`
+                    : '已刷新，壁纸数量无变化');
+            } catch (err) {
+                setHint(`刷新失败：${err.message}`);
+            } finally {
+                refreshBtn.classList.remove('busy');
+                refreshBtn.disabled = false;
+            }
+        });
+
+        filterBtns.forEach(btn => btn.addEventListener('click', () => {
+            state.filterType = btn.dataset.filter;
+            pickerState.page = 1;
+            saveSettings();
+            renderGrid();
+        }));
+        searchEl.addEventListener('input', () => { pickerState.page = 1; renderGrid(); });
+        pagePrev.addEventListener('click', () => { if (pickerState.page > 1) { pickerState.page--; renderGrid(); grid.scrollTop = 0; } });
+        pageNext.addEventListener('click', () => {
+            const total = totalPages();
+            if (pickerState.page < total) { pickerState.page++; renderGrid(); grid.scrollTop = 0; }
+        });
+        searchEl.focus();
+
+        function visibleItems() {
+            const list = state.inventory?.wallpapers || [];
+            const q = searchEl.value.trim().toLowerCase();
+            return list.filter(w => {
+                if (q && !(w.title || '').toLowerCase().includes(q)) return false;
+                if (state.filterType === 'all') return true;
+                return w.type === state.filterType;
+            });
+        }
+        function totalPages() { return Math.max(1, Math.ceil(visibleItems().length / PAGE_SIZE)); }
+
+        /** 提示条：带 3 秒保护期，避免被下一次 renderGrid 立即清空。 */
+        function setHint(text, sticky = false) {
+            statusEl.textContent = text;
+            statusEl.classList.toggle('hint', Boolean(text));
+            pickerState.hintUntil = sticky ? Infinity : Date.now() + 3000;
+        }
+
+        function renderGrid() {
+            filterBtns.forEach(b => b.classList.toggle('on', b.dataset.filter === state.filterType));
+
+            if (!state.inventory) {
+                grid.innerHTML = '';
+                pageInfo.textContent = '';
+                if (Date.now() > pickerState.hintUntil) {
+                    statusEl.textContent = state.inventoryError || '正在加载库存…';
+                }
+                pagePrev.disabled = pageNext.disabled = true;
+                return;
+            }
+
+            const items = visibleItems();
+            const pages = totalPages();
+            if (pickerState.page > pages) pickerState.page = pages;
+            const start = (pickerState.page - 1) * PAGE_SIZE;
+            const slice = items.slice(start, start + PAGE_SIZE);
+
+            countEl.textContent = `${items.length} / ${state.inventory.total}`;
+            pagePrev.disabled = pickerState.page <= 1;
+            pageNext.disabled = pickerState.page >= pages;
+            pageInfo.textContent = pages > 1 ? `第 ${pickerState.page} / ${pages} 页` : '';
+
+            if (Date.now() > pickerState.hintUntil) {
+                statusEl.textContent = '';
+                statusEl.classList.remove('hint');
+            }
+
+            grid.innerHTML = '';
+            const frag = document.createDocumentFragment();
+            for (const w of slice) {
+                // div 而非 button：button 的格式化上下文与 line-clamp 有兼容怪癖，
+                // 且 div 让徽章 flex-shrink:0 生效，彻底根治标签被裁断问题。
+                const card = document.createElement('div');
+                card.role = 'button';
+                card.tabIndex = 0;
+                card.className = 'vwp-card' + (w.id === state.wallpaperId ? ' current' : '');
+                card.title = w.title;
+                const kind = resolveKind(w);
+                const typeName = TYPE_LABELS[w.type] || w.type;
+                const badgeText = kind === 'video' ? '视频 · 动态'
+                    : kind === 'web' ? '网页 · 动态'
+                    : kind === 'image' ? `${typeName} · 静态`
+                    : `${typeName} · 不可用`;
+                card.innerHTML = `
+                    <span class="vwp-card-thumb" style="background-image:url('${w.preview ? state.serverBase + w.preview : ''}')">${w.preview ? '' : '<span class="vwp-thumb-empty">无预览</span>'}</span>
+                    <span class="vwp-card-name"></span>
+                    <span class="vwp-card-badge vwp-badge-${kind || 'none'}">${badgeText}</span>`;
+                card.querySelector('.vwp-card-name').textContent = w.title;
+
+                const pick = () => {
+                    if (kind === 'video' || kind === 'web') {
+                        selectWallpaper(w, { autoplay: true });
+                        closePicker();
+                        return;
+                    }
+                    if (kind === 'image') {
+                        // 静态兜底：不关闭弹窗，让主人看到提示并能继续挑
+                        selectWallpaper(w);
+                        renderGrid();
+                        const why = w.type === 'web'
+                            ? '该网页壁纸此前载入超时，已降级'
+                            : '3D 场景壁纸无法在聊天窗口动态渲染';
+                        setHint(`已应用「${w.title}」的静态预览图 —— ${why}`);
+                        return;
+                    }
+                    setHint(`「${w.title}」既无可播放视频也无预览图，无法使用`);
+                };
+                card.addEventListener('click', pick);
+                card.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); pick(); }
+                });
+                frag.appendChild(card);
+            }
+            grid.appendChild(frag);
+        }
+
+        renderGrid();
+        fetchInventory().then(renderGrid).catch(() => renderGrid());
+    }
+
+    function closePicker() {
+        pickerOverlay?.remove();
+        pickerOverlay = null;
+    }
+
+    /* ═══════════════ §3.5 轮播 ═══════════════ */
+
+    /**
+     * 轮播候选：当前过滤范围内所有"能动态呈现"的壁纸（video + web）。
+     * 静态兜底图不参与轮播——一张不动的图轮换只会莫名闪烁。
+     */
+    function rotatePool() {
+        const list = state.inventory?.wallpapers || [];
+        const pool = list.filter(w => {
+            const k = resolveKind(w);
+            if (k !== 'video' && k !== 'web') return false;
+            if (state.filterType === 'all') return true;
+            return w.type === state.filterType;
+        });
+        // 过滤器选中的类别没有动态候选时，退回全部动态壁纸，避免轮播静默失效
+        return pool.length > 0
+            ? pool
+            : list.filter(w => ['video', 'web'].includes(resolveKind(w)));
+    }
+
+    /** 切到下一张（手动点击与定时器共用）。 */
+    function rotateNext({ manual = false } = {}) {
+        const pool = rotatePool();
+        if (pool.length === 0) return false;
+        const at = pool.findIndex(w => w.id === state.wallpaperId);
+        const next = pool[(at + 1) % pool.length];
+        // 单张时手动点击也重播一次，给出"确实响应了"的反馈
+        if (pool.length === 1 && !manual && next.id === state.wallpaperId) return false;
+        const ok = selectWallpaper(next, { autoplay: true });
+        if (ok && state.rotate) scheduleRotate();   // 手动切换后重置计时
+        return ok;
+    }
+
+    function scheduleRotate() {
+        if (rotateTimer) { clearInterval(rotateTimer); rotateTimer = null; }
+        if (!state.rotate) return;
+        const ms = Math.max(1, state.rotateMinutes) * 60 * 1000;
+        rotateTimer = setInterval(() => {
+            if (!state.enabled || document.hidden) return;   // 窗口不可见时不浪费切换
+            rotateNext();
+        }, ms);
+    }
+
+    /* ═══════════════ §4 控制面板（chat-actions 插槽，全图标化） ═══════════════ */
+
+    /* 图标统一规格：viewBox 24 / stroke 1.8 / 16px，线条风格与 VCPChat 原生按钮一致 */
+    const icons = {
+        grid: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7.5" height="7.5" rx="1.5"/><rect x="13.5" y="3" width="7.5" height="7.5" rx="1.5"/><rect x="3" y="13.5" width="7.5" height="7.5" rx="1.5"/><rect x="13.5" y="13.5" width="7.5" height="7.5" rx="1.5"/></svg>',
+        library: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="m7 15 4.2-4.2a1 1 0 0 1 1.4 0L16 14"/><circle cx="15.2" cy="9.2" r="1.3"/><path d="M21 15.5 18 13l-3 2.5"/></svg>',
+        play: '<svg data-icon="play" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M8 5.5v13l10.5-6.5z"/></svg>',
+        pause: '<svg data-icon="pause" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><rect x="7" y="5" width="3.4" height="14" rx="1"/><rect x="13.6" y="5" width="3.4" height="14" rx="1"/></svg>',
+        volume: '<svg data-icon="volume" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5.5 6.5 9H3.5v6h3L11 18.5z" fill="currentColor" stroke="none"/><path d="M14.5 9.5a3.5 3.5 0 0 1 0 5"/><path d="M17 7a7 7 0 0 1 0 10"/><path d="M19.5 4.8a10.5 10.5 0 0 1 0 14.4"/></svg>',
+        mute: '<svg data-icon="mute" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5.5 6.5 9H3.5v6h3L11 18.5z" fill="currentColor" stroke="none"/><path d="m15 9.5 5 5"/><path d="m20 9.5-5 5"/></svg>',
+        visible: '<svg data-icon="visible" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 12S6 5.5 12 5.5 21.5 12 21.5 12 18 18.5 12 18.5 2.5 12 2.5 12z"/><circle cx="12" cy="12" r="3"/></svg>',
+        hidden: '<svg data-icon="hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.4 10.4 0 0 1 12 19.5c-6 0-9.5-7.5-9.5-7.5a17.4 17.4 0 0 1 4.06-4.94M9.9 5.24A9.9 9.9 0 0 1 12 4.5c6 0 9.5 7.5 9.5 7.5a17.5 17.5 0 0 1-2.16 3.19"/><path d="m14.12 14.12a3 3 0 1 1-4.24-4.24"/><path d="m3 3 18 18"/></svg>',
+        /* 轮播：环形箭头。开启时整体高亮（.on），右键循环切换间隔 */
+        rotate: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="16" height="16" stroke-linecap="round" stroke-linejoin="round"><path d="M20 11.5A8 8 0 0 0 6.3 6.3L4 8.5"/><path d="M4 4.5v4h4"/><path d="M4 12.5a8 8 0 0 0 13.7 5.2L20 15.5"/><path d="M20 19.5v-4h-4"/></svg>',
+        /* 下一张：跳到下一首式的双三角 */
+        next: '<svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M6 5.5v13l8-6.5z"/><rect x="15.5" y="5.5" width="2.6" height="13" rx="1"/></svg>',
+        /* 重新扫描：单向回旋箭头，与轮播的双向环形区分开 */
+        refresh: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" width="15" height="15" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12a8 8 0 1 1-2.34-5.66"/><path d="M20 4.5V10h-5.5"/></svg>'
+    };
+
+    let playIcon, pauseIcon, volumeIcon, muteIcon, visibleIcon, hiddenIcon, volumeSlider;
+    let rotateBtn;
+
+    function buildPanel() {
+        const actions = document.querySelector('.chat-actions');
+        if (!actions) return;
+        panel = document.createElement('div');
+        panel.id = 'vcp-we-wallpaper-panel';
+        panel.className = state.panelCollapsed ? 'collapsed' : '';
+        panel.innerHTML = `
+            <button type="button" class="header-button vwp-toggle" data-action="collapse" title="WE 壁纸控制（点击展开 / 右键打开壁纸库）">${icons.grid}</button>
+            <div class="vwp-controls">
+                <button type="button" class="vwp-ctrl" data-action="picker" title="打开壁纸库">${icons.library}</button>
+                <button type="button" class="vwp-ctrl" data-action="play" title="暂停/播放">${icons.pause}${icons.play}</button>
+                <button type="button" class="vwp-ctrl" data-action="mute" title="静音/取消静音">${icons.volume}${icons.mute}</button>
+                <button type="button" class="vwp-ctrl" data-action="visible" title="显示/隐藏背景（不停止播放）">${icons.visible}${icons.hidden}</button>
+                <button type="button" class="vwp-ctrl vwp-rotate" data-action="rotate">${icons.rotate}</button>
+                <button type="button" class="vwp-ctrl" data-action="next" title="下一张壁纸">${icons.next}</button>
+                <div class="vwp-volume"><input type="range" min="0" max="1" step="0.05" value="${state.volume}"></div>
+            </div>`;
+        actions.appendChild(panel);
+
+        playIcon = panel.querySelector('[data-icon="play"]');
+        pauseIcon = panel.querySelector('[data-icon="pause"]');
+        volumeIcon = panel.querySelector('[data-icon="volume"]');
+        muteIcon = panel.querySelector('[data-icon="mute"]');
+        visibleIcon = panel.querySelector('[data-icon="visible"]');
+        hiddenIcon = panel.querySelector('[data-icon="hidden"]');
+        volumeSlider = panel.querySelector('.vwp-volume input');
+        rotateBtn = panel.querySelector('[data-action="rotate"]');
+
+        panel.addEventListener('click', (e) => {
+            const action = e.target.closest('[data-action]')?.dataset.action;
+            if (action === 'collapse') {
+                state.panelCollapsed = !state.panelCollapsed;
+                panel.classList.toggle('collapsed', state.panelCollapsed);
+                saveSettings();
+            } else if (action === 'picker') {
+                openPicker();
+            } else if (action === 'play') {
+                if (!state.enabled) return;
+                state.playing = video.paused;
+                saveSettings();
+                if (state.playing) video.play().catch(() => { state.playing = false; saveSettings(); });
+                else video.pause();
+                updatePanel();
+            } else if (action === 'mute') {
+                state.muted = !state.muted;
+                video.muted = state.muted;
+                saveSettings();
+                updatePanel();
+            } else if (action === 'visible') {
+                state.visible = !state.visible;
+                applyVisibility({ resume: state.visible });
+                saveSettings();
+                updatePanel();
+            } else if (action === 'rotate') {
+                state.rotate = !state.rotate;
+                saveSettings();
+                scheduleRotate();
+                updatePanel();
+            } else if (action === 'next') {
+                if (!rotateNext({ manual: true })) {
+                    console.warn('[VCPWEWallpaperUI] 当前范围内没有可轮播的动态壁纸。');
+                }
+            }
+        });
+        panel.querySelector('[data-action="collapse"]').addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+            openPicker();
+        });
+        // 右键轮播按钮：在 ROTATE_STEPS 里循环下一档间隔，省掉一个输入框
+        rotateBtn.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+            const at = ROTATE_STEPS.indexOf(state.rotateMinutes);
+            state.rotateMinutes = ROTATE_STEPS[(at + 1) % ROTATE_STEPS.length];
+            saveSettings();
+            scheduleRotate();
+            updatePanel();
+        });
+        volumeSlider.addEventListener('input', (e) => {
+            state.volume = Number(e.target.value);
+            video.volume = state.volume;
+            state.muted = state.volume === 0;
+            video.muted = state.muted;
+            saveSettings();
+            updatePanel();
+        });
+
+        video.addEventListener('play', () => { state.playing = true; saveSettings(); updatePanel(); });
+        video.addEventListener('pause', () => { capturePlayback(); saveSettings(); updatePanel(); });
+        video.addEventListener('timeupdate', capturePlayback);
+        video.addEventListener('error', () => {
+            if (!state.enabled || state.switching) return;
+            console.warn('[VCPWEWallpaperUI] 当前壁纸播放失败，可在壁纸库中更换。');
+        });
+        window.addEventListener('beforeunload', () => { capturePlayback(); saveSettings(); });
+        updatePanel();
+    }
+
+    function updatePanel() {
+        if (!panel) return;
+
+        // 静态兜底态下，播放/静音/音量三个控件没有意义，直接隐藏
+        const kind = resolveKind(currentWallpaper()) || state.wallpaperKind;
+        const isVideo = kind === 'video';
+        panel.querySelectorAll('[data-action="play"], [data-action="mute"]').forEach(btn => {
+            btn.style.display = isVideo ? '' : 'none';
+        });
+        const volumeBox = panel.querySelector('.vwp-volume');
+        if (volumeBox) volumeBox.style.display = isVideo ? '' : 'none';
+
+        const playing = video && !video.paused && !video.ended && Boolean(video.src);
+        if (playIcon) playIcon.style.display = playing ? 'none' : '';
+        if (pauseIcon) pauseIcon.style.display = playing ? '' : 'none';
+        if (volumeIcon) volumeIcon.style.display = state.muted || state.volume === 0 ? 'none' : '';
+        if (muteIcon) muteIcon.style.display = state.muted || state.volume === 0 ? '' : 'none';
+        if (visibleIcon) visibleIcon.style.display = state.visible ? '' : 'none';
+        if (hiddenIcon) hiddenIcon.style.display = state.visible ? 'none' : '';
+        if (volumeSlider) {
+            volumeSlider.value = String(state.volume);
+            volumeSlider.style.backgroundSize = `${state.volume * 100}% 100%`;
+        }
+        if (rotateBtn) {
+            rotateBtn.classList.toggle('on', state.rotate);
+            rotateBtn.title = state.rotate
+                ? `轮播已开启：每 ${state.rotateMinutes} 分钟换一张（左键关闭 / 右键调间隔）`
+                : `轮播已关闭（左键开启 / 右键调间隔，当前 ${state.rotateMinutes} 分钟）`;
+        }
+    }
+
+    /* ═══════════════ §5 互斥协调（与辉宝插件） ═══════════════ */
+
+    let hunbaoSuppressed = false;
+
+    function suppressHunbao() {
+        const hunbao = window.VCPFrontendPlugins?.get('vchat-dynamic-wallpaper');
+        if (!hunbao || hunbaoSuppressed) return;
+        hunbaoSuppressed = true;
+        try {
+            if (hunbao.state) {
+                hunbao.state.enabled = false;      // 只改内存态，不动其 localStorage
+                hunbao.state.wallpaperVisible = false;
+            }
+            hunbao.applyVisibility?.();
+        } catch (e) { console.warn('[VCPWEWallpaperUI] 暂停辉宝壁纸失败', e); }
+    }
+
+    /* ═══════════════ §6 启动 / registry / destroy ═══════════════ */
+
+    function create() {
+        imageLayer = document.createElement('div');
+        imageLayer.id = 'vcp-we-wallpaper-image';
+        document.body.prepend(imageLayer);
+
+        // web 壁纸层：iframe 提供独立文档/全局环境，壁纸自带的 body/* 选择器与
+        // jQuery 之类的全局污染都被隔在里面，碰不到聊天窗口。
+        webFrame = document.createElement('iframe');
+        webFrame.id = 'vcp-we-wallpaper-web';
+        webFrame.setAttribute('tabindex', '-1');
+        webFrame.setAttribute('aria-hidden', 'true');
+        webFrame.dataset.loaded = '0';
+        webFrame.addEventListener('load', () => {
+            if (!webFrame.getAttribute('src')) return;   // removeAttribute 触发的空 load 不算成功
+            webFrame.dataset.loaded = '1';
+            if (webLoadTimer) { clearTimeout(webLoadTimer); webLoadTimer = null; }
+        });
+        document.body.prepend(webFrame);
+
+        video = document.createElement('video');
+        video.id = 'vcp-we-wallpaper-video';
+        video.playsInline = true;
+        // 壁纸必须无缝循环：HTML5 video 默认播完停在最后一帧，会让背景"死掉"。
+        // 这与轮播是两套机制——loop 管单张无限重播，轮播管到点换下一张。
+        video.loop = true;
+        // preload 默认 auto，Chromium 会尽量把整个文件缓冲进内存。
+        // 实测本机视频壁纸平均 76MB、最大 205MB，auto 就是几百 MB 的白花。
+        // metadata 只取时长/尺寸，播放时按 Range 流式取，画面表现无差别。
+        video.preload = 'metadata';
+        video.muted = state.muted;
+        video.volume = state.volume;
+        document.body.prepend(video);
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        buildPanel();
+        restoreSelection();
+        scheduleRotate();
+    }
+
+    function pause() { video?.pause(); }
+    function resume() { if (state.enabled && state.playing) video?.play().catch(() => {}); }
+
+    function destroy() {
+        capturePlayback();
+        saveSettings();
+        if (rotateTimer) { clearInterval(rotateTimer); rotateTimer = null; }
+        if (webLoadTimer) { clearTimeout(webLoadTimer); webLoadTimer = null; }
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+        document.body.classList.remove('vcp-we-wallpaper-visible');
+        closePicker();
+        video?.remove();
+        imageLayer?.remove();
+        webFrame?.remove();
+        panel?.remove();
+        video = null; imageLayer = null; webFrame = null; panel = null; rotateBtn = null;
+    }
+
+    loadSettings();
+    create();
+    window.VCPFrontendPlugins?.register(ID, {
+        destroy,
+        pause,
+        resume,
+        openPicker,
+        next: () => rotateNext({ manual: true }),
+        setRotate(on) { state.rotate = Boolean(on); saveSettings(); scheduleRotate(); updatePanel(); },
+        state,
+        get active() { return document.body.classList.contains('vcp-we-wallpaper-visible'); },
+        get kind() { return resolveKind(currentWallpaper()); }
+    });
+})();

--- a/main.html
+++ b/main.html
@@ -4,12 +4,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- frame-src: 仅放通本机环回的 VCPDistributedServer(5974)，供 VCPWEWallpaper
+         插件以 iframe 隔离渲染 Wallpaper Engine 的 web 类型壁纸。不开放任何外网源。 -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data:;
                    script-src 'self' 'unsafe-inline';
                    style-src 'self' 'unsafe-inline' https:;
                    img-src * data: file: blob:;
                    media-src * data: file: blob:;
                    font-src *;
+                   frame-src 'self' http://127.0.0.1:5974 http://localhost:5974;
                    connect-src * ws: wss:;">
     <title>VCPChat</title>
     <link rel="stylesheet" href="vendor/fontawesome-v6/fontawesome-v6.css">


### PR DESCRIPTION
双插件架构：VCPWEWallpaper(service) 定位并托管本机 WE 壁纸库，VCPWEWallpaperUI(renderer) 负责壁纸库选择器与播放器。

三类壁纸的呈现：video 走 <video loop preload=metadata> 直接播放；web 走 iframe 隔离渲染 + WE JS API 垫片（属性回喂/静音频谱）；scene 无法在窗口内渲染，降级为静态 preview。

主程序仅一处改动：main.html 的 CSP 增加 frame-src 放通本机环回 5974，不开放任何外网源。

service 端 4 条路由全部只读，/web/:token/* 做了 path traversal 与软链逃逸校验，token 由绝对路径派生、不接受客户端构造。

含视频轮播、断点续播、窗口不可见时挂起（visibilitychange 暂停视频/卸载 iframe）、壁纸库手动重新扫描（?refresh=1 绕过 5 分钟缓存）。