### PR TITLE
fix(chat): restore hasUserParticipation declaration swallowed by unclosed JSDoc comment (fixes ReferenceError on unread-count IPC)

### DIFF
--- a/modules/ipc/chatHandlers.js
+++ b/modules/ipc/chatHandlers.js
@@ -1397,14 +1397,18 @@ function initialize(mainWindow, context) {
     }
 
     /**
-     function hasUserParticipation(history) {
-         return Array.isArray(history) && history.some(message =>
-             message &&
-             message.role === 'user' &&
-             message.isThinking !== true
-         );
-     }
- 
+     * 判断话题历史中是否出现过用户参与（用户真实消息）。
+     * @param {Array} history - 消息历史
+     * @returns {boolean}
+     */
+    function hasUserParticipation(history) {
+        return Array.isArray(history) && history.some(message =>
+            message &&
+            message.role === 'user' &&
+            message.isThinking !== true
+        );
+    }
+
      /**
       * Part C: 计算单个话题的未读消息数
       * @param {Object} topic - 话题对象


### PR DESCRIPTION
## Bug: `hasUserParticipation` 函数声明被 JSDoc 注释吞掉，导致未读计数 IPC 抛 ReferenceError

### 问题描述 / Problem

启动应用后，每次未读话题计数 IPC（`get-unread-topic-counts`）触发时，控制台都会打印：

```
读取 history.json 失败: ...\topics\topic_xxx\history.json
ReferenceError: hasUserParticipation is not defined
    at calculateTopicUnreadCount (modules/ipc/chatHandlers.js:1421:34)
    at modules/ipc/chatHandlers.js:1447:60
```

### 错误缘由 / Root Cause

`modules/ipc/chatHandlers.js` 中 `hasUserParticipation` 的**函数声明整段被它前面的 JSDoc 注释吞掉了**。函数体本应带 ` * ` 行前缀的注释格式变成了裸代码行，而开头只有 `/**`、没有正常闭合的 ` * ` 行，导致从 `/**` 到下一个 `/**` 之间的全部内容都被 JS 解析为**注释**——函数在运行时根本不存在。

修复前（节选，chatHandlers.js L1399-L1407）：

```js
    /**
     function hasUserParticipation(history) {        // ← 这行及以下全部在注释里
         return Array.isArray(history) && history.some(message =>
             message &&
             message.role === 'user' &&
             message.isThinking !== true
         );
     }
                                                     // ← 注释到这里都没有闭合
    /**
     * Part C: 计算单个话题的未读消息数
```

而 `calculateTopicUnreadCount()`（L1421）仍在调用这个函数：

```js
    (topic.unreadSource === 'manual' || !hasUserParticipation(history))
```

函数不存在 → 每次遍历话题计算未读数都抛 `ReferenceError`。

### 引入位置 / Introduced In

该写法首次出现在上游 commit `068d8035`（2026-08-07，“修复未读话题无法置顶”，chatHandlers.js +88 行改动）中。此后上游 main 一直带着这个 bug，至今未修——当前 upstream/main 的 L1400 仍是被注释吞掉的声明。

### 影响 / Impact

- 未读话题的小圆点/计数显示不正确（每个话题的 history.json 读取都在 catch 里失败）
- 聊天主流程不受影响，但控制台持续刷错误日志，且掩盖了其他真实读取错误

### 修复内容 / Fix

把函数声明从注释中恢复出来，并补全规范的 JSDoc 头（+12 / -8 行，仅此一处）：

```js
    /**
     * 判断话题历史中是否出现过用户参与（用户真实消息）。
     * @param {Array} history - 消息历史
     * @returns {boolean}
     */
    function hasUserParticipation(history) {
        return Array.isArray(history) && history.some(message =>
            message &&
            message.role === 'user' &&
            message.isThinking !== true
        );
    }
```

### 验证 / Verification

- `node --check modules/ipc/chatHandlers.js` 通过
- 提取三个相关函数（`countUnreadMessages` / `hasUserParticipation` / `calculateTopicUnreadCount`）单独跑行为测试，8/8 通过：
  - 含用户消息 → `true`；纯助手消息 → `false`；空数组 → `false`
  - 计数优先：纯助手 2 条 + 手动未读 → 返回 2
  - 手动未读小点保留（用户已参与）→ 返回 -1
  - 旧 unread 标记在用户参与后失效 → 返回 0
- 实际启动后 `读取 history.json 失败 ... ReferenceError` 日志消失

---

This restores the `hasUserParticipation` function declaration, which was accidentally absorbed into the preceding unclosed JSDoc comment block (introduced in 068d8035). The function never existed at runtime, so every unread-count IPC tick threw `ReferenceError: hasUserParticipation is not defined` at chatHandlers.js:1421. Only comment/whitespace lines around the declaration changed; logic is byte-identical to the swallowed original.
