### PR TITLE
fix(prompt): 模式切换按钮在首次交互后失效

### DIFF
--- a/Promptmodules/prompt-manager.js
+++ b/Promptmodules/prompt-manager.js
@@ -352,7 +352,12 @@ class PromptManager {
       clearTimeout(this.rightClickTimer);
       this.rightClickTimer = null;
     }
+  }
 
+  /**
+   * 解绑容器事件监听（仅销毁时调用；正常运行期间解绑会导致模式按钮失效）
+   */
+  unbindContainerEvents() {
     this.boundContainerListeners.forEach(([type, handler]) => {
       this.containerElement?.removeEventListener(type, handler);
     });
@@ -528,15 +533,15 @@ class PromptManager {
     }
 
     // 2. 清理计时器
-    if (this.rightClickTimer) {
-      clearTimeout(this.rightClickTimer);
-      this.rightClickTimer = null;
-    }
+    this.cancelRightClickTimer();
 
-    // 3. 清理 DOM 引用
+    // 3. 解绑容器事件监听
+    this.unbindContainerEvents();
+
+    // 4. 清理 DOM 引用
     this.containerElement = null;
 
-    // 4. 重置模块引用
+    // 5. 重置模块引用
     this.originalModule = null;
     this.modularModule = null;
     this.presetModule = null;


### PR DESCRIPTION
## 问题

点击「模块」等任一模式按钮后，再也无法切回「文本」等其他模式——按钮完全无响应。

## 根因

`83a7b5fe` 为解决监听器泄漏，把解绑容器监听的逻辑放进了 `cancelRightClickTimer()`，但该函数在 `mouseout`/`mouseup` 时即被调用。于是首次点击模式按钮后，鼠标一旦移出按钮，click/dblclick/contextmenu 监听即被全部拆除，后续所有模式切换失效。

## 修复

- `cancelRightClickTimer()` 回归单一职责，只清长按计时器；
- 解绑职责拆分为 `unbindContainerEvents()`，仅在 `destroy()` 中调用，防泄漏意图不变。

## 验证

- `node --check` 语法通过；
- 核对全部 4 处调用点（mouseup/mouseout/startRightClickTimer/destroy），正常运行期间不再有路径会拆除监听；
- 实测：模块/文本/预制三个模式反复切换正常。