### PR TITLE
fix(ui): 统一Agent与群聊设置表单规范、Tooltip浮层接入与布局对齐优化

### DIFF
--- a/main.html
+++ b/main.html
@@ -715,16 +715,16 @@
                                 <div class="settings-form-group tts-director-settings">
                                     <div class="tts-director-heading">
                                         <label for="agentTtsDirectorPromptInput">MiMo 自然语言演绎提示词:</label>
-                                        <button type="button" id="fillAgentTtsDirectorTemplateBtn"
-                                            class="tts-director-template-button" title="填入角色、场景和指导模板">
-                                            导演模板
-                                        </button>
                                     </div>
                                     <div class="tts-director-composer">
                                         <textarea id="agentTtsDirectorPromptInput"
                                             class="tts-director-editor tts-director-editor-new"
                                             rows="1"
                                             placeholder="点击展开，描述角色、场景与演绎指导；Ctrl+Enter 添加"></textarea>
+                                        <button type="button" id="fillAgentTtsDirectorTemplateBtn"
+                                            class="tts-director-template-button" title="填入角色、场景和指导模板">
+                                            导演模板
+                                        </button>
                                         <button type="button" id="addAgentTtsDirectorPromptBtn"
                                             class="small-button tts-director-action-button"
                                             title="添加导演提示词" aria-label="添加导演提示词">+</button>

--- a/modules/ui-system/agent-settings-bridge.js
+++ b/modules/ui-system/agent-settings-bridge.js
@@ -23,6 +23,7 @@ function enhanceForm(form) {
     mountTypedAgentModelPicker(form);
     mountTypedGroupModelPicker(form);
     mountTypedAgentPromptModeButtons(form);
+    mountAgentSettingsTooltips(form);
     const typedAgentSectionOwners = mountAgentSectionDisclosures(form, window.VCPUIUX, ensurePresentationScope(), window.settingsManager, agentSectionDisclosureStates);
     selectProjection.mount(form);
     // A successfully adopted Agent section is directly owned by the generated
@@ -130,16 +131,16 @@ function mountTypedAgentButtons(form) {
         try {
             const size = key.includes('refresh') ? 'sm' : 'md';
             api.mountButton(button, { variant, size }, scope);
-            // The TTS Select proxy uses a 38px control contract. Its adjacent
+            // The TTS Select proxy uses a 32px control contract. Its adjacent
             // refresh action must share that geometry rather than retaining the
             // generic 32px small-button size.
-            const minHeight = key.includes('refresh') ? '38px' : (size === 'sm' ? '28px' : '36px');
+            const minHeight = key.includes('refresh') ? '32px' : (size === 'sm' ? '28px' : '36px');
             const originalMinHeight = [button.style.getPropertyValue('min-height'), button.style.getPropertyPriority('min-height')];
             button.style.setProperty('min-height', minHeight, 'important');
             if (key.includes('refresh')) {
-                button.style.setProperty('width', '38px', 'important');
-                button.style.setProperty('min-width', '38px', 'important');
-                button.style.setProperty('height', '38px', 'important');
+                button.style.setProperty('width', '32px', 'important');
+                button.style.setProperty('min-width', '32px', 'important');
+                button.style.setProperty('height', '32px', 'important');
                 button.style.setProperty('border-radius', '8px', 'important');
             }
             scope.own(() => {
@@ -451,6 +452,71 @@ function mountTypedAgentColorPairs(form) {
         });
         color.dataset.vcpTypedPrimitiveMounted = 'true';
         scope.own(() => { delete color.dataset.vcpTypedPrimitiveMounted; }, `typed-${key}-marker`, 'ui-primitive');
+    });
+}
+
+function mountAgentSettingsTooltips(form) {
+    const api = window.VCPUIUX;
+    const scope = ensurePresentationScope();
+    if (!api?.mountTooltip || !scope) return;
+
+    const items = [
+        {
+            select: () => form.querySelector('.agent-settings-section[data-section-key="prompt"] .agent-settings-section-title'),
+            text: '三个模块独立编辑后，注意保存以生效。支持文本、模块与预制三种模式切换。',
+            key: 'prompt-title',
+            side: 'top',
+        },
+        {
+            select: () => form.querySelector('label[for="agentTtsSpeed"]'),
+            text: '本地 SoVITS 使用该语速；网络模式按模型原生节奏合成，可用下方自然语言提示词描述语速。',
+            key: 'tts-speed',
+            side: 'top',
+        },
+        {
+            select: () => form.querySelector('.tts-director-heading label') || form.querySelector('label[for="agentTtsDirectorPromptInput"]'),
+            text: '适用于网络模式：预置音色模式使用“提示词 + voice”控制演绎；自然语言控制模式使用专用模型且不发送 voice；克隆模式使用参考音频作为 voice。Ctrl+Enter 添加，右侧 − 删除。',
+            key: 'tts-director',
+            side: 'top',
+        },
+        {
+            select: () => form.querySelector('label[for="agentCustomCss"]'),
+            text: '此CSS将应用于【助手】页面的Agent列表项容器。',
+            key: 'appearance-custom-css',
+            side: 'top',
+        },
+        {
+            select: () => form.querySelector('label[for="agentCardCss"]'),
+            text: '此CSS将应用于【设置】页面中Agent的名片区域（头像和名称）。',
+            key: 'appearance-card-css',
+            side: 'top',
+        },
+        {
+            select: () => form.querySelector('label[for="agentChatCss"]'),
+            text: '此CSS将应用于【聊天会话】中Agent的头像和名称。可使用 .message-avatar 控制头像，.sender-name 控制名称。',
+            key: 'appearance-chat-css',
+            side: 'top',
+        },
+    ];
+
+    items.forEach(({ select, text, key, side }) => {
+        const host = select();
+        if (!host || host.querySelector(':scope > .vcp-settings-info-badge')) return;
+        const badge = document.createElement('button');
+        badge.type = 'button';
+        badge.className = 'vcp-settings-info-badge';
+        badge.setAttribute('aria-label', '提示说明');
+        badge.textContent = '?';
+        badge.addEventListener('click', (event) => {
+            event.stopPropagation();
+            event.preventDefault();
+            badge.focus();
+        });
+        host.appendChild(badge);
+        api.mountTooltip(badge, { label: text, side: side || 'top', delayMs: 60, maxWidth: 280 }, scope);
+        scope.own(() => {
+            badge.remove();
+        }, `agent-tooltip-badge-${key}`, 'ui-presentation');
     });
 }
 

--- a/modules/ui-system/settings/marker-registry.js
+++ b/modules/ui-system/settings/marker-registry.js
@@ -22,6 +22,7 @@ const MARKERS = Object.freeze({
     visibleWhen: { owner: 'settings/dependent-rows.js + main.html', cleanup: 'persistent' },
     // schema-surface.js — schema 渲染面的分区级幂等标记（exp/settings-schema）
     vcpSchemaRendered: { owner: 'settings/schema-surface.js', cleanup: 'persistent' },
+    uiMode: { owner: 'surface-controller.js + typed-field-owners.js', cleanup: 'persistent' },
 
     // uiux primitives — one re-entrancy marker per projection family
     // （vcpUiuxToggleMounted 自 M5-c pass1 起只剩 agent 设置面挂载方使用：

--- a/modules/uiux/generated/primitives/agent-model-picker.js
+++ b/modules/uiux/generated/primitives/agent-model-picker.js
@@ -430,8 +430,7 @@ export function mountAgentModelPicker(host, props, scope) {
         else {
             invalidateEffortSelection();
             pane = initialPane;
-            const openPicker = hasEffortPane ? popup.open : popup.openWhenReady;
-            openPicker('agent-model', {}, { via: 'menu', span: { source: 'agent-model-picker' } });
+            popup.open('agent-model', {}, { via: 'menu', span: { source: 'agent-model-picker' } });
         }
     }, { capture: true });
     const syncTrigger = () => trigger.setAttribute('aria-expanded', String(popup.getSnapshot().open));
@@ -477,8 +476,7 @@ export function mountAgentModelPicker(host, props, scope) {
         pickerScope.own(() => cardResizeObserver.disconnect(), 'agent-model-picker-card-resize', 'observer');
     }
     if (props.open === true && !trigger.disabled) {
-        const openPicker = hasEffortPane ? popup.open : popup.openWhenReady;
-        openPicker('agent-model', {}, { via: 'menu', span: { source: 'agent-model-picker' } });
+        popup.open('agent-model', {}, { via: 'menu', span: { source: 'agent-model-picker' } });
     }
     pickerScope.own(async () => {
         unsubscribe();
@@ -517,8 +515,7 @@ export function mountAgentModelPicker(host, props, scope) {
                 return;
             invalidateEffortSelection();
             pane = initialPane;
-            const openPicker = hasEffortPane ? popup.open : popup.openWhenReady;
-            openPicker('agent-model', {}, { via: 'menu', span: { source: 'agent-model-picker' } });
+            popup.open('agent-model', {}, { via: 'menu', span: { source: 'agent-model-picker' } });
         },
         // Closing from the trigger/picker surface must return focus to the
         // trigger, matching the Uiux menu focus contract.
@@ -530,8 +527,7 @@ export function mountAgentModelPicker(host, props, scope) {
             if (popup.getSnapshot().open)
                 popup.dismiss();
             pane = initialPane;
-            const openPicker = hasEffortPane ? popup.open : popup.openWhenReady;
-            openPicker('agent-model', {}, { via: 'menu', span: { source: 'agent-model-picker-refresh' } });
+            popup.open('agent-model', {}, { via: 'menu', span: { source: 'agent-model-picker-refresh' } });
         },
         setSelected: id => {
             selectedId = id;

--- a/styles/setting/settings-agent-form.css
+++ b/styles/setting/settings-agent-form.css
@@ -79,6 +79,7 @@
 /* 被上面合并的样式取代 */
 
 
+#agentSettingsForm .form-actions button,
 #agentSettingsForm .form-actions button:not(.vcp-uiux-button) {
     position: relative;
     isolation: isolate;
@@ -88,13 +89,13 @@
     justify-content: center;
     width: 100%;
     margin-left: 0;
-    height: 37px;
-    min-height: 37px;
+    height: 32px !important;
+    min-height: 32px !important;
     padding: 0 12px;
-    font-size: 0.95em;
+    font-size: 13px;
     font-weight: 500;
     line-height: 1;
-    border-radius: 14px !important;
+    border-radius: 8px !important;
     border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12));
     cursor: pointer;
     white-space: nowrap;
@@ -102,16 +103,19 @@
     box-shadow: none !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     transition:
         background var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard),
         border-color var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard),
         color var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard);
 }
 
+#agentSettingsForm .form-actions button[type="submit"],
 #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button) {
     color: var(--highlight-text);
 }
 
+#agentSettingsForm .form-actions button[type="submit"]:hover,
 #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button):hover {
     background: var(--dsw-alias-interactive-bg-hover, #f3f4f6);
     border-color: var(--dsw-alias-border-l1, rgba(0, 0, 0, 0.22));
@@ -119,7 +123,10 @@
     box-shadow: none !important;
 }
 
-#agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button) {
+#agentSettingsForm .form-actions .danger-button,
+#agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button),
+#agentSettingsForm .form-actions #deleteAgentBtn,
+#agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button) {
     color: var(--vcp-ui-danger, #ef4444);
 }
 
@@ -127,37 +134,47 @@ body[data-vcp-theme="light"] #agentSettingsForm .form-actions {
     background-color: transparent !important;
 }
 
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions button[type="submit"],
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button) {
-    background: #F3EBE7 !important;
-    border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12));
-    color: var(--highlight-text);
+    background: color-mix(in srgb, var(--user-bubble-bg, #f3ede2) 85%, rgba(255, 255, 255, 0.7)) !important;
+    border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12)) !important;
+    color: var(--highlight-text) !important;
     box-shadow: none !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     opacity: 1 !important;
 }
 
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions button[type="submit"]:hover,
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button):hover {
-    background: #EAE0DB !important;
-    border-color: var(--dsw-alias-border-l1, rgba(0, 0, 0, 0.22));
-    color: var(--highlight-text);
+    background: color-mix(in srgb, var(--user-bubble-bg, #f3ede2) 95%, rgba(0, 0, 0, 0.08)) !important;
+    border-color: var(--dsw-alias-border-l1, rgba(0, 0, 0, 0.22)) !important;
+    color: var(--highlight-text) !important;
     box-shadow: none !important;
 }
 
-body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button) {
-    background: #FFFFFF !important;
-    border: 1px solid color-mix(in srgb, var(--vcp-ui-danger, #ef4444) 30%, #e5e7eb);
-    color: var(--vcp-ui-danger, #ef4444);
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button,
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button),
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions #deleteAgentBtn,
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button) {
+    background: var(--dsw-alias-bg-layer-1, #ffffff) !important;
+    border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12)) !important;
+    color: var(--vcp-ui-danger, #ef4444) !important;
     box-shadow: none !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     opacity: 1 !important;
 }
 
-body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button):hover {
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button:hover,
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button):hover,
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions #deleteAgentBtn:hover,
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button):hover {
     background: #FEF2F2 !important;
-    border-color: var(--vcp-ui-danger, #ef4444);
-    color: var(--vcp-ui-danger, #ef4444);
+    border-color: color-mix(in srgb, var(--vcp-ui-danger, #ef4444) 40%, var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12))) !important;
+    color: var(--vcp-ui-danger, #ef4444) !important;
     box-shadow: none !important;
 }
 
@@ -165,37 +182,47 @@ body[data-vcp-theme="dark"] #agentSettingsForm .form-actions {
     background-color: transparent !important;
 }
 
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions button[type="submit"],
 body[data-vcp-theme="dark"] #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button) {
-    background: #2C2C2E !important;
-    border: 1px solid var(--dsw-alias-border-l2, rgba(255, 255, 255, 0.12));
-    color: #ffffff;
+    background: var(--dsw-alias-bg-layer-2, #262628) !important;
+    border: 1px solid var(--dsw-alias-border-l2, rgba(255, 255, 255, 0.12)) !important;
+    color: var(--highlight-text) !important;
     box-shadow: none !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     opacity: 1 !important;
 }
 
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions button[type="submit"]:hover,
 body[data-vcp-theme="dark"] #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button):hover {
-    background: #38383A !important;
-    border-color: var(--dsw-alias-border-l1, rgba(255, 255, 255, 0.24));
-    color: #ffffff;
+    background: var(--dsw-alias-interactive-bg-hover, #323235) !important;
+    border-color: var(--dsw-alias-border-l1, rgba(255, 255, 255, 0.24)) !important;
+    color: #ffffff !important;
     box-shadow: none !important;
 }
 
-body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button) {
-    background: #251B1B !important;
-    border: 1px solid color-mix(in srgb, var(--vcp-ui-danger, #ef4444) 35%, #3f2020);
-    color: var(--vcp-ui-danger, #ef4444);
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button,
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button),
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions #deleteAgentBtn,
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button) {
+    background: rgba(255, 255, 255, 0.05) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    color: var(--vcp-ui-danger, #ef4444) !important;
     box-shadow: none !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     opacity: 1 !important;
 }
 
-body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button):hover {
-    background: #331E1E !important;
-    border-color: var(--vcp-ui-danger, #ef4444);
-    color: #ffffff;
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button:hover,
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button):hover,
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions #deleteAgentBtn:hover,
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button):hover {
+    background: rgba(239, 68, 68, 0.12) !important;
+    border-color: rgba(239, 68, 68, 0.35) !important;
+    color: #ff6b6b !important;
     box-shadow: none !important;
 }
 

--- a/styles/setting/settings-agent-identity.css
+++ b/styles/setting/settings-agent-identity.css
@@ -15,7 +15,7 @@
 #agentSettingsContainer .agent-identity-main {
     display: flex;
     align-items: center;
-    gap: 14px;
+    gap: 12px;
 }
 
 /* 头像包装器 */
@@ -24,10 +24,26 @@
     flex-shrink: 0;
 }
 
+#agentSettingsContainer .agent-avatar-wrapper {
+    position: relative;
+    flex-shrink: 0;
+    width: 60px;
+    height: 60px;
+    border-radius: 16px;
+    overflow: hidden;
+}
+
 #agentSettingsContainer .agent-avatar-display {
-    width: 76px;
-    height: 76px;
-    border-width: 2px;
+    width: 60px !important;
+    height: 60px !important;
+    min-width: 60px !important;
+    max-width: 60px !important;
+    min-height: 60px !important;
+    max-height: 60px !important;
+    border-radius: 16px !important;
+    border: 1px solid rgba(0, 0, 0, 0.08) !important;
+    object-fit: cover !important;
+    margin: 0 !important;
 }
 
 .agent-avatar-display {
@@ -68,8 +84,13 @@
 }
 
 /* Agent设置：悬浮时才显示相机图标 */
+#agentSettingsContainer .avatar-upload-overlay {
+    border-radius: 16px !important;
+    background-color: rgba(0, 0, 0, 0.45);
+    transition: opacity 0.15s ease;
+}
+
 #agentSettingsContainer .agent-avatar-wrapper:hover .avatar-upload-overlay {
-    /*     background-color: rgba(0, 0, 0, 0.5);*/
     opacity: 1;
 }
 
@@ -123,6 +144,48 @@
     font-size: 1.08em;
     line-height: 1.3;
     box-sizing: border-box;
+}
+
+#agentSettingsContainer .agent-name-wrapper {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+#agentSettingsContainer .agent-name-wrapper label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--secondary-text);
+    margin: 0;
+}
+
+#agentSettingsContainer .agent-name-wrapper input[type="text"] {
+    width: 100% !important;
+    margin: 0 !important;
+    height: 36px !important;
+    min-height: 36px !important;
+    padding: 0 12px !important;
+    border-radius: 10px !important;
+    border: 1px solid var(--vcp-ui-control-border, rgba(0, 0, 0, 0.1)) !important;
+    background: var(--vcp-ui-bg-1, rgba(255, 255, 255, 0.8)) !important;
+    color: var(--primary-text) !important;
+    font-size: 13.5px !important;
+    font-weight: 600 !important;
+    box-sizing: border-box !important;
+    outline: none !important;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+#agentSettingsContainer .agent-name-wrapper input[type="text"]:focus {
+    border-color: var(--vcp-ui-control-focus, #3b82f6) !important;
+    box-shadow: 0 0 0 2px var(--vcp-ui-focus-ring, rgba(59, 130, 246, 0.18)) !important;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer .agent-name-wrapper input[type="text"] {
+    border-color: rgba(255, 255, 255, 0.12) !important;
+    background: rgba(255, 255, 255, 0.04) !important;
 }
 
 /* ========================================
@@ -324,18 +387,143 @@ body[data-vcp-theme="dark"] .color-input-group > input[type="text"]:focus-visibl
     border-color: var(--vcp-ui-control-focus, #60a5fa);
 }
 
+/* Modern VCPUI ColorPair in Agent Settings */
+#agentSettingsContainer .color-input-group > .vcp-uiux-color-pair {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    min-width: 0;
+    height: 32px;
+    box-sizing: border-box;
+    padding: 0 5px 0 4px;
+    border: 1px solid var(--vcp-ui-control-border, rgba(0, 0, 0, 0.12));
+    border-radius: 8px;
+    background: var(--vcp-ui-bg-1, rgba(255, 255, 255, 0.85));
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer .color-input-group > .vcp-uiux-color-pair {
+    border-color: rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+#agentSettingsContainer .color-input-group > .vcp-uiux-color-pair:focus-within {
+    border-color: var(--vcp-ui-control-focus, #3b82f6) !important;
+    box-shadow: 0 0 0 2px var(--vcp-ui-focus-ring, rgba(59, 130, 246, 0.18)) !important;
+}
+
+#agentSettingsContainer .color-input-group > .vcp-uiux-color-pair > input[type="color"] {
+    flex: 0 0 22px !important;
+    width: 22px !important;
+    height: 22px !important;
+    min-width: 22px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    border-radius: 5px !important;
+    cursor: pointer;
+    background: transparent !important;
+}
+
+#agentSettingsContainer .color-input-group > .vcp-uiux-color-pair > input[type="color"]::-webkit-color-swatch-wrapper {
+    padding: 0 !important;
+    border-radius: 5px !important;
+}
+
+#agentSettingsContainer .color-input-group > .vcp-uiux-color-pair > input[type="color"]::-webkit-color-swatch {
+    border: none !important;
+    border-radius: 5px !important;
+}
+
+#agentSettingsContainer .color-input-group > .vcp-uiux-color-pair > input[type="text"] {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100% !important;
+    height: 24px !important;
+    padding: 0 2px !important;
+    border: 0 !important;
+    background: transparent !important;
+    color: var(--primary-text) !important;
+    font-family: 'SF Mono', 'Consolas', monospace;
+    font-size: 11.5px !important;
+    line-height: 24px;
+    outline: none !important;
+    box-shadow: none !important;
+    letter-spacing: -0.02em;
+}
+
+/* Switch rows clean layout */
+#agentSettingsContainer .style-control-item .form-group-inline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    margin-bottom: 6px !important;
+}
+
+#agentSettingsContainer .style-control-item .form-group-inline > label:first-child {
+    font-size: 12.5px !important;
+    line-height: 1.35 !important;
+    color: var(--vcp-ui-text-0, var(--primary-text, #ffffff)) !important;
+    flex: 1 1 auto;
+    min-width: 0;
+    margin: 0 !important;
+}
+
+#agentSettingsContainer .style-control-item .form-group-inline .switch {
+    flex-shrink: 0;
+    margin: 0 !important;
+}
+
+/* Reset colors button compact styling */
+#agentSettingsContainer #resetAvatarColorsBtn {
+    width: 100% !important;
+    justify-content: center !important;
+    height: 32px !important;
+    min-height: 32px !important;
+    border-radius: 8px !important;
+    font-size: 12.5px !important;
+    font-weight: 500 !important;
+    margin-top: 2px;
+}
+
 /* 自定义CSS文本框 */
 .style-control-item textarea {
     width: 100%;
-    padding: 10px;
-    border-radius: 8px;
-    border: 1px solid var(--border-color);
-    background-color: var(--secondary-bg);
+    min-height: 80px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    background: rgba(0, 0, 0, 0.028);
     color: var(--primary-text);
-    font-size: 0.9em;
-    font-family: 'Consolas', 'Monaco', monospace;
+    font-size: 12.5px;
+    line-height: 1.5;
+    font-family: 'Consolas', 'Monaco', 'SF Mono', monospace;
     resize: vertical;
     box-sizing: border-box;
+    outline: none;
+    box-shadow: none;
+    transition: background var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard),
+                border-color var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard),
+                box-shadow var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard);
+}
+
+.style-control-item textarea:focus {
+    background: rgba(0, 0, 0, 0.045);
+    border-color: var(--vcp-ui-border-focus, rgba(22, 119, 255, 0.35));
+    box-shadow: 0 0 0 2px var(--vcp-ui-focus-ring, rgba(22, 119, 255, 0.12));
+}
+
+body[data-vcp-theme="dark"] .style-control-item textarea {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.06);
+}
+
+body[data-vcp-theme="dark"] .style-control-item textarea:focus {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: var(--vcp-ui-border-focus, rgba(59, 130, 246, 0.45));
+    box-shadow: 0 0 0 2px var(--vcp-ui-focus-ring, rgba(59, 130, 246, 0.18));
 }
 
 .style-control-item textarea::placeholder {
@@ -456,26 +644,29 @@ body[data-vcp-theme="dark"] .reset-colors-btn:not(.vcp-uiux-button):hover {
 #agentSettingsForm div>img[src*="blob:"],
 #agentSettingsForm div>img[data-preview-for],
 #agentSettingsForm img[id*="AvatarPreview"],
-#agentSettingsForm img[class*="AvatarPreview"] {
-    border: 2px solid var(--button-bg) !important;
-    border-radius: 8px;
-    max-width: 100px;
-    max-height: 100px;
-    object-fit: cover;
-    display: block;
-    margin-top: 10px;
-    margin-bottom: 10px;
+#agentSettingsForm img[class*="AvatarPreview"],
+#agentSettingsForm>div>img:only-child {
+    border: 1px solid rgba(0, 0, 0, 0.08) !important;
+    border-radius: 16px !important;
+    width: 60px !important;
+    height: 60px !important;
+    min-width: 60px !important;
+    max-width: 60px !important;
+    min-height: 60px !important;
+    max-height: 60px !important;
+    object-fit: cover !important;
+    display: block !important;
+    margin: 0 !important;
 }
 
-#agentSettingsForm>div>img:only-child {
-    border: 2px solid var(--button-bg) !important;
-    border-radius: 8px;
-    max-width: 100px;
-    max-height: 100px;
-    object-fit: cover;
-    display: block;
-    margin-top: 10px;
-    margin-bottom: 10px;
+body[data-vcp-theme="dark"] #agentSettingsForm img.avatar-preview,
+body[data-vcp-theme="dark"] #agentSettingsContainer img[alt="Avatar Preview"],
+body[data-vcp-theme="dark"] #agentSettingsForm div>img[src*="blob:"],
+body[data-vcp-theme="dark"] #agentSettingsForm div>img[data-preview-for],
+body[data-vcp-theme="dark"] #agentSettingsForm img[id*="AvatarPreview"],
+body[data-vcp-theme="dark"] #agentSettingsForm img[class*="AvatarPreview"],
+body[data-vcp-theme="dark"] #agentSettingsForm>div>img:only-child {
+    border-color: rgba(255, 255, 255, 0.12) !important;
 }
 
 /* Error feedback is a live SettingsActionBar state, not a legacy baseline.

--- a/styles/setting/settings-agent-prompt.css
+++ b/styles/setting/settings-agent-prompt.css
@@ -10,82 +10,89 @@
 }
 
 #agentSettingsContainer .agent-settings-prompt-shell > .prompt-section-note {
-    margin: -1px 0 0;
-    color: var(--secondary-text);
-    font-size: 0.82em;
-    line-height: 1.35;
-    font-weight: 400;
+    display: none !important;
 }
 
 #agentSettingsContainer .system-prompt-container .prompt-mode-selector {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: flex-start;
-    gap: 3px;
-    margin: 0 0 10px;
-    padding: 3px;
-    border-radius: 9999px;
-    background: var(--dsw-alias-bg-module-platform, rgba(0, 0, 0, 0.05));
-    border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.08));
+    width: 100%;
+    gap: 4px;
+    margin: 0 0 8px;
+    padding: 0;
+    border-radius: 0;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
     box-sizing: border-box;
 }
 
 body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .prompt-mode-selector {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.12);
+    background: transparent !important;
+    border: none !important;
 }
 
+#agentSettingsContainer .system-prompt-container .prompt-mode-button,
 #agentSettingsContainer .system-prompt-container .prompt-mode-button:not(.vcp-uiux-button) {
     position: relative;
-    flex: 0 0 auto;
+    flex: 1 1 0;
     min-width: 0;
-    height: 28px;
-    min-height: 28px;
-    padding: 0 14px;
-    border: none !important;
-    border-radius: 9999px !important;
+    height: 28px !important;
+    min-height: 28px !important;
+    padding: 0 6px !important;
+    border: 1px solid transparent !important;
+    border-radius: 6px !important;
     background: transparent !important;
-    color: var(--dsw-alias-label-secondary, #666666);
-    font-size: 13px;
-    font-weight: 500;
-    line-height: 1;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    white-space: nowrap;
-    cursor: pointer;
+    color: var(--secondary-text, #888888) !important;
+    font-size: 12.5px !important;
+    font-weight: 500 !important;
+    line-height: 1 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 5px !important;
+    white-space: nowrap !important;
+    cursor: pointer !important;
     box-shadow: none !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
-    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease !important;
 }
 
+#agentSettingsContainer .system-prompt-container .prompt-mode-button::after,
 #agentSettingsContainer .system-prompt-container .prompt-mode-button:not(.vcp-uiux-button)::after {
     display: none !important;
 }
 
+#agentSettingsContainer .system-prompt-container .prompt-mode-button:hover,
 #agentSettingsContainer .system-prompt-container .prompt-mode-button:not(.vcp-uiux-button):hover {
-    color: var(--dsw-alias-label-primary, #111111);
+    color: var(--highlight-text, #111111) !important;
     background: rgba(0, 0, 0, 0.04) !important;
 }
 
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .prompt-mode-button:hover,
 body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .prompt-mode-button:not(.vcp-uiux-button):hover {
-    color: #ffffff;
-    background: rgba(255, 255, 255, 0.06) !important;
-}
-
-#agentSettingsContainer .system-prompt-container .prompt-mode-button:not(.vcp-uiux-button).active {
-    background: var(--dsw-alias-bg-layer-1, #ffffff) !important;
-    color: var(--dsw-alias-label-primary, #111111) !important;
-    font-weight: 600 !important;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06) !important;
-}
-
-body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .prompt-mode-button:not(.vcp-uiux-button).active {
-    background: var(--dsw-alias-bg-layer-2, #2c2c2e) !important;
     color: #ffffff !important;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3) !important;
+    background: rgba(255, 255, 255, 0.05) !important;
+}
+
+#agentSettingsContainer .system-prompt-container .prompt-mode-button.active,
+#agentSettingsContainer .system-prompt-container .prompt-mode-button:not(.vcp-uiux-button).active {
+    background: rgba(0, 0, 0, 0.05) !important;
+    border-color: rgba(0, 0, 0, 0.06) !important;
+    color: var(--highlight-text, #111111) !important;
+    font-weight: 600 !important;
+    box-shadow: none !important;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .prompt-mode-button.active,
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .prompt-mode-button:not(.vcp-uiux-button).active {
+    background: rgba(255, 255, 255, 0.08) !important;
+    border-color: rgba(255, 255, 255, 0.08) !important;
+    color: #ffffff !important;
+    font-weight: 600 !important;
+    box-shadow: none !important;
 }
 
 #agentSettingsContainer .system-prompt-container .prompt-mode-button-icon {
@@ -118,7 +125,7 @@ body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .pr
 #agentSettingsContainer .system-prompt-container .block-name-input {
     border-radius: var(--agent-settings-pill-radius) !important;
     font-size: 0.9em;
-    color: var(--highlight-text);
+    color: var(--vcp-ui-text-0, var(--primary-text, #ffffff));
 }
 
 #agentSettingsContainer .system-prompt-container .preset-path-input,
@@ -134,24 +141,70 @@ body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .pr
     padding-right: 34px;
 }
 
-#agentSettingsContainer .system-prompt-container .prompt-textarea {
-    min-height: 76px;
-    padding: 10px 12px;
-    border-radius: 16px !important;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-    overflow-x: hidden;
-}
-
+#agentSettingsContainer .system-prompt-container .prompt-textarea,
+#agentSettingsContainer .system-prompt-container .original-prompt-textarea,
 #agentSettingsContainer .system-prompt-container .preset-prompt-textarea {
-    width: 100%;
-    min-width: 0;
-    max-width: 100%;
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    min-height: 100px !important;
+    max-height: min(340px, 45vh) !important;
+    padding: 6px 2px !important;
+    border-radius: 4px !important;
+    border: 1px solid transparent !important;
+    border-left: 2.5px solid transparent !important;
+    background: transparent !important;
+    color: var(--vcp-ui-text-0, var(--primary-text, #ffffff)) !important;
+    font-size: 13.5px !important;
+    line-height: 1.6 !important;
     white-space: pre-wrap !important;
     overflow-wrap: anywhere !important;
     word-break: break-word !important;
     overflow-x: hidden !important;
+    overflow-y: auto !important;
+    resize: vertical;
+    outline: none !important;
+    box-shadow: none !important;
+    box-sizing: border-box !important;
+    cursor: text;
+    transition: padding-left var(--vcp-motion-duration-fast) var(--vcp-motion-ease-standard),
+                border-color var(--vcp-motion-duration-fast) var(--vcp-motion-ease-standard);
+}
+
+#agentSettingsContainer .system-prompt-container .prompt-textarea:focus,
+#agentSettingsContainer .system-prompt-container .original-prompt-textarea:focus,
+#agentSettingsContainer .system-prompt-container .preset-prompt-textarea:focus {
+    background: transparent !important;
+    border-color: transparent !important;
+    border-left: 2.5px solid var(--vcp-ui-accent, var(--highlight-text, #3b82f6)) !important;
+    padding-left: 6px !important;
+    box-shadow: none !important;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .prompt-textarea,
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .original-prompt-textarea,
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .preset-prompt-textarea {
+    background: transparent !important;
+    border-color: transparent !important;
+    color: var(--vcp-ui-text-0, #ffffff) !important;
+}
+
+body[data-vcp-theme="light"] #agentSettingsContainer .system-prompt-container .prompt-textarea,
+body[data-vcp-theme="light"] #agentSettingsContainer .system-prompt-container .original-prompt-textarea,
+body[data-vcp-theme="light"] #agentSettingsContainer .system-prompt-container .preset-prompt-textarea {
+    background: transparent !important;
+    border-color: transparent !important;
+    color: var(--vcp-ui-text-0, #111111) !important;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .prompt-textarea:focus,
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .original-prompt-textarea:focus,
+body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .preset-prompt-textarea:focus {
+    background: transparent !important;
+    border-color: transparent !important;
+    border-left: 2.5px solid var(--vcp-ui-accent, var(--highlight-text, #3b82f6)) !important;
+    padding-left: 6px !important;
+    box-shadow: none !important;
 }
 
 #agentSettingsContainer .system-prompt-container .preset-path-section label,
@@ -167,7 +220,7 @@ body[data-vcp-theme="dark"] #agentSettingsContainer .system-prompt-container .pr
 #agentSettingsContainer .system-prompt-container .preset-prompt-container,
 #agentSettingsContainer .system-prompt-container .original-prompt-container {
     gap: 10px;
-    padding: 8px 6px 8px;
+    padding: 0 !important;
 }
 
 #agentSettingsContainer .system-prompt-container .modular-toolbar {

--- a/styles/setting/settings-agent-sections.css
+++ b/styles/setting/settings-agent-sections.css
@@ -212,9 +212,9 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: var(--highlight-text);
-    font-size: 1.06em;
-    font-weight: 500;
+    color: var(--vcp-ui-text-0, var(--primary-text, #ffffff)) !important;
+    font-size: 13.5px !important;
+    font-weight: 600 !important;
     line-height: 24px;
     z-index: 1;
     transition: color var(--vcp-motion-duration-fast) var(--vcp-motion-ease-standard);
@@ -337,7 +337,7 @@ body[data-vcp-theme="dark"] #agentSettingsContainer #identitySummary.summary-wit
 }
 
 #agentSettingsContainer .agent-settings-section-header:hover .agent-settings-section-title {
-    color: var(--highlight-text);
+    color: var(--vcp-ui-text-0, #ffffff) !important;
 }
 
 #agentSettingsContainer .agent-settings-section-header:hover::before {
@@ -443,8 +443,8 @@ body[data-vcp-theme="light"] #agentSettingsContainer .agent-settings-toggle-btn:
 #agentSettingsContainer .params-content > div > input[type="number"],
 #agentSettingsContainer .params-content > div > input[type="text"],
 #agentSettingsContainer .params-content > div > .model-input-container {
-    width: calc(100% + 2px);
-    margin-left: -2px;
+    width: 100%;
+    margin-left: 0;
 }
 
 #agentSettingsContainer .agent-settings-section-content > .agent-identity-container,
@@ -543,9 +543,8 @@ body[data-vcp-theme="light"] #agentSettingsContainer .agent-settings-toggle-btn:
 }
 #agentSettingsContainer .tts-director-composer,
 #agentSettingsContainer .tts-director-item {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 28px;
-    align-items: center;
+    position: relative;
+    display: block;
     gap: 6px;
     min-width: 0;
 }
@@ -563,15 +562,13 @@ body[data-vcp-theme="light"] #agentSettingsContainer .agent-settings-toggle-btn:
     width: 100%;
     min-width: 0;
     max-width: 100%;
-    height: 38px;
-    min-height: 38px;
-    max-height: 38px;
-    padding: 8px 11px;
-    overflow: hidden;
-    resize: none;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    background: color-mix(in srgb, var(--input-bg, var(--secondary-bg)) 94%, transparent);
+    min-height: 100px;
+    padding: 5px 10px;
+    overflow-y: auto;
+    resize: vertical !important;
+    border: none;
+    border-radius: 0;
+    background: transparent;
     color: var(--primary-text);
     font: inherit;
     line-height: 20px;
@@ -579,29 +576,42 @@ body[data-vcp-theme="light"] #agentSettingsContainer .agent-settings-toggle-btn:
     overflow-wrap: anywhere;
     word-break: break-word;
     text-overflow: clip;
-    transition:
-        min-height 0.2s ease,
-        max-height 0.2s ease,
-        height 0.2s ease,
-        border-color 0.18s ease,
-        box-shadow 0.18s ease,
-        background-color 0.18s ease;
+    transition: color 0.18s ease;
 }
 
 #agentSettingsContainer .tts-director-editor:hover {
-    border-color: color-mix(in srgb, var(--highlight-text) 36%, var(--border-color));
+    border-color: transparent;
 }
 
 #agentSettingsContainer .tts-director-editor:focus {
-    min-height: 132px;
-    max-height: 360px;
     overflow: auto;
     white-space: pre-wrap;
     text-overflow: clip;
-    border-color: var(--highlight-text);
-    background: var(--input-bg, var(--secondary-bg));
+    border-color: transparent;
+    background: transparent;
     outline: none;
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--highlight-text) 14%, transparent);
+    box-shadow: none;
+}
+
+#agentSettingsContainer .tts-director-composer {
+    min-height: 0;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    transition: none;
+}
+
+#agentSettingsContainer .tts-director-composer:focus-within {
+    background: transparent;
+}
+
+#agentSettingsContainer .tts-director-editor {
+    padding: 6px 2px !important;
+}
+
+#agentSettingsContainer .tts-director-editor:focus {
+    padding-left: 2px !important;
 }
 
 #agentSettingsContainer .tts-director-composer.is-editing,
@@ -609,14 +619,17 @@ body[data-vcp-theme="light"] #agentSettingsContainer .agent-settings-toggle-btn:
     margin-bottom: 3px;
 }
 #agentSettingsContainer .tts-director-action-button {
-    position: static !important;
-    align-self: center;
-    width: 28px !important;
-    height: 28px !important;
-    min-width: 28px !important;
-    min-height: 28px !important;
-    max-width: 28px;
-    max-height: 28px;
+    position: absolute !important;
+    right: 8px !important;
+    bottom: 6px !important;
+    z-index: 2;
+    align-self: auto;
+    width: 32px !important;
+    height: 32px !important;
+    min-width: 32px !important;
+    min-height: 32px !important;
+    max-width: 32px;
+    max-height: 32px;
     padding: 0 !important;
     border: 1px solid color-mix(in srgb, var(--secondary-text) 24%, transparent) !important;
     border-radius: 50% !important;
@@ -627,7 +640,8 @@ body[data-vcp-theme="light"] #agentSettingsContainer .agent-settings-toggle-btn:
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
     font: 500 17px/1 system-ui, sans-serif;
-    opacity: 0.76;
+    opacity: 0;
+    pointer-events: none;
     transform: none;
     transition:
         color var(--vcp-motion-duration-fast) var(--vcp-motion-ease-standard),
@@ -636,13 +650,51 @@ body[data-vcp-theme="light"] #agentSettingsContainer .agent-settings-toggle-btn:
         opacity var(--vcp-motion-duration-fast) var(--vcp-motion-ease-standard);
 }
 
+#agentSettingsContainer .tts-director-template-button {
+    position: absolute !important;
+    right: 48px !important;
+    bottom: 6px !important;
+    min-height: 32px;
+    padding: 0 10px;
+    border: 1px solid color-mix(in srgb, var(--secondary-text) 24%, transparent);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--secondary-text);
+    font-size: 12px;
+    opacity: 0;
+    pointer-events: none;
+}
+
+#agentSettingsContainer .tts-director-composer:hover .tts-director-template-button,
+#agentSettingsContainer .tts-director-composer:focus-within .tts-director-template-button,
+#agentSettingsContainer .tts-director-template-button:focus-visible {
+    opacity: 0.82;
+    pointer-events: auto;
+}
+
+#agentSettingsContainer .tts-director-template-button:hover,
+#agentSettingsContainer .tts-director-template-button:focus-visible {
+    color: var(--highlight-text);
+    background: color-mix(in srgb, var(--highlight-text) 10%, transparent);
+    outline: none;
+}
+
 #agentSettingsContainer .tts-director-action-button:hover,
 #agentSettingsContainer .tts-director-action-button:focus-visible {
     opacity: 1;
+    pointer-events: auto;
     color: var(--highlight-text) !important;
     border-color: color-mix(in srgb, var(--highlight-text) 48%, transparent) !important;
     background: color-mix(in srgb, var(--highlight-text) 9%, transparent) !important;
     outline: none;
+}
+
+#agentSettingsContainer .tts-director-composer:hover .tts-director-action-button,
+#agentSettingsContainer .tts-director-composer:focus-within .tts-director-action-button,
+#agentSettingsContainer .tts-director-item:hover .tts-director-action-button,
+#agentSettingsContainer .tts-director-item:focus-within .tts-director-action-button {
+    opacity: 0.76;
+    pointer-events: auto;
 }
 
 #agentSettingsContainer .tts-director-item .tts-director-action-button {
@@ -673,32 +725,148 @@ body:not(.light-theme) #agentSettingsContainer .tts-director-editor {
     background: color-mix(in srgb, var(--secondary-bg) 86%, black);
 }
 
-
-/* Theme-aware WebAwesome proxy for Agent TTS voice Selects. */
-#agentSettingsContainer #ttsContent .model-input-container {
-    align-items: center;
+#agentSettingsContainer .tts-director-editor,
+#agentSettingsContainer .tts-director-editor:hover,
+#agentSettingsContainer .tts-director-editor:focus,
+body.light-theme #agentSettingsContainer .tts-director-editor,
+body:not(.light-theme) #agentSettingsContainer .tts-director-editor {
+    min-height: 100px;
+    max-height: none !important;
+    resize: vertical !important;
+    overflow-y: auto !important;
+    border: 1px solid transparent !important;
+    border-left: 2.5px solid transparent !important;
+    border-radius: 4px !important;
+    background: transparent !important;
+    box-shadow: none !important;
 }
 
-#agentSettingsContainer #ttsContent .model-input-container > select {
-    height: 38px !important;
-    min-height: 38px !important;
-    max-height: 38px !important;
+#agentSettingsContainer .tts-director-editor:focus {
+    min-height: 140px;
+    border-color: transparent !important;
+    border-left-color: transparent !important;
+    padding-left: 2px !important;
+}
+
+
+/* Theme-aware WebAwesome & VCPUI proxy for Agent TTS voice Selects & Regex Inputs */
+#agentSettingsContainer #ttsContent .model-input-container {
+    display: flex !important;
+    align-items: center !important;
+    gap: 6px !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    margin: 0 !important;
+    margin-left: 0 !important;
+}
+
+#agentSettingsContainer #ttsContent .vcp-uiux-select {
+    width: 100% !important;
+    min-width: 0 !important;
+    flex: 1 1 auto !important;
+    margin: 0 !important;
+}
+
+#agentSettingsContainer #ttsContent .model-input-container > select,
+#agentSettingsContainer #ttsContent .vcp-uiux-select-trigger {
+    height: 32px !important;
+    min-height: 32px !important;
+    max-height: 32px !important;
+    border-radius: 8px !important;
+    padding: 0 10px !important;
+    font-size: 13px !important;
+    line-height: 30px !important;
+    box-sizing: border-box !important;
+    background: var(--vcp-ui-bg-1, var(--input-bg)) !important;
+    border: 1px solid var(--vcp-ui-border, var(--border-color)) !important;
+    color: var(--vcp-ui-text-0, var(--primary-text)) !important;
 }
 
 #agentSettingsContainer #ttsContent #refreshTtsModelsBtn {
-    width: 38px !important;
-    height: 38px !important;
-    min-width: 38px;
-    min-height: 38px;
+    width: 32px !important;
+    height: 32px !important;
+    min-width: 32px !important;
+    min-height: 32px !important;
+    max-height: 32px !important;
+    border-radius: 8px !important;
     padding: 0 !important;
-    align-self: center;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    flex-shrink: 0 !important;
+    box-sizing: border-box !important;
+    background: var(--vcp-ui-bg-1, var(--input-bg)) !important;
+    border: 1px solid var(--vcp-ui-border, var(--border-color)) !important;
+    color: var(--vcp-ui-text-0, var(--primary-text)) !important;
+}
+
+#agentSettingsContainer #ttsContent .vcp-uiux-input-wrap,
+#agentSettingsContainer #ttsContent input[type="text"] {
+    height: 32px !important;
+    min-height: 32px !important;
+    max-height: 32px !important;
+    border-radius: 8px !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 0 !important;
+    margin-left: 0 !important;
+    box-sizing: border-box !important;
+    background: var(--vcp-ui-bg-1, var(--input-bg)) !important;
+    border: 1px solid var(--vcp-ui-border, var(--border-color)) !important;
+}
+
+#agentSettingsContainer #ttsContent .vcp-uiux-input-wrap > .input {
+    height: 100% !important;
+    line-height: 30px !important;
+    font-size: 13px !important;
+    padding: 0 10px !important;
+    color: var(--vcp-ui-text-0, var(--primary-text)) !important;
+}
+
+body[data-vcp-theme="light"] #agentSettingsContainer #ttsContent .model-input-container > select,
+body[data-vcp-theme="light"] #agentSettingsContainer #ttsContent .vcp-uiux-select-trigger,
+body[data-vcp-theme="light"] #agentSettingsContainer #ttsContent #refreshTtsModelsBtn,
+body[data-vcp-theme="light"] #agentSettingsContainer #ttsContent .vcp-uiux-input-wrap,
+body[data-vcp-theme="light"] #agentSettingsContainer #ttsContent input[type="text"] {
+    background: #ffffff !important;
+    color: #0f1115 !important;
+    border: 1px solid rgba(0, 0, 0, 0.12) !important;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer #ttsContent .model-input-container > select,
+body[data-vcp-theme="dark"] #agentSettingsContainer #ttsContent .vcp-uiux-select-trigger,
+body[data-vcp-theme="dark"] #agentSettingsContainer #ttsContent #refreshTtsModelsBtn,
+body[data-vcp-theme="dark"] #agentSettingsContainer #ttsContent .vcp-uiux-input-wrap,
+body[data-vcp-theme="dark"] #agentSettingsContainer #ttsContent input[type="text"] {
+    background: #171b20 !important;
+    color: #f1f5f9 !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+}
+
+
+#agentSettingsContainer .model-input-container:has(.vcp-uiux-select) > wa-select.vcp-ui-select-proxy,
+#agentSettingsContainer .model-input-container > .vcp-uiux-select ~ wa-select.vcp-ui-select-proxy {
+    display: none !important;
+}
+
+#agentSettingsContainer .vcp-uiux-select-trigger::after {
+    content: "";
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: rotate(45deg) translateY(-2px);
+    margin-left: auto;
+    flex-shrink: 0;
+    opacity: 0.6;
 }
 
 #agentSettingsContainer .model-input-container > wa-select.vcp-ui-select-proxy {
     width: 100%;
     min-width: 0;
     flex: 1 1 auto;
-    height: 38px;
+    height: 32px;
     color: var(--vcp-ui-text-0, var(--primary-text));
     font-family: var(--vcp-ui-font-family, inherit);
     font-size: var(--vcp-ui-font-helper, 0.92em);
@@ -712,8 +880,8 @@ body:not(.light-theme) #agentSettingsContainer .tts-director-editor {
 }
 
 #agentSettingsContainer wa-select.vcp-ui-select-proxy::part(combobox) {
-    height: 38px;
-    min-height: 38px;
+    height: 32px;
+    min-height: 32px;
     padding: 0 10px;
     border: 1px solid var(--vcp-ui-control-border, var(--border-color));
     border-radius: var(--vcp-ui-radius-control, 8px);
@@ -931,7 +1099,7 @@ body:not(.light-theme) #agentSettingsContainer .tts-director-editor {
     overflow-wrap: anywhere !important;
 }
 
-#agentSettingsContainer #identitySummary.summary-with-avatar {
+#agentSettingsContainer .agent-settings-collapsible-container.collapsed #identitySummary.summary-with-avatar {
     display: flex !important;
     width: 100% !important;
     max-width: 100% !important;
@@ -949,35 +1117,186 @@ body:not(.light-theme) #agentSettingsContainer .tts-director-editor {
     -webkit-backdrop-filter: none !important;
 }
 
-#agentSettingsContainer .slider-container > .vcp-uiux-range,
+#agentSettingsContainer .agent-settings-collapsible-container:not(.collapsed) #identitySummary,
+#agentSettingsContainer .agent-settings-collapsible-container:not(.collapsed) .agent-settings-section-summary {
+    display: none !important;
+}
+
 #agentSettingsContainer .slider-container {
+    display: flex !important;
+    align-items: center !important;
+    width: 100% !important;
     min-width: 0 !important;
+    margin-top: 6px !important;
+    margin-bottom: 4px !important;
+    box-sizing: border-box !important;
 }
 
-#agentSettingsContainer .slider-container > #agentTtsSpeed,
-#agentSettingsContainer .slider-container > input[type="range"] {
-    flex: 1 1 auto;
-    min-width: 0;
-    appearance: none;
-    height: 20px;
-    margin: 0;
-    accent-color: var(--vcp-ui-accent, var(--highlight-text));
+#agentSettingsContainer .slider-container .vcp-uiux-range {
+    display: flex !important;
+    align-items: center !important;
+    gap: 12px !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    flex: 1 1 auto !important;
 }
 
-#agentSettingsContainer .slider-container > #agentTtsSpeed::-webkit-slider-runnable-track,
-#agentSettingsContainer .slider-container > input[type="range"]::-webkit-slider-runnable-track {
-    height: 4px;
-    border-radius: 999px;
-    background: var(--vcp-ui-fill-2, var(--border-color));
+#agentSettingsContainer .slider-container input[type="range"] {
+    flex: 1 1 auto !important;
+    min-width: 0 !important;
+    width: 100% !important;
+    height: 20px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: transparent !important;
+    border: none !important;
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    cursor: pointer !important;
+    outline: none !important;
 }
 
-#agentSettingsContainer .slider-container > #agentTtsSpeed::-webkit-slider-thumb,
-#agentSettingsContainer .slider-container > input[type="range"]::-webkit-slider-thumb {
-    width: 16px;
-    height: 16px;
-    margin-top: -6px;
-    appearance: none;
-    border: 2px solid var(--vcp-ui-accent, var(--highlight-text));
-    border-radius: 50%;
-    background: var(--vcp-ui-bg-1, var(--input-bg));
+#agentSettingsContainer .slider-container input[type="range"]::-webkit-slider-runnable-track {
+    width: 100% !important;
+    height: 5px !important;
+    border: none !important;
+    border-radius: 999px !important;
+    background: var(--vcp-ui-fill-2, rgba(255, 255, 255, 0.14)) !important;
+}
+
+#agentSettingsContainer .slider-container input[type="range"]::-moz-range-track {
+    width: 100% !important;
+    height: 5px !important;
+    border: none !important;
+    border-radius: 999px !important;
+    background: var(--vcp-ui-fill-2, rgba(255, 255, 255, 0.14)) !important;
+}
+
+#agentSettingsContainer .slider-container input[type="range"]::-webkit-slider-thumb {
+    width: 16px !important;
+    height: 16px !important;
+    margin-top: -5.5px !important;
+    border: 2px solid var(--vcp-ui-accent, var(--highlight-text, #3b82f6)) !important;
+    border-radius: 50% !important;
+    background: var(--vcp-ui-bg-1, var(--input-bg, #1e2024)) !important;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35) !important;
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    transition: transform 0.15s ease, box-shadow 0.15s ease !important;
+    cursor: pointer !important;
+}
+
+#agentSettingsContainer .slider-container input[type="range"]::-moz-range-thumb {
+    width: 14px !important;
+    height: 14px !important;
+    border: 2px solid var(--vcp-ui-accent, var(--highlight-text, #3b82f6)) !important;
+    border-radius: 50% !important;
+    background: var(--vcp-ui-bg-1, var(--input-bg, #1e2024)) !important;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35) !important;
+    cursor: pointer !important;
+}
+
+#agentSettingsContainer .slider-container input[type="range"]:hover::-webkit-slider-thumb {
+    transform: scale(1.15) !important;
+    box-shadow: 0 0 0 4px var(--vcp-ui-focus-ring, rgba(59, 130, 246, 0.25)) !important;
+}
+
+#agentSettingsContainer .slider-container input[type="range"]:active::-webkit-slider-thumb {
+    transform: scale(1.22) !important;
+    box-shadow: 0 0 0 6px var(--vcp-ui-focus-ring, rgba(59, 130, 246, 0.35)) !important;
+}
+
+#agentSettingsContainer .slider-container output,
+#agentSettingsContainer .slider-container #ttsSpeedValue {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    min-width: 40px !important;
+    height: 24px !important;
+    padding: 0 8px !important;
+    border-radius: 6px !important;
+    background: var(--vcp-ui-fill-1, rgba(255, 255, 255, 0.08)) !important;
+    border: 1px solid var(--vcp-ui-border, rgba(255, 255, 255, 0.1)) !important;
+    color: var(--vcp-ui-text-0, var(--primary-text, #ffffff)) !important;
+    font-size: 12px !important;
+    font-weight: 600 !important;
+    font-variant-numeric: tabular-nums !important;
+    text-align: center !important;
+    box-sizing: border-box !important;
+    flex-shrink: 0 !important;
+}
+
+body[data-vcp-theme="light"] #agentSettingsContainer .slider-container input[type="range"]::-webkit-slider-thumb {
+    background: #ffffff !important;
+}
+
+body[data-vcp-theme="light"] #agentSettingsContainer .slider-container input[type="range"]::-moz-range-thumb {
+    background: #ffffff !important;
+}
+
+body[data-vcp-theme="light"] #agentSettingsContainer .slider-container output,
+body[data-vcp-theme="light"] #agentSettingsContainer .slider-container #ttsSpeedValue {
+    background: rgba(0, 0, 0, 0.05) !important;
+    border: 1px solid rgba(0, 0, 0, 0.1) !important;
+    color: #0f1115 !important;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer .slider-container input[type="range"]::-webkit-slider-thumb {
+    background: #171b20 !important;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer .slider-container input[type="range"]::-moz-range-thumb {
+    background: #171b20 !important;
+}
+
+body[data-vcp-theme="dark"] #agentSettingsContainer .slider-container output,
+body[data-vcp-theme="dark"] #agentSettingsContainer .slider-container #ttsSpeedValue {
+    background: rgba(255, 255, 255, 0.08) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    color: #ffffff !important;
+}
+
+/* ========================================
+   Tooltip Info Badges & Subtraction of Bulky Explanatory Texts
+   ======================================== */
+.vcp-settings-info-badge {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: 15px !important;
+    height: 15px !important;
+    margin-left: 6px !important;
+    border-radius: 50% !important;
+    border: 1px solid currentColor !important;
+    opacity: 0.55 !important;
+    background: transparent !important;
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: 10px !important;
+    font-weight: 600 !important;
+    line-height: 1 !important;
+    padding: 0 !important;
+    cursor: pointer !important;
+    vertical-align: middle !important;
+    transition: opacity 120ms ease, background-color 120ms ease !important;
+    outline: none !important;
+    flex-shrink: 0 !important;
+    box-sizing: border-box !important;
+}
+
+.vcp-settings-info-badge:hover,
+.vcp-settings-info-badge:focus-visible {
+    opacity: 1 !important;
+    background-color: var(--dsw-alias-fill-hover, rgba(128, 128, 128, 0.15)) !important;
+}
+
+#agentSettingsContainer .tts-director-help,
+#agentSettingsContainer .agent-settings-section[data-section-key="tts"] .slider-container + small,
+#agentSettingsContainer .agent-settings-section[data-section-key="tts"] small[data-vcp-style="4"],
+#agentSettingsContainer .agent-settings-section[data-section-key="appearance"] .style-control-item.full-width > small {
+    display: none !important;
+}
+
+.vcp-uiux-tooltip-bubble {
+    z-index: 10000 !important;
 }

--- a/styles/setting/settings-agent-style-collapse.css
+++ b/styles/setting/settings-agent-style-collapse.css
@@ -52,9 +52,9 @@ body[data-vcp-theme="dark"] .style-collapse-header:hover::before {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: var(--highlight-text);
-    font-size: 0.98em;
-    font-weight: 500;
+    color: var(--vcp-ui-text-0, var(--primary-text, #ffffff)) !important;
+    font-size: 13px !important;
+    font-weight: 550 !important;
     line-height: 24px;
 }
 

--- a/styles/setting/settings-group-form.css
+++ b/styles/setting/settings-group-form.css
@@ -195,12 +195,15 @@ body[data-vcp-theme="light"] #groupSettingsForm .form-actions #deleteGroupBtn:ho
 }
 
 #groupSettingsForm img#groupAvatarPreview {
-    border: 2px solid var(--button-bg) !important;
-    border-radius: 8px;
-    max-width: 100px;
-    max-height: 100px;
-    object-fit: cover;
+    width: 60px !important;
+    height: 60px !important;
+    min-width: 60px !important;
+    max-width: 60px !important;
+    min-height: 60px !important;
+    max-height: 60px !important;
+    border-radius: 16px !important;
+    border: 1px solid rgba(0, 0, 0, 0.08) !important;
+    object-fit: cover !important;
     display: block;
-    margin-top: 10px;
-    margin-bottom: 6px;
+    margin: 0 !important;
 }

--- a/styles/setting/settings-group-sections.css
+++ b/styles/setting/settings-group-sections.css
@@ -95,9 +95,9 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: var(--highlight-text);
-    font-size: 1.06em;
-    font-weight: 500;
+    color: var(--vcp-ui-text-0, var(--primary-text, #ffffff)) !important;
+    font-size: 13.5px !important;
+    font-weight: 600 !important;
     line-height: 24px;
     z-index: 1;
     transition: color var(--vcp-motion-duration-fast) var(--vcp-motion-ease-standard);
@@ -280,23 +280,92 @@ body[data-vcp-theme="light"] #groupSettingsContainer .group-settings-toggle-btn:
 #groupSettingsContainer .group-identity-main {
     display: flex;
     align-items: center;
-    gap: 14px;
+    gap: 12px;
 }
 
-#groupSettingsContainer .group-avatar-display {
-    width: 76px;
-    height: 76px;
-    border-width: 2px;
+#groupSettingsContainer .group-avatar-wrapper {
+    position: relative;
+    flex-shrink: 0;
+    width: 60px;
+    height: 60px;
+    border-radius: 16px;
+    overflow: hidden;
+}
+
+#groupSettingsContainer .group-avatar-display,
+#groupSettingsForm img#groupAvatarPreview {
+    width: 60px !important;
+    height: 60px !important;
+    min-width: 60px !important;
+    max-width: 60px !important;
+    min-height: 60px !important;
+    max-height: 60px !important;
+    border-radius: 16px !important;
+    border: 1px solid rgba(0, 0, 0, 0.08) !important;
+    object-fit: cover !important;
+    margin: 0 !important;
+}
+
+body[data-vcp-theme="dark"] #groupSettingsContainer .group-avatar-display,
+body[data-vcp-theme="dark"] #groupSettingsForm img#groupAvatarPreview {
+    border-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+#groupSettingsContainer .avatar-upload-overlay {
+    border-radius: 16px !important;
+    background-color: rgba(0, 0, 0, 0.45);
+    transition: opacity 0.15s ease;
+}
+
+#groupSettingsContainer .group-avatar-wrapper:hover .avatar-upload-overlay {
+    opacity: 1;
+}
+
+#groupSettingsContainer .avatar-upload-overlay svg {
+    width: 22px;
+    height: 22px;
+}
+
+#groupSettingsContainer .group-name-wrapper {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }
 
 #groupSettingsContainer .group-name-wrapper label {
-    margin-left: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--secondary-text);
+    margin: 0;
 }
 
 #groupSettingsContainer .group-name-wrapper input[type="text"] {
-    width: calc(100% + 4px);
-    margin-left: -4px;
-    font-size: 1.08em;
+    width: 100% !important;
+    margin: 0 !important;
+    height: 36px !important;
+    min-height: 36px !important;
+    padding: 0 12px !important;
+    border-radius: 10px !important;
+    border: 1px solid var(--vcp-ui-control-border, rgba(0, 0, 0, 0.1)) !important;
+    background: var(--vcp-ui-bg-1, rgba(255, 255, 255, 0.8)) !important;
+    color: var(--primary-text) !important;
+    font-size: 13.5px !important;
+    font-weight: 600 !important;
+    box-sizing: border-box !important;
+    outline: none !important;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+#groupSettingsContainer .group-name-wrapper input[type="text"]:focus {
+    border-color: var(--vcp-ui-control-focus, #3b82f6) !important;
+    box-shadow: 0 0 0 2px var(--vcp-ui-focus-ring, rgba(59, 130, 246, 0.18)) !important;
+}
+
+body[data-vcp-theme="dark"] #groupSettingsContainer .group-name-wrapper input[type="text"] {
+    border-color: rgba(255, 255, 255, 0.12) !important;
+    background: rgba(255, 255, 255, 0.04) !important;
 }
 
 #groupSettingsContainer .group-settings-field-shell {
@@ -313,34 +382,55 @@ body[data-vcp-theme="light"] #groupSettingsContainer .group-settings-toggle-btn:
     font-size: 0.9em;
 }
 
-#groupSettingsForm input[type="text"],
-#groupSettingsForm textarea,
-#groupSettingsForm select {
+#groupSettingsForm select,
+#groupSettingsForm .model-input-container input[type="text"],
+#groupSettingsContainer .member-tag-input-item input[type="text"] {
     width: 100%;
     box-sizing: border-box;
     color: var(--primary-text);
     font-size: 0.95em;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    background: transparent;
-}
-
-#groupSettingsForm input[type="text"],
-#groupSettingsForm select {
-    height: 37px;
-    padding: 0 12px;
-    border-radius: 999px;
+    border: 1px solid var(--dsw-alias-border-l2, var(--border-color));
+    background: var(--dsw-alias-bg-layer-1, var(--input-bg));
+    height: 32px;
+    min-height: 32px;
+    max-height: 32px;
+    padding: 0 10px;
+    border-radius: 8px;
 }
 
 #groupSettingsForm textarea {
     min-height: 96px;
-    padding: 12px 14px;
-    border-radius: 18px;
+    padding: 12px 14px !important;
+    border-radius: 12px !important;
+    border: 1px solid transparent !important;
+    background: rgba(0, 0, 0, 0.028) !important;
+    color: var(--highlight-text) !important;
+    font-size: 13.5px !important;
+    line-height: 1.6 !important;
     resize: vertical;
+    outline: none !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
 }
 
-body[data-vcp-theme="light"] #groupSettingsForm input[type="text"],
-body[data-vcp-theme="light"] #groupSettingsForm textarea,
-body[data-vcp-theme="light"] #groupSettingsForm select,
+#groupSettingsForm textarea:focus {
+    background: rgba(0, 0, 0, 0.045) !important;
+    border-color: var(--vcp-ui-border-focus, rgba(22, 119, 255, 0.35)) !important;
+    box-shadow: 0 0 0 2px var(--vcp-ui-focus-ring, rgba(22, 119, 255, 0.12)) !important;
+}
+
+body[data-vcp-theme="dark"] #groupSettingsForm textarea {
+    background: rgba(255, 255, 255, 0.04) !important;
+    border-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+body[data-vcp-theme="dark"] #groupSettingsForm textarea:focus {
+    background: rgba(255, 255, 255, 0.06) !important;
+    border-color: var(--vcp-ui-border-focus, rgba(59, 130, 246, 0.45)) !important;
+    box-shadow: 0 0 0 2px var(--vcp-ui-focus-ring, rgba(59, 130, 246, 0.18)) !important;
+}
+
 body[data-vcp-theme="light"] #groupSettingsContainer .group-member-item label {
     background: linear-gradient(
         180deg,
@@ -356,9 +446,6 @@ body[data-vcp-theme="light"] #groupSettingsContainer .group-member-item label {
         inset 0 0 1px rgba(0, 0, 0, 0.08);
 }
 
-body[data-vcp-theme="dark"] #groupSettingsForm input[type="text"],
-body[data-vcp-theme="dark"] #groupSettingsForm textarea,
-body[data-vcp-theme="dark"] #groupSettingsForm select,
 body[data-vcp-theme="dark"] #groupSettingsContainer .group-member-item label {
     background: linear-gradient(
         180deg,
@@ -372,28 +459,6 @@ body[data-vcp-theme="dark"] #groupSettingsContainer .group-member-item label {
         inset 1px -1px 1px -1px rgba(255, 255, 255, 0.16),
         inset -1px 1px 1px -1px rgba(255, 255, 255, 0.12),
         inset 0 0 0 1px rgba(255, 255, 255, 0.04);
-}
-
-body[data-vcp-theme="light"] #groupSettingsForm input[type="text"]:hover,
-body[data-vcp-theme="light"] #groupSettingsForm input[type="text"]:focus,
-body[data-vcp-theme="light"] #groupSettingsForm input[type="text"]:focus-visible,
-body[data-vcp-theme="light"] #groupSettingsForm textarea:hover,
-body[data-vcp-theme="light"] #groupSettingsForm textarea:focus,
-body[data-vcp-theme="light"] #groupSettingsForm textarea:focus-visible,
-body[data-vcp-theme="light"] #groupSettingsForm select:hover,
-body[data-vcp-theme="light"] #groupSettingsForm select:focus,
-body[data-vcp-theme="light"] #groupSettingsForm select:focus-visible,
-body[data-vcp-theme="dark"] #groupSettingsForm input[type="text"]:hover,
-body[data-vcp-theme="dark"] #groupSettingsForm input[type="text"]:focus,
-body[data-vcp-theme="dark"] #groupSettingsForm input[type="text"]:focus-visible,
-body[data-vcp-theme="dark"] #groupSettingsForm textarea:hover,
-body[data-vcp-theme="dark"] #groupSettingsForm textarea:focus,
-body[data-vcp-theme="dark"] #groupSettingsForm textarea:focus-visible,
-body[data-vcp-theme="dark"] #groupSettingsForm select:hover,
-body[data-vcp-theme="dark"] #groupSettingsForm select:focus,
-body[data-vcp-theme="dark"] #groupSettingsForm select:focus-visible {
-    border-color: var(--highlight-text);
-    outline: none;
 }
 
 #groupSettingsContainer .group-settings-helper-text {
@@ -445,24 +510,30 @@ body[data-vcp-theme="dark"] #groupSettingsForm select:focus-visible {
 #groupSettingsContainer .group-member-item label {
     flex: 1 1 auto;
     min-width: 0;
-    display: inline-flex;
-    align-items: center;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: flex-start !important;
     cursor: pointer;
     font-weight: 400;
     color: var(--primary-text);
     font-size: 0.95em;
-    padding: 9px 12px;
+    line-height: 1 !important;
+    margin: 0 !important;
+    padding: 6px 12px !important;
     border-radius: 16px;
     border: 1px solid rgba(255, 255, 255, 0.08);
+    box-sizing: border-box !important;
 }
 
 #groupSettingsContainer .group-member-item .avatar-small {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    margin-right: 8px;
-    object-fit: cover;
-    flex-shrink: 0;
+    display: block !important;
+    width: 24px !important;
+    height: 24px !important;
+    min-width: 24px !important;
+    border-radius: 50% !important;
+    margin: 0 8px 0 0 !important;
+    object-fit: cover !important;
+    flex-shrink: 0 !important;
 }
 
 #groupSettingsContainer #memberTagsInputs {
@@ -733,7 +804,7 @@ body[data-vcp-theme="dark"] #groupSettingsForm .form-actions .danger-button {
    Unifies save button + bubble family with Agent settings.
    ======================================== */
 #groupSettingsContainer {
-    --agent-settings-pill-radius: 16px;
+    --agent-settings-pill-radius: 8px;
 }
 
 #agentSettingsContainer,
@@ -790,8 +861,7 @@ body[data-vcp-theme="dark"] #groupSettingsForm .form-actions .danger-button {
     gap: 6px !important;
     position: sticky;
     bottom: 0;
-    background-color: transparent;
-    padding: 8px 0 10px;
+    padding: 12px 0 16px !important;
     border-radius: 0;
     border: none !important;
     border-top: none !important;
@@ -802,13 +872,25 @@ body[data-vcp-theme="dark"] #groupSettingsForm .form-actions .danger-button {
     width: 100% !important;
     box-sizing: border-box !important;
     z-index: 10;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.92) 28%, rgba(255, 255, 255, 0.98) 100%) !important;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions,
+body[data-vcp-theme="dark"] #groupSettingsForm .form-actions {
+    background: linear-gradient(180deg, rgba(20, 24, 33, 0) 0%, rgba(20, 24, 33, 0.9) 28%, rgba(20, 24, 33, 0.98) 100%) !important;
 }
 
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions,
-body[data-vcp-theme="light"] #groupSettingsForm .form-actions,
-body[data-vcp-theme="dark"] #agentSettingsForm .form-actions,
-body[data-vcp-theme="dark"] #groupSettingsForm .form-actions {
-    background-color: transparent !important;
+body[data-vcp-theme="light"] #groupSettingsForm .form-actions {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.92) 28%, rgba(255, 255, 255, 0.98) 100%) !important;
+}
+
+#tabContentSettings,
+#agentSettingsContainer,
+#groupSettingsContainer {
+    padding-bottom: 120px !important;
 }
 
 #agentSettingsForm .form-actions .delete-button-container,
@@ -833,6 +915,7 @@ body[data-vcp-theme="dark"] #groupSettingsForm .form-actions {
     overflow: visible;
 }
 
+#agentSettingsForm .form-actions button,
 #agentSettingsForm .form-actions button:not(.vcp-uiux-button),
 #groupSettingsForm .form-actions button {
     position: relative;
@@ -845,49 +928,31 @@ body[data-vcp-theme="dark"] #groupSettingsForm .form-actions {
     width: 100%;
     margin-right: 0;
     margin-left: 0;
-    height: 37px;
-    min-height: 37px;
+    height: 32px !important;
+    min-height: 32px !important;
     padding: 0 12px;
-    font-size: 0.95em;
+    font-size: 13px;
     font-weight: 500;
     line-height: 1;
-    border-radius: 14px !important;
-    border: 1px solid color-mix(
-        in srgb,
-        var(--vcp-ui-border-strong, var(--border-color)) var(--vcp-material-border, 36%),
-        transparent
-    );
+    border-radius: 8px !important;
+    border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12));
     cursor: pointer;
     white-space: nowrap;
     box-sizing: border-box;
     flex: 0 0 auto;
     appearance: none;
     -webkit-appearance: none;
-    box-shadow:
-        inset 0 1px 0 color-mix(
-            in srgb,
-            var(--primary-text) var(--vcp-material-sheen, 14%),
-            transparent
-        ),
-        0 2px 8px color-mix(
-            in srgb,
-            #000000 var(--vcp-material-shadow-color, 8%),
-            transparent
-        ) !important;
-    backdrop-filter:
-        blur(var(--vcp-material-blur, 10px))
-        saturate(var(--vcp-material-saturation, 125%))
-        brightness(var(--vcp-material-brightness, 100%)) !important;
-    -webkit-backdrop-filter:
-        blur(var(--vcp-material-blur, 10px))
-        saturate(var(--vcp-material-saturation, 125%))
-        brightness(var(--vcp-material-brightness, 100%)) !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     transition:
         background var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard),
         border-color var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard),
         color var(--vcp-motion-duration-normal) var(--vcp-motion-ease-standard);
 }
 
+#agentSettingsForm .form-actions button[type="submit"],
 #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button),
 #groupSettingsForm .form-actions button[type="submit"] {
     color: var(--highlight-text);
@@ -905,6 +970,7 @@ body[data-vcp-theme="dark"] #groupSettingsForm .form-actions {
     align-self: stretch !important;
 }
 
+#agentSettingsForm .form-actions button[type="submit"]:hover,
 #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button):hover,
 #groupSettingsForm .form-actions button[type="submit"]:hover {
     background: var(--dsw-alias-interactive-bg-hover, #f3f4f6);
@@ -913,130 +979,124 @@ body[data-vcp-theme="dark"] #groupSettingsForm .form-actions {
     box-shadow: none !important;
 }
 
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions button[type="submit"],
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button),
 body[data-vcp-theme="light"] #groupSettingsForm .form-actions button[type="submit"] {
-    background-color: color-mix(
-        in srgb,
-        var(--secondary-bg) var(--vcp-material-opacity, 68%),
-        transparent
-    ) !important;
-    background-image: var(--vcp-material-texture, linear-gradient(
-        180deg,
-        rgba(255, 255, 255, 0.32),
-        rgba(255, 255, 255, 0.08)
-    )) !important;
-    border-color: color-mix(in srgb, var(--highlight-text) 24%, var(--border-color));
-    color: var(--highlight-text);
+    background: color-mix(in srgb, var(--user-bubble-bg, #f3ede2) 85%, rgba(255, 255, 255, 0.7)) !important;
+    border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12)) !important;
+    color: var(--highlight-text) !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     opacity: 1 !important;
 }
 
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions button[type="submit"]:hover,
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button):hover,
 body[data-vcp-theme="light"] #groupSettingsForm .form-actions button[type="submit"]:hover {
-    background: #EAE0DB !important;
+    background: color-mix(in srgb, var(--user-bubble-bg, #f3ede2) 95%, rgba(0, 0, 0, 0.08)) !important;
     border-color: var(--dsw-alias-border-l1, rgba(0, 0, 0, 0.22));
-    color: var(--highlight-text);
+    color: var(--highlight-text) !important;
     box-shadow: none !important;
 }
 
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions button[type="submit"],
 body[data-vcp-theme="dark"] #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button),
 body[data-vcp-theme="dark"] #groupSettingsForm .form-actions button[type="submit"] {
-    background-color: color-mix(
-        in srgb,
-        var(--secondary-bg) var(--vcp-material-opacity, 58%),
-        transparent
-    ) !important;
-    background-image: var(--vcp-material-texture, linear-gradient(
-        180deg,
-        rgba(255, 255, 255, 0.09),
-        rgba(255, 255, 255, 0.025)
-    )) !important;
-    border-color: color-mix(in srgb, var(--highlight-text) 24%, var(--border-color));
-    color: var(--primary-text);
+    background: var(--dsw-alias-bg-layer-2, #262628) !important;
+    border: 1px solid var(--dsw-alias-border-l2, rgba(255, 255, 255, 0.12)) !important;
+    color: var(--highlight-text) !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     opacity: 1 !important;
 }
 
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions button[type="submit"]:hover,
 body[data-vcp-theme="dark"] #agentSettingsForm .form-actions button[type="submit"]:not(.vcp-uiux-button):hover,
 body[data-vcp-theme="dark"] #groupSettingsForm .form-actions button[type="submit"]:hover {
-    background: #38383A !important;
-    border-color: var(--dsw-alias-border-l1, rgba(255, 255, 255, 0.24));
-    color: #ffffff;
+    background: var(--dsw-alias-interactive-bg-hover, #323235) !important;
+    border-color: var(--dsw-alias-border-l1, rgba(255, 255, 255, 0.24)) !important;
+    color: #ffffff !important;
     box-shadow: none !important;
 }
 
+#agentSettingsForm .form-actions .danger-button,
 #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button),
 #groupSettingsForm .form-actions .danger-button,
+#agentSettingsForm .form-actions #deleteAgentBtn,
 #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button),
 #groupSettingsForm .form-actions #deleteGroupBtn {
     color: var(--vcp-ui-danger, #ef4444);
 }
 
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button,
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button),
 body[data-vcp-theme="light"] #groupSettingsForm .form-actions .danger-button,
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions #deleteAgentBtn,
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button),
 body[data-vcp-theme="light"] #groupSettingsForm .form-actions #deleteGroupBtn {
-    background-color: color-mix(
-        in srgb,
-        var(--vcp-ui-danger, #ef4444) 9%,
-        color-mix(in srgb, var(--secondary-bg) var(--vcp-material-opacity, 64%), transparent)
-    ) !important;
-    background-image: var(--vcp-material-texture, linear-gradient(
-        180deg,
-        rgba(255, 255, 255, 0.3),
-        rgba(255, 255, 255, 0.06)
-    )) !important;
-    border-color: color-mix(in srgb, var(--vcp-ui-danger, #ef4444) 34%, var(--border-color));
-    color: var(--vcp-ui-danger, #ef4444);
+    background: var(--dsw-alias-bg-layer-1, #ffffff) !important;
+    border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12)) !important;
+    color: var(--vcp-ui-danger, #ef4444) !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     opacity: 1 !important;
 }
 
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button:hover,
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button):hover,
 body[data-vcp-theme="light"] #groupSettingsForm .form-actions .danger-button:hover,
+body[data-vcp-theme="light"] #agentSettingsForm .form-actions #deleteAgentBtn:hover,
 body[data-vcp-theme="light"] #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button):hover,
 body[data-vcp-theme="light"] #groupSettingsForm .form-actions #deleteGroupBtn:hover {
     background: #FEF2F2 !important;
-    border-color: var(--vcp-ui-danger, #ef4444);
-    color: var(--vcp-ui-danger, #ef4444);
+    border-color: color-mix(in srgb, var(--vcp-ui-danger, #ef4444) 40%, var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12))) !important;
+    color: var(--vcp-ui-danger, #ef4444) !important;
     box-shadow: none !important;
 }
 
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button,
 body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button),
 body[data-vcp-theme="dark"] #groupSettingsForm .form-actions .danger-button,
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions #deleteAgentBtn,
 body[data-vcp-theme="dark"] #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button),
 body[data-vcp-theme="dark"] #groupSettingsForm .form-actions #deleteGroupBtn {
-    background-color: color-mix(
-        in srgb,
-        var(--vcp-ui-danger, #ef4444) 14%,
-        color-mix(in srgb, var(--secondary-bg) var(--vcp-material-opacity, 52%), transparent)
-    ) !important;
-    background-image: var(--vcp-material-texture, linear-gradient(
-        180deg,
-        rgba(255, 255, 255, 0.08),
-        rgba(255, 255, 255, 0.02)
-    )) !important;
-    border-color: color-mix(in srgb, var(--vcp-ui-danger, #ef4444) 38%, var(--border-color));
-    color: var(--vcp-ui-danger, #ef4444);
+    background: rgba(255, 255, 255, 0.05) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    color: var(--vcp-ui-danger, #ef4444) !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    background-image: none !important;
     opacity: 1 !important;
 }
 
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button:hover,
 body[data-vcp-theme="dark"] #agentSettingsForm .form-actions .danger-button:not(.vcp-uiux-button):hover,
 body[data-vcp-theme="dark"] #groupSettingsForm .form-actions .danger-button:hover,
+body[data-vcp-theme="dark"] #agentSettingsForm .form-actions #deleteAgentBtn:hover,
 body[data-vcp-theme="dark"] #agentSettingsForm .form-actions #deleteAgentBtn:not(.vcp-uiux-button):hover,
 body[data-vcp-theme="dark"] #groupSettingsForm .form-actions #deleteGroupBtn:hover {
-    background: #331E1E !important;
-    border-color: var(--vcp-ui-danger, #ef4444);
-    color: #ffffff;
+    background: rgba(239, 68, 68, 0.12) !important;
+    border-color: rgba(239, 68, 68, 0.35) !important;
+    color: #ff6b6b !important;
     box-shadow: none !important;
 }
 
 #groupSettingsContainer input[type="text"],
 #groupSettingsContainer select {
     width: 100%;
-    height: 34px;
-    min-height: 34px;
-    max-height: 34px;
+    height: 32px;
+    min-height: 32px;
+    max-height: 32px;
     padding: 0 12px;
     margin-bottom: 0;
-    border-radius: var(--agent-settings-pill-radius) !important;
+    border-radius: 8px !important;
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: transparent;
     background-clip: padding-box;
@@ -1219,12 +1279,18 @@ body[data-vcp-theme="dark"] #groupSettingsContainer select:focus-visible {
 }
 
 #groupSettingsContainer .group-member-item label {
-    min-height: 34px;
-    padding: 4px 12px 4px 9px;
+    min-height: 36px;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: flex-start !important;
+    padding: 6px 12px 6px 9px !important;
     border-radius: var(--agent-settings-pill-radius);
     color: var(--highlight-text);
     background: transparent;
     background-clip: padding-box;
+    box-sizing: border-box !important;
+    margin: 0 !important;
+    line-height: 1 !important;
 }
 
 #groupSettingsContainer .group-member-item input[type="checkbox"]:checked + label {
@@ -1310,4 +1376,85 @@ body[data-vcp-theme="dark"] #groupSettingsContainer .group-settings-model-shell 
     background-color: var(--accent-bg);
     color: var(--highlight-text);
     border-color: var(--highlight-text);
+}
+
+#groupSettingsContainer .group-settings-collapsible-container:not(.collapsed) .group-settings-section-summary,
+#groupSettingsContainer .group-settings-collapsible-container:not(.collapsed) #groupIdentitySummary {
+    display: none !important;
+}
+
+#groupSettingsContainer #groupPrompt,
+#groupSettingsContainer #invitePrompt {
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    min-height: 100px !important;
+    max-height: min(340px, 45vh) !important;
+    padding: 6px 2px !important;
+    border-radius: 4px !important;
+    border: 1px solid transparent !important;
+    border-left: 2.5px solid transparent !important;
+    background: transparent !important;
+    color: var(--vcp-ui-text-0, var(--primary-text, #ffffff)) !important;
+    font-size: 13.5px !important;
+    line-height: 1.6 !important;
+    white-space: pre-wrap !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
+    resize: vertical;
+    outline: none !important;
+    box-shadow: none !important;
+    box-sizing: border-box !important;
+    cursor: text;
+    transition: padding-left var(--vcp-motion-duration-fast) var(--vcp-motion-ease-standard),
+                border-color var(--vcp-motion-duration-fast) var(--vcp-motion-ease-standard);
+}
+
+#groupSettingsContainer #groupPrompt:focus,
+#groupSettingsContainer #invitePrompt:focus {
+    background: transparent !important;
+    border-color: transparent !important;
+    border-left: 2.5px solid var(--vcp-ui-accent, var(--highlight-text, #3b82f6)) !important;
+    padding-left: 6px !important;
+    box-shadow: none !important;
+}
+
+body[data-vcp-theme="dark"] #groupSettingsContainer #groupPrompt,
+body[data-vcp-theme="dark"] #groupSettingsContainer #invitePrompt {
+    background: transparent !important;
+    border-color: transparent !important;
+    color: var(--vcp-ui-text-0, #ffffff) !important;
+}
+
+body[data-vcp-theme="dark"] #groupSettingsContainer #groupPrompt:focus,
+body[data-vcp-theme="dark"] #groupSettingsContainer #invitePrompt:focus {
+    background: transparent !important;
+    border-color: transparent !important;
+    border-left: 2.5px solid var(--vcp-ui-accent, var(--highlight-text, #3b82f6)) !important;
+    padding-left: 6px !important;
+    box-shadow: none !important;
+}
+
+body[data-vcp-theme="light"] #groupSettingsContainer #groupPrompt,
+body[data-vcp-theme="light"] #groupSettingsContainer #invitePrompt {
+    background: transparent !important;
+    border-color: transparent !important;
+    color: var(--vcp-ui-text-0, #111111) !important;
+}
+
+#groupSettingsContainer .group-settings-field-shell label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 13px !important;
+    font-weight: 550 !important;
+    color: var(--vcp-ui-text-1, var(--secondary-text)) !important;
+}
+
+#groupSettingsContainer .group-settings-helper-text {
+    margin-top: 6px;
+    font-size: 12px !important;
+    line-height: 1.4 !important;
+    color: var(--vcp-ui-text-2, var(--placeholder-text)) !important;
 }

--- a/styles/setting/settings-regex.css
+++ b/styles/setting/settings-regex.css
@@ -157,12 +157,13 @@
     align-items: center;
     justify-content: center;
     width: 100%;
-    height: 37px;
+    height: 32px;
+    min-height: 32px;
     padding: 0 12px;
-    font-size: 0.95em;
+    font-size: 13px;
     font-weight: 500;
     line-height: 1;
-    border-radius: 14px;
+    border-radius: 8px;
     border: 1px solid var(--dsw-alias-border-l2, rgba(0, 0, 0, 0.12));
     cursor: pointer;
     background: var(--dsw-alias-bg-layer-1, #ffffff);

--- a/styles/ui-system/group-settings.css
+++ b/styles/ui-system/group-settings.css
@@ -230,6 +230,11 @@
 
     html .vcp-ui-scope #groupSettingsContainer .group-member-item label {
         min-width: 0;
+        display: inline-flex !important;
+        align-items: center !important;
+        justify-content: flex-start !important;
+        min-height: 36px;
+        margin: 0 !important;
         padding: var(--vcp-ui-space-2) var(--vcp-ui-space-3);
         border: 1px solid var(--vcp-ui-control-border);
         border-radius: var(--vcp-ui-radius-md);
@@ -238,6 +243,8 @@
         box-shadow: none;
         backdrop-filter: none;
         -webkit-backdrop-filter: none;
+        box-sizing: border-box !important;
+        line-height: 1 !important;
     }
 
     html .vcp-ui-scope #groupSettingsContainer .group-member-item label:hover {


### PR DESCRIPTION
## 概述与背景

本次修改针对 Agent 设置、群聊设置、系统提示词及表单控件进行了深度的 UI/UX 体验重构与对齐优化，重点消除组件尺寸割裂、说明文案冗长占用空间、卡片未垂直居中以及输入框调整受阻等体验问题。

> **注意**：已严格排除所有个人主题文件（如 `themes.css`），不包含任何自定义主题变动。

---

## 核心改动明细

### 1. 系统提示词与 MiMo 演绎区域重构（无感融合与拖拽修复）
- **Tab 栏轻量无感化**：剥离厚重胶囊外框与纯黑背景，改为紧凑 28px 高度幽灵切换 Tab，消除原本占据纵向空间的冗余说明文案。
- **MiMo 演绎提示词无边框融入**：
  - 剔除输入框实体边框与卡片背景，与上方角色提示词区域的无边框质感和左对齐基准（2px 起始间距）严格对齐；
  - 辅助操作（「+」与「导演模板」）收敛为输入框右下角悬浮操作组，不再横向挤占输入空间；
  - 彻底移除 `max-height: min(340px, 45vh) !important;` 限制及 `transition: height` 动画干扰，恢复顺畅的原生垂直拖拽调整（`resize: vertical`）。

### 2. 全量接入轻量 Tooltip 浮层系统
- 在 `modules/ui-system/agent-settings-bridge.js` 与相关样式中接入统一的 `VCPUIUX.mountTooltip` 系统；
- 采用 15px × 15px 精致正圆形 `?` 徽标浮层，支持 hover / focus 触发并内置 `stopPropagation` 防误触；
- 彻底隐藏原先占据纵向阅读流的多处密集说明文字（系统提示词、TTS 语速、MiMo 演绎模式、自定义 CSS 提示等），大幅压缩面板垂直空间。

### 3. 表单控件与按钮规格严格收敛对齐
- **32px 高度与 8px 圆角基准**：将群聊模式 `select` 下拉框、文本输入框及底部操作按钮从旧版 34px / 胶囊圆角统一收敛为标准 `32px` 高度与 `8px` 圆角，与「添加/导入正则」标准规格实现像素级统一；
- **群组成员卡片垂直居中对齐**：
  - 修复群组成员卡片（`label`）继承表单外边距导致头像和名字偏上、底部留空过大的问题；
  - 明确锁定 `display: inline-flex !important; align-items: center !important;` 与对称内边距，确保 24px 正圆形头像与名字文本严格共轴水平居中。

---

## 验证与门禁
- 运行 `git diff --check`，全量文件无空白悬挂与语法冲突；
- 通过 UI 架构门禁规则，保证跨深色与浅色主题的一致性表现。