### PR TITLE
fix(ci): 修复 chat_kernel_ui.yml 裸标量中冒号空格导致的 YAML 解析失败

### DIFF
--- a/.github/workflows/chat_kernel_ui.yml
+++ b/.github/workflows/chat_kernel_ui.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Publish Chat evidence summary
         env:
           CHAT_EVIDENCE_MANIFEST: ${{ runner.temp }}/chat-evidence-manifest.json
-        run: node -e "const fs=require('fs'); const m=JSON.parse(fs.readFileSync(process.env.CHAT_EVIDENCE_MANIFEST,'utf8')); fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, ['## Chat evidence','', '- status: `'+m.status+'`','- contracts/events: `'+m.checks.contracts+'/'+m.checks.generatedEvents+'`','- dynamic sites: registered `'+m.checks.dynamicSites.registered+'`, undiscovered `'+m.checks.dynamicSites.undiscovered+'`','- artifact plane: `'+m.checks.artifactPlane+'`','- packaged artifact: `'+m.checks.packagedArtifact+'`','- Windows matrix: `'+m.checks.windowsMatrix+'`','- manual soak: `'+m.checks.manualSoak+'`','- real Electron: `'+m.checks.realElectronSequence+'` (manual/platform evidence remains separate)',''].join('\\n'));"
+        run: |
+          node -e "const fs=require('fs'); const m=JSON.parse(fs.readFileSync(process.env.CHAT_EVIDENCE_MANIFEST,'utf8')); fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, ['## Chat evidence','', '- status: `'+m.status+'`','- contracts/events: `'+m.checks.contracts+'/'+m.checks.generatedEvents+'`','- dynamic sites: registered `'+m.checks.dynamicSites.registered+'`, undiscovered `'+m.checks.dynamicSites.undiscovered+'`','- artifact plane: `'+m.checks.artifactPlane+'`','- packaged artifact: `'+m.checks.packagedArtifact+'`','- Windows matrix: `'+m.checks.windowsMatrix+'`','- manual soak: `'+m.checks.manualSoak+'`','- real Electron: `'+m.checks.realElectronSequence+'` (manual/platform evidence remains separate)',''].join('\\n'));"
 
       - name: Upload Chat evidence manifest
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 问题

自 `ddbd3c2c` 起，所有基于 main 的 PR 均报：

```
Invalid workflow file: .github/workflows/chat_kernel_ui.yml#L70
You have an error in your yaml syntax on line 70
```

## 根因

`Publish Chat evidence summary` 步骤的 `run` 值是一条**裸标量**（以 `node` 开头，双引号位于标量中部，不构成 YAML quoting）。内联 JS 里的 `'- status: '` 含**冒号+空格**，YAML 将其解析为新 mapping 的键，第 70 行第 211 列抛出 `mapping values are not allowed here`。

## 修复

将该 `run` 改为块标量 `|`，`node -e` 载荷逐字符保持原样（728 字符比对无差异），执行语义不变：

```yaml
run: |
  node -e "const fs=..."
```

## 验证

- `yaml.safe_load` 解析通过；
- 块标量解出的命令与原裸标量内容逐字符一致。
