### PR TITLE
fix(ui): constrain chat bubble visual effects

### DIFF
--- a/styles/chat.css
+++ b/styles/chat.css
@@ -265,8 +265,18 @@ body.light-theme #moon-icon {
     max-width: var(--chat-bubble-max-width, 82%); /* Default width when sidebar is closed */
     word-wrap: break-word;
     line-height: 1.5;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+    /* Bubble surfaces are defined by their clipped fill and border.  A
+     * generic outer shadow here creates a dark halo on translucent themes
+     * (especially while the list is scrolling), so keep emphasis inside the
+     * rounded boundary instead. */
+    box-shadow: none;
     position: relative;
+    /* Keep animated/colored descendants and backdrop compositing inside the
+     * rounded bubble.  Without an explicit clipping/isolation boundary,
+     * Chromium may paint translucent bubble layers into the surrounding
+     * scrolling surface during fast scrolls. */
+    overflow: hidden;
+    isolation: isolate;
     backdrop-filter: blur(8px); /* Keep if desired */
     -webkit-backdrop-filter: blur(8px); /* Keep if desired */
     /* Theme backgrounds can be multi-layer color-mix() gradients over a

--- a/styles/themes/themes纸墨与机芯.css
+++ b/styles/themes/themes纸墨与机芯.css
@@ -171,9 +171,7 @@ body.light-theme {
     border: 1px solid rgba(242, 169, 0, 0.24) !important;
     border-right: 3px solid rgba(242, 169, 0, 0.82) !important;
     border-radius: 14px 4px 14px 14px !important;
-    box-shadow:
-        0 7px 22px rgba(0, 0, 0, 0.20),
-        inset 0 1px 0 rgba(255, 255, 255, 0.035) !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035) !important;
 }
 
 /* Dark assistant bubble: graphite equipment plate with status edge. */
@@ -183,9 +181,7 @@ body.light-theme {
     border: 1px solid rgba(59, 68, 73, 0.76) !important;
     border-left: 3px solid rgba(118, 191, 174, 0.68) !important;
     border-radius: 4px 14px 14px 14px !important;
-    box-shadow:
-        0 8px 26px rgba(0, 0, 0, 0.25),
-        inset 0 1px 0 rgba(255, 255, 255, 0.035) !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035) !important;
 }
 
 /* Tool output behaves like a compact operational status plate. */
@@ -236,9 +232,7 @@ body.light-theme .message-item.user .md-content {
     ) !important;
     border: 1px solid rgba(185, 72, 50, 0.22) !important;
     border-right: 3px solid rgba(185, 72, 50, 0.82) !important;
-    box-shadow:
-        0 7px 22px rgba(27, 33, 31, 0.085),
-        inset 0 1px 0 rgba(255, 255, 255, 0.78) !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78) !important;
 }
 
 /* Warm paper assistant card with strong long-reading stability. */
@@ -251,9 +245,7 @@ body.light-theme .message-item.assistant .md-content {
     ) !important;
     border: 1px solid rgba(210, 203, 192, 0.88) !important;
     border-left: 3px solid rgba(33, 103, 92, 0.72) !important;
-    box-shadow:
-        0 8px 25px rgba(27, 33, 31, 0.09),
-        inset 0 1px 0 rgba(255, 255, 255, 0.82) !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.82) !important;
 }
 
 body.light-theme .tool-bubble {
@@ -278,16 +270,11 @@ body.light-theme .title-bar-button:hover {
 @keyframes vcpOperationalPulse {
     0%, 100% {
         border-left-color: rgba(118, 191, 174, 0.56);
-        box-shadow:
-            0 8px 26px rgba(0, 0, 0, 0.25),
-            inset 0 1px 0 rgba(255, 255, 255, 0.035);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
     }
     50% {
         border-left-color: rgba(118, 191, 174, 0.82);
-        box-shadow:
-            0 8px 28px rgba(0, 0, 0, 0.27),
-            -3px 0 14px rgba(118, 191, 174, 0.075),
-            inset 0 1px 0 rgba(255, 255, 255, 0.045);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.045);
     }
 }
 


### PR DESCRIPTION
## 问题
部分主题下聊天气泡会出现明显的外部灰黑光晕。

## 原因
聊天气泡公共样式和纸墨与机芯主题分别声明了外部 `box-shadow`。主题规则使用 `!important`，会覆盖公共样式；同时气泡缺少明确的圆角裁剪和合成隔离边界。

## 修复
- 移除普通聊天气泡的通用外部阴影。
- 移除纸墨与机芯主题用户/助手气泡及流式脉冲的外部阴影。
- 为气泡增加 `overflow: hidden` 和 `isolation: isolate`，将内部渐变、透明层和材质合成限制在圆角边界内。
- 保留内部高光、主题边框和强调色侧边。

## 验证
- `git diff --check` 通过。
- 已在 Windows 工作树中重新应用主题并确认规则来自实际加载的主题文件。
