### PR TITLE
fix: 补全 applyUserMessageLayoutState 缺失的 import，修复保存全局设置报错

### DIFF
--- a/modules/renderer/mainChatSettingsPresentationOwner.js
+++ b/modules/renderer/mainChatSettingsPresentationOwner.js
@@ -1,3 +1,5 @@
+import { applyUserMessageLayoutState } from './domBuilder.js';
+
 /** Owns global-settings DOM projection, chat layout controls and presentation bindings. */
 export function createMainChatSettingsPresentationOwner({
     documentRef,


### PR DESCRIPTION
## 问题

在全局设置中点击「保存」时，必现如下报错（设置本身已写入，但保存后的界面即时应用被中断）：

```
设置已保存，但界面应用失败:
applyUserMessageLayoutState is not defined
```

## 根因

`2a259e39f` 在 `modules/renderer/mainChatSettingsPresentationOwner.js` 的 `applyUserChatBubbleUiState()` 中新增了对 `applyUserMessageLayoutState()` 的调用，但该文件没有任何 import 语句，模块作用域内不存在此标识符，保存设置后刷新用户气泡布局时抛出 `ReferenceError`。

## 修复

补全缺失的 import：

```js
import { applyUserMessageLayoutState } from './domBuilder.js';
```

`domBuilder.js` 为零依赖的叶子模块，不存在循环引用风险。

## 验证

- `node --check` 通过；
- 保存全局设置不再弹出该警告，用户气泡布局/字体/气泡宽度等即时应用恢复正常。