### PR TITLE
fix(flowlock): 保留续写历史的时间戳绑定

### DIFF
--- a/Flowlockmodules/flowlock-integration.js
+++ b/Flowlockmodules/flowlock-integration.js
@@ -54,6 +54,25 @@ function normalizeFlowlockHeartbeatPrompt(prompt) {
     return `${FLOWLOCK_SYSTEM_PROMPT_PREFIX}${normalized ? ` ${normalized}` : ''}`;
 }
 
+function attachFlowlockTimestampMetadata(vcpMessage, historyMessage) {
+    if (
+        !historyMessage?.id
+        || typeof historyMessage.timestamp !== 'number'
+        || !Number.isFinite(historyMessage.timestamp)
+    ) {
+        return vcpMessage;
+    }
+
+    return {
+        ...vcpMessage,
+        __vcpchatTimestampMeta: {
+            messageId: historyMessage.id,
+            role: historyMessage.role,
+            timestamp: historyMessage.timestamp
+        }
+    };
+}
+
 /**
  * 按指定 Agent/Topic 执行后台续写
  * 不依赖当前 UI 状态，直接从文件系统读取历史记录
@@ -138,7 +157,10 @@ async function continueWritingForContext(params) {
                     .join('\n');
             }
         }
-        return { role: msg.role, content: currentMessageTextContent };
+        return attachFlowlockTimestampMetadata(
+            { role: msg.role, content: currentMessageTextContent },
+            msg
+        );
     }));
 
     // 心跳仍使用 user role 进入现有续写链路，但内容前缀使后端可可靠识别其系统来源。

--- a/tests/flowlock-timestamp-bindings.test.js
+++ b/tests/flowlock-timestamp-bindings.test.js
@@ -1,0 +1,103 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadFlowlockIntegration({ history, onSend }) {
+    let continueWritingForContext;
+    const chatAPI = {
+        getChatHistory: async () => history,
+        getAgentConfig: async () => ({
+            name: 'Nova',
+            model: 'test-model',
+            streamOutput: true,
+            systemPrompt: 'You are Nova.'
+        }),
+        tavernGetRules: async () => ({ success: true, store: { rules: [] } }),
+        sendToVCP: async (...args) => {
+            onSend(...args);
+            return {};
+        }
+    };
+    const window = {
+        chatAPI,
+        electronAPI: chatAPI,
+        VCPMainChatState: {
+            snapshot: () => ({ selectedItem: { id: 'agent-1' }, topicId: 'topic-1' })
+        },
+        flowlockManager: {
+            initialize: ({ continueWritingForContext: continuation }) => {
+                continueWritingForContext = continuation;
+            },
+            recoverPendingRequests: async () => {},
+            cleanup: () => {}
+        },
+        addEventListener: () => {}
+    };
+    const document = {
+        getElementById: () => null,
+        addEventListener: () => {}
+    };
+    const context = vm.createContext({
+        console,
+        document,
+        window,
+        setTimeout,
+        clearTimeout,
+        Promise
+    });
+    const source = fs.readFileSync(
+        path.join(__dirname, '..', 'Flowlockmodules', 'flowlock-integration.js'),
+        'utf8'
+    );
+    vm.runInContext(source, context, { filename: 'flowlock-integration.js' });
+    window.initializeFlowlockIntegration({
+        chatManager: { loadChatHistory: async () => {}, isReady: () => true },
+        historyMutationAuthority: { replace: async () => {} },
+        settings: {
+            get: () => ({
+                vcpServerUrl: 'http://127.0.0.1:6005/v1/chat/completions',
+                vcpApiKey: 'test-key',
+                continueWritingPrompt: '请继续'
+            })
+        }
+    });
+
+    return async () => continueWritingForContext({
+        agentId: 'agent-1',
+        topicId: 'topic-1',
+        messageId: 'flowlock-request-1'
+    });
+}
+
+test('Flowlock preserves history timestamps for OneRing and ends with a user heartbeat', async () => {
+    const history = [
+        { id: 'user-1', role: 'user', content: '开始任务', timestamp: 1000 },
+        { id: 'assistant-1', role: 'assistant', content: '第一阶段完成', timestamp: 2000 },
+        { id: 'legacy', role: 'assistant', content: '旧消息没有合法时间戳', timestamp: '3000' }
+    ];
+    let sentMessages;
+    const run = loadFlowlockIntegration({
+        history,
+        onSend: (_url, _key, messages) => {
+            sentMessages = messages;
+        }
+    });
+
+    await run();
+
+    assert.deepEqual(JSON.parse(JSON.stringify(sentMessages[1].__vcpchatTimestampMeta)), {
+        messageId: 'user-1',
+        role: 'user',
+        timestamp: 1000
+    });
+    assert.deepEqual(JSON.parse(JSON.stringify(sentMessages[2].__vcpchatTimestampMeta)), {
+        messageId: 'assistant-1',
+        role: 'assistant',
+        timestamp: 2000
+    });
+    assert.equal(sentMessages[3].__vcpchatTimestampMeta, undefined);
+    assert.equal(sentMessages.at(-1).role, 'user');
+    assert.match(sentMessages.at(-1).content, /^\[系统提示:\] 请继续$/);
+});


### PR DESCRIPTION
## 问题

Flowlock 构造续写请求时会把历史消息重新映射为只有 role/content 的对象，丢失 VCPChat 已持久化的消息 id 和 timestamp。主进程因而无法生成 vcpchatExtensions.messageTimestampBindings，OneRing 只能按服务端时间推断消息顺序，某些长会话最终会被重排为 assistant 结尾，上游随后返回 400：Requests ending with a model turn are not supported.

## 修复

- 为 Flowlock 历史消息保留内部 __vcpchatTimestampMeta，复用现有 IPC 的时间戳绑定协议。
- 仅接受有限数值 timestamp；旧数据或异常时间戳继续走原有回退路径。
- 保持续写心跳 [系统提示:] 请继续 为最后一条 user 消息。
- 新增 Flowlock 请求组装回归测试，覆盖有效绑定、异常时间戳和末尾 user 心跳。

## 验证

- node --test tests/flowlock-timestamp-bindings.test.js tests/single-chat-request-orchestrator.test.js tests/main-chat-flowlock-owner.test.mjs：8/8 通过。
- node --check Flowlockmodules/flowlock-integration.js：通过。
- git diff --check：通过。
- 实际重启 VCPChat 并恢复 Flowlock：后端请求从 timestampBindings=0 变为非零；最终上下文 lastRole=user；上游返回 [DONE]，后续续写继续运行。

## 已知检查

npm run guard:next-delta 仍因 modules/renderer/messageContextMenu.js 的既有断言失败；该文件不在本 PR diff 中，本修复未扩大范围处理。