### PR TITLE
feat: 恢复「开启Agent自定义气泡主题」全局开关

### DIFF
--- a/Groupmodules/groupchat.js
+++ b/Groupmodules/groupchat.js
@@ -214,6 +214,7 @@ async function getVcpGlobalSettings() {
                 vcpApiKey: settings.vcpApiKey,
                 userName: settings.userName || '用户',
                 topicSummaryModel: settings.topicSummaryModel,
+                enableAgentBubbleTheme: settings.enableAgentBubbleTheme === true,
                 // 添加净化器相关配置
                 enableContextSanitizer: settings.enableContextSanitizer === true,
                 contextSanitizerDepth: settings.contextSanitizerDepth,
@@ -229,6 +230,7 @@ async function getVcpGlobalSettings() {
         vcpApiKey: null,
         userName: '用户',
         topicSummaryModel: null,
+        enableAgentBubbleTheme: false,
         // 添加净化器默认值
         enableContextSanitizer: false,
         contextSanitizerDepth: 2,
@@ -785,6 +787,22 @@ ${canvasData.errors || 'No errors'}
               
             console.log(`[GroupChat Context Sanitizer] Messages processed successfully`);
         }
+        // --- Agent Bubble Theme Injection ---
+        if (globalVcpSettings.enableAgentBubbleTheme) {
+            let systemMsgIndex = messagesForAI.findIndex(m => m.role === 'system');
+            if (systemMsgIndex === -1) {
+                messagesForAI.unshift({ role: 'system', content: '' });
+                systemMsgIndex = 0;
+            }
+
+            const injection = '为你在群聊中构建独特的个性气泡，输出规范要求：{{VarDivRender}}';
+            if (!messagesForAI[systemMsgIndex].content.includes(injection)) {
+                messagesForAI[systemMsgIndex].content += `\n\n${injection}`;
+                messagesForAI[systemMsgIndex].content = messagesForAI[systemMsgIndex].content.trim();
+            }
+        }
+        // --- End of Injection ---
+
         const modelResolution = resolveEffectiveModel(groupConfig, agentConfig);
         if (!globalVcpSettings.vcpUrl) {
             const errorMsg = `Agent ${agentName} (${agentId}) 无法响应：VCP URL 未配置。`;
@@ -1341,6 +1359,22 @@ ${canvasData.errors || 'No errors'}
           
         console.log(`[GroupChat Context Sanitizer] Messages processed successfully`);
     }
+    // --- Agent Bubble Theme Injection ---
+    if (globalVcpSettings.enableAgentBubbleTheme) {
+        let systemMsgIndex = messagesForAI.findIndex(m => m.role === 'system');
+        if (systemMsgIndex === -1) {
+            messagesForAI.unshift({ role: 'system', content: '' });
+            systemMsgIndex = 0;
+        }
+
+        const injection = '为你在群聊中构建独特的个性气泡，输出规范要求：{{VarDivRender}}';
+        if (!messagesForAI[systemMsgIndex].content.includes(injection)) {
+            messagesForAI[systemMsgIndex].content += `\n\n${injection}`;
+            messagesForAI[systemMsgIndex].content = messagesForAI[systemMsgIndex].content.trim();
+        }
+    }
+    // --- End of Injection ---
+
     const modelResolution = resolveEffectiveModel(groupConfig, agentConfig);
     if (!globalVcpSettings.vcpUrl) {
         const errorMsg = `Agent ${agentName} (${invitedAgentId}) 无法响应（邀请）：VCP URL 未配置。`;

--- a/main.html
+++ b/main.html
@@ -1371,6 +1371,15 @@
                                         <div class="settings-subsection-title">聊天字体与气泡</div>
                                         <p class="settings-subsection-description">调整聊天正文、代码、场景字体和 Agent 气泡外观。</p>
                                     </div>
+                                    <div class="form-group-inline"
+                                        style="justify-content: space-between; align-items: center; margin-bottom: 15px;">
+                                        <label for="enableAgentBubbleTheme">开启Agent自定义气泡主题</label>
+                                        <label class="switch">
+                                            <input type="checkbox" id="enableAgentBubbleTheme" name="enableAgentBubbleTheme"
+                                                checked>
+                                            <span class="slider round"></span>
+                                        </label>
+                                    </div>
                                     <div class="settings-form-group" id="chatFontSettingsGroup" style="margin-top: 18px;">
                                         <label for="chatFontPreset">聊天字体</label>
                                         <select id="chatFontPreset" name="chatFontPreset">

--- a/modules/global-settings-manager.js
+++ b/modules/global-settings-manager.js
@@ -91,6 +91,7 @@ async function saveGlobalSettings(deps, settingsForm) {
         networkNotesPaths: networkNotesPaths,
         sidebarWidth: refs.globalSettings.get().sidebarWidth,
         notificationsSidebarWidth: refs.globalSettings.get().notificationsSidebarWidth,
+        enableAgentBubbleTheme: document.getElementById('enableAgentBubbleTheme')?.checked === true,
         enableSmoothStreaming: document.getElementById('enableSmoothStreaming').checked,
         showHomeVisualBrand: document.getElementById('showHomeVisualBrand')?.checked !== false,
         showHomeVisualTagline: document.getElementById('showHomeVisualTagline')?.checked !== false,

--- a/modules/ipc/chatHandlers.js
+++ b/modules/ipc/chatHandlers.js
@@ -1016,6 +1016,27 @@ function initialize(mainWindow, context) {
                 }
             }
 
+            // --- Agent Bubble Theme Injection ---
+            try {
+                // Settings already loaded, just check the flag
+                if (settings.enableAgentBubbleTheme) {
+                    let systemMsgIndex = messages.findIndex(m => m.role === 'system');
+                    if (systemMsgIndex === -1) {
+                        messages.unshift({ role: 'system', content: '' });
+                        systemMsgIndex = 0;
+                    }
+
+                    const injection = '输出规范要求：{{VarDivRender}}';
+                    if (!messages[systemMsgIndex].content.includes(injection)) {
+                        messages[systemMsgIndex].content += `\n\n${injection}`;
+                        messages[systemMsgIndex].content = messages[systemMsgIndex].content.trim();
+                    }
+                }
+            } catch (e) {
+                console.error('[Agent Bubble Theme] Failed to inject bubble theme info:', e);
+            }
+            // --- End of Injection ---
+
             // --- VCP Thought Chain Stripping ---
             try {
                 // 默认不注入元思考链，除非明确开启

--- a/modules/messageRenderer.js
+++ b/modules/messageRenderer.js
@@ -3299,7 +3299,7 @@ async function renderPostProcessedHtml(contentDiv, rawHtml, options = {}) {
     if (!isStillValid()) return;
     // stable block 会在终态被规范整树替换；提前执行脚本会把 rAF、timer 和事件
     // 绑定到即将销毁的局部 DOM。CSS 动画不依赖此处理器，可继续即时播放。
-    if (processScripts) {
+    if (processScripts && settings.enableAgentBubbleTheme === true) {
         processAnimationsInContent(contentDiv, visibilityOptimizer);
         if (!isStillValid()) {
             cleanupAnimationsInContent(contentDiv);

--- a/modules/renderer/mainChatSettingsPresentationOwner.js
+++ b/modules/renderer/mainChatSettingsPresentationOwner.js
@@ -621,6 +621,7 @@ export function createMainChatSettingsPresentationOwner({
             }
         }
 
+        safeCheck('enableAgentBubbleTheme', globalSettings.enableAgentBubbleTheme !== false);
         safeCheck('enableSmoothStreaming', globalSettings.enableSmoothStreaming === true);
         safeCheck('showHomeVisualBrand', globalSettings.showHomeVisualBrand !== false);
         safeCheck('showHomeVisualTagline', globalSettings.showHomeVisualTagline !== false);

--- a/modules/renderer/streamManager.js
+++ b/modules/renderer/streamManager.js
@@ -2415,7 +2415,7 @@ async function projectStreamTerminalInternal(messageId, finishReason, context, f
                     }, 0);
 
                     // Step 3: Process animations, scripts, and 3D scenes
-                    if (refs.processAnimationsInContent) {
+                    if (refs.processAnimationsInContent && refs.globalSettingsRef?.get?.().enableAgentBubbleTheme === true) {
                         refs.processAnimationsInContent(contentDiv);
                     }
                 }

--- a/modules/utils/appSettingsManager.js
+++ b/modules/utils/appSettingsManager.js
@@ -148,6 +148,7 @@ class SettingsManager extends EventEmitter {
             filterRules: [],
             toolAutoApprovalEnabled: false,
             toolAutoApprovalRules: [],
+            enableAgentBubbleTheme: false,
             enableSmoothStreaming: false,
             uiMode: 'next',
             showHomeVisualBrand: true,


### PR DESCRIPTION
## 背景

`0137f925` 移除了全局设置中的「开启Agent自定义气泡主题」开关，同时删掉了渲染与注入侧的条件判断，该功能变为**强制开启**且用户没有任何关闭入口。实际上社区用户对此有真实的关闭需求（例如不需要 Agent 输出 DIV 气泡、不希望 system prompt 被注入 `{{VarDivRender}}` 规范、或希望停用气泡内脚本/动画执行）。

本 PR 将该开关连同其完整控制链路按 `0137f925` 之前的原样恢复，用户可在 设置 → 聊天字体与气泡 小节自行开关。

## 改动内容

| 环节 | 文件 | 说明 |
|---|---|---|
| UI | `main.html` | 恢复开关（位置在原处：「聊天字体与气泡」小节顶部） |
| 默认值 | `modules/utils/appSettingsManager.js` | `enableAgentBubbleTheme: false` |
| 保存 | `modules/global-settings-manager.js` | 保存时收集 checkbox 状态 |
| 回填 | `modules/renderer/mainChatSettingsPresentationOwner.js` | 打开设置面板时回显当前值 |
| 渲染 | `modules/messageRenderer.js` `modules/renderer/streamManager.js` | 关闭时不再执行气泡内动画/脚本/3D（`processAnimationsInContent`） |
| 注入（单聊） | `modules/ipc/chatHandlers.js` | 关闭时不再向 system prompt 注入 `{{VarDivRender}}` 输出规范 |
| 注入（群聊） | `Groupmodules/groupchat.js` | 同上，恢复设置字段读取与两处注入点 |

默认值与删除前一致（`false`）；已有 settings.json 中存留 `enableAgentBubbleTheme` 键的老用户升级后直接按原值生效。

## 验证

- 全部改动文件 `node --check` 通过；
- 实机验证：开 → Agent 气泡动画/注入生效；关 → 渲染与注入全链路停止，settings.json 正确落盘。

## 备注

保存全局设置时还有一个与本 PR 无关的 `applyUserMessageLayoutState is not defined` 报错，见 #184，两个 PR 相互独立、可分别合并。